### PR TITLE
Look for direct string matches and then for fuzzy string matches

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,15 @@
             "args": "/bin/ls"
         },
         {
+            "name": "pyghidra streamablehttp server",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "src/pyghidra_mcp/server.py",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "args": "--transport streamable-http"
+        },
+        {
             "name": "Python: Current File (with pytest)",
             "type": "debugpy",
             "request": "launch",


### PR DESCRIPTION
For example, we now get direct http string matches here. We could support regex but I've found that actually seems to confuse gpt. Perhaps worth revisiting in the future, but this is still in improvement.

<img width="1003" height="700" alt="image" src="https://github.com/user-attachments/assets/a7a3f391-839a-42bd-920d-1bd5a83d0e79" />
