### PR TITLE
Fix _init_project_programs failing on Windows

### DIFF
--- a/src/pyghidra_mcp/context.py
+++ b/src/pyghidra_mcp/context.py
@@ -171,14 +171,13 @@ class PyGhidraContext:
         """
         from ghidra.program.model.listing import Program
 
-        all_binary_paths = self.list_binaries()
-        for binary_path_s in all_binary_paths:
-            binary_path = Path(binary_path_s)
+        domain_files = self.list_binary_domain_files()
+        for df in domain_files:
             program: Program = self.project.openProgram(
-                str(binary_path.parent), binary_path.name, False
+                df.getParent().getPathname(), df.getName(), False
             )
             program_info = self._init_program_info(program)
-            self.programs[binary_path_s] = program_info
+            self.programs[df.getPathname()] = program_info
 
     def list_binaries(self) -> list[str]:
         """List all the binaries within the Ghidra project."""


### PR DESCRIPTION
Use DomainFile API instead of pathlib.Path for Ghidra internal project paths. On Windows, `Path("/foo").parent` converts to `\`, which Ghidra rejects.

Tested on Windows with existing project containing multiple binaries.

Closes #39