### PR TITLE
Tools desc optimization core

### DIFF
--- a/.github/workflows/pytest-devcontainer-pypi-all.yml
+++ b/.github/workflows/pytest-devcontainer-pypi-all.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  test-linux:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pytest-devcontainer-pypi-cli.yml
+++ b/.github/workflows/pytest-devcontainer-pypi-cli.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  test-linux:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pytest-devcontainer-repo-all.yml
+++ b/.github/workflows/pytest-devcontainer-repo-all.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  test-linux:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/pytest-devcontainer-repo-all.yml
+++ b/.github/workflows/pytest-devcontainer-repo-all.yml
@@ -80,10 +80,23 @@ jobs:
         retention-days: 7
 
   test-macos:
+    name: test-macos (${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python)
     runs-on: macos-latest
-    timeout-minutes: 90
-    env:
-      GHIDRA_RELEASE_API: https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ghidra_version: latest
+            python_version: "3.13"
+          - ghidra_version: "12.0"
+            python_version: "3.13"
+          - ghidra_version: "11.3.2"
+            python_version: "3.12"
+          - ghidra_version: "11.4.1"
+            python_version: "3.11"
+          - ghidra_version: "11.3"
+            python_version: "3.10"
 
     steps:
     - uses: actions/checkout@v4
@@ -91,7 +104,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: ${{ matrix.python_version }}
         cache: pip
         cache-dependency-path: pyproject.toml
 
@@ -101,8 +114,10 @@ jobs:
         distribution: temurin
         java-version: "21"
 
-    - name: Resolve latest Ghidra release asset
+    - name: Resolve Ghidra release asset
       id: ghidra-asset
+      env:
+        GHIDRA_VERSION: ${{ matrix.ghidra_version }}
       run: |
         python - <<'PY'
         import json
@@ -110,7 +125,15 @@ jobs:
         import re
         import urllib.request
 
-        api_url = os.environ["GHIDRA_RELEASE_API"]
+        ghidra_version = os.environ["GHIDRA_VERSION"]
+        if ghidra_version == "latest":
+            api_url = "https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/latest"
+        else:
+            api_url = (
+                "https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/tags/"
+                f"Ghidra_{ghidra_version}_build"
+            )
+
         with urllib.request.urlopen(api_url) as resp:
             release_data = json.load(resp)
 
@@ -124,7 +147,7 @@ jobs:
         )
 
         if asset is None:
-            raise SystemExit("No Ghidra public zip asset found in latest release.")
+            raise SystemExit(f"No Ghidra public zip asset found for {ghidra_version}.")
 
         with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
             output.write(f"asset_name={asset['name']}\n")
@@ -137,7 +160,7 @@ jobs:
         path: |
           ${{ runner.temp }}/ghidra-download
           ${{ runner.temp }}/ghidra-install
-        key: ${{ runner.os }}-ghidra-${{ steps.ghidra-asset.outputs.asset_name }}
+        key: ${{ runner.os }}-ghidra-${{ matrix.ghidra_version }}-${{ steps.ghidra-asset.outputs.asset_name }}
 
     - name: Install Ghidra
       run: |
@@ -164,36 +187,35 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+
+        if [[ "${{ matrix.ghidra_version }}" == 11.* ]]; then
+          pip install "pyghidra==2.2.1"
+        fi
+
         pip install -e .[dev]
 
     - name: Run unit tests on macOS
       run: |
         mkdir -p junit
-        python -m pytest tests/unit/ --doctest-modules --junitxml=junit/unit-test-results-macos.xml
+        python -m pytest tests/unit/ --doctest-modules --junitxml=junit/unit-test-results-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python-macos.xml
 
-    - name: Run integration smoke tests on macOS
+    - name: Run integration tests on macOS
       run: |
         mkdir -p junit
-        python -m pytest \
-          tests/integration/test_sse_client.py \
-          tests/integration/test_streamable_client.py \
-          tests/integration/test_search_code.py \
-          -v \
-          --doctest-modules \
-          --junitxml=junit/integration-smoke-test-results-macos.xml
+        python -m pytest tests/integration/ --doctest-modules --junitxml=junit/integration-test-results-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python-macos.xml
 
     - name: Upload unit test results (macOS)
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
-        name: unit-test-results-macos
-        path: junit/unit-test-results-macos.xml
+        name: unit-test-results-macos-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python
+        path: junit/unit-test-results-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python-macos.xml
         retention-days: 7
 
-    - name: Upload integration smoke test results (macOS)
+    - name: Upload integration test results (macOS)
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
-        name: integration-smoke-test-results-macos
-        path: junit/integration-smoke-test-results-macos.xml
+        name: integration-test-results-macos-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python
+        path: junit/integration-test-results-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python-macos.xml
         retention-days: 7

--- a/.github/workflows/pytest-devcontainer-repo-all.yml
+++ b/.github/workflows/pytest-devcontainer-repo-all.yml
@@ -9,7 +9,7 @@ on:
     paths:
       - 'src/pyghidra_mcp/**'
       - 'tests/**'
-      - '.github/workflows/pytest-devcontainer-all.yml'
+      - '.github/workflows/pytest-devcontainer-repo-all.yml'
   pull_request:
     branches: [ "main" ]
   schedule:
@@ -77,4 +77,123 @@ jobs:
       with:
         name: integration-test-results-${{ matrix.image }}
         path: junit/integration-test-results-${{ matrix.image }}.xml
+        retention-days: 7
+
+  test-macos:
+    runs-on: macos-latest
+    timeout-minutes: 90
+    env:
+      GHIDRA_RELEASE_API: https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        cache: pip
+        cache-dependency-path: pyproject.toml
+
+    - name: Set up Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: "21"
+
+    - name: Resolve latest Ghidra release asset
+      id: ghidra-asset
+      run: |
+        python - <<'PY'
+        import json
+        import os
+        import re
+        import urllib.request
+
+        api_url = os.environ["GHIDRA_RELEASE_API"]
+        with urllib.request.urlopen(api_url) as resp:
+            release_data = json.load(resp)
+
+        asset = next(
+            (
+                candidate
+                for candidate in release_data.get("assets", [])
+                if re.match(r"ghidra_.*_PUBLIC_.*\.zip$", candidate["name"])
+            ),
+            None,
+        )
+
+        if asset is None:
+            raise SystemExit("No Ghidra public zip asset found in latest release.")
+
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+            output.write(f"asset_name={asset['name']}\n")
+            output.write(f"download_url={asset['browser_download_url']}\n")
+        PY
+
+    - name: Cache Ghidra
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ runner.temp }}/ghidra-download
+          ${{ runner.temp }}/ghidra-install
+        key: ${{ runner.os }}-ghidra-${{ steps.ghidra-asset.outputs.asset_name }}
+
+    - name: Install Ghidra
+      run: |
+        set -euxo pipefail
+        GHIDRA_DOWNLOAD_DIR="${RUNNER_TEMP}/ghidra-download"
+        GHIDRA_INSTALL_ROOT="${RUNNER_TEMP}/ghidra-install"
+
+        mkdir -p "${GHIDRA_DOWNLOAD_DIR}" "${GHIDRA_INSTALL_ROOT}"
+
+        GHIDRA_ZIP="${GHIDRA_DOWNLOAD_DIR}/${{ steps.ghidra-asset.outputs.asset_name }}"
+        if [ ! -f "${GHIDRA_ZIP}" ]; then
+          curl -fsSL "${{ steps.ghidra-asset.outputs.download_url }}" -o "${GHIDRA_ZIP}"
+        fi
+
+        GHIDRA_DIR="$(find "${GHIDRA_INSTALL_ROOT}" -maxdepth 1 -type d -name 'ghidra_*_PUBLIC*' | head -n1 || true)"
+        if [ -z "${GHIDRA_DIR}" ]; then
+          unzip -q "${GHIDRA_ZIP}" -d "${GHIDRA_INSTALL_ROOT}"
+          GHIDRA_DIR="$(find "${GHIDRA_INSTALL_ROOT}" -maxdepth 1 -type d -name 'ghidra_*_PUBLIC*' | head -n1)"
+        fi
+
+        xattr -dr com.apple.quarantine "${GHIDRA_DIR}" || true
+        echo "GHIDRA_INSTALL_DIR=${GHIDRA_DIR}" >> "${GITHUB_ENV}"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+
+    - name: Run unit tests on macOS
+      run: |
+        mkdir -p junit
+        python -m pytest tests/unit/ --doctest-modules --junitxml=junit/unit-test-results-macos.xml
+
+    - name: Run integration smoke tests on macOS
+      run: |
+        mkdir -p junit
+        python -m pytest \
+          tests/integration/test_sse_client.py \
+          tests/integration/test_streamable_client.py \
+          tests/integration/test_search_code.py \
+          -v \
+          --doctest-modules \
+          --junitxml=junit/integration-smoke-test-results-macos.xml
+
+    - name: Upload unit test results (macOS)
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: unit-test-results-macos
+        path: junit/unit-test-results-macos.xml
+        retention-days: 7
+
+    - name: Upload integration smoke test results (macOS)
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: integration-smoke-test-results-macos
+        path: junit/integration-smoke-test-results-macos.xml
         retention-days: 7

--- a/.github/workflows/pytest-devcontainer-repo-all.yml
+++ b/.github/workflows/pytest-devcontainer-repo-all.yml
@@ -118,14 +118,18 @@ jobs:
       id: ghidra-asset
       env:
         GHIDRA_VERSION: ${{ matrix.ghidra_version }}
+        GH_API_TOKEN: ${{ github.token }}
       run: |
         python - <<'PY'
         import json
         import os
         import re
+        import time
+        import urllib.error
         import urllib.request
 
         ghidra_version = os.environ["GHIDRA_VERSION"]
+        gh_api_token = os.environ.get("GH_API_TOKEN", "")
         if ghidra_version == "latest":
             api_url = "https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/latest"
         else:
@@ -134,8 +138,32 @@ jobs:
                 f"Ghidra_{ghidra_version}_build"
             )
 
-        with urllib.request.urlopen(api_url) as resp:
-            release_data = json.load(resp)
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "pyghidra-mcp-ci",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if gh_api_token:
+            headers["Authorization"] = f"Bearer {gh_api_token}"
+
+        release_data = None
+        for attempt in range(5):
+            req = urllib.request.Request(api_url, headers=headers)
+            try:
+                with urllib.request.urlopen(req) as resp:
+                    release_data = json.load(resp)
+                break
+            except urllib.error.HTTPError as err:
+                if err.code not in {403, 429, 500, 502, 503, 504} or attempt == 4:
+                    details = err.read().decode("utf-8", errors="replace")
+                    raise SystemExit(
+                        f"Failed to resolve Ghidra release asset for {ghidra_version}: "
+                        f"HTTP {err.code} {details}"
+                    )
+                time.sleep(min(30, 2 ** (attempt + 1)))
+
+        if release_data is None:
+            raise SystemExit(f"Unable to resolve Ghidra release asset for {ghidra_version}.")
 
         asset = next(
             (

--- a/.github/workflows/pytest-devcontainer-repo-cli.yml
+++ b/.github/workflows/pytest-devcontainer-repo-cli.yml
@@ -89,10 +89,23 @@ jobs:
         retention-days: 7
 
   test-macos:
+    name: test-macos (${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python)
     runs-on: macos-latest
-    timeout-minutes: 90
-    env:
-      GHIDRA_RELEASE_API: https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ghidra_version: latest
+            python_version: "3.13"
+          - ghidra_version: "12.0"
+            python_version: "3.13"
+          - ghidra_version: "11.3.2"
+            python_version: "3.12"
+          - ghidra_version: "11.4.1"
+            python_version: "3.11"
+          # 11.3/3.10 intentionally excluded for CLI because this combo currently fails
+          # with ModuleNotFoundError: No module named 'aiohttp' during integration test import.
 
     steps:
     - uses: actions/checkout@v4
@@ -100,7 +113,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: ${{ matrix.python_version }}
         cache: pip
         cache-dependency-path: |
           cli/pyproject.toml
@@ -112,8 +125,10 @@ jobs:
         distribution: temurin
         java-version: "21"
 
-    - name: Resolve latest Ghidra release asset
+    - name: Resolve Ghidra release asset
       id: ghidra-asset
+      env:
+        GHIDRA_VERSION: ${{ matrix.ghidra_version }}
       run: |
         python - <<'PY'
         import json
@@ -121,7 +136,15 @@ jobs:
         import re
         import urllib.request
 
-        api_url = os.environ["GHIDRA_RELEASE_API"]
+        ghidra_version = os.environ["GHIDRA_VERSION"]
+        if ghidra_version == "latest":
+            api_url = "https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/latest"
+        else:
+            api_url = (
+                "https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/tags/"
+                f"Ghidra_{ghidra_version}_build"
+            )
+
         with urllib.request.urlopen(api_url) as resp:
             release_data = json.load(resp)
 
@@ -135,7 +158,7 @@ jobs:
         )
 
         if asset is None:
-            raise SystemExit("No Ghidra public zip asset found in latest release.")
+            raise SystemExit(f"No Ghidra public zip asset found for {ghidra_version}.")
 
         with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
             output.write(f"asset_name={asset['name']}\n")
@@ -148,7 +171,7 @@ jobs:
         path: |
           ${{ runner.temp }}/ghidra-download
           ${{ runner.temp }}/ghidra-install
-        key: ${{ runner.os }}-ghidra-${{ steps.ghidra-asset.outputs.asset_name }}
+        key: ${{ runner.os }}-ghidra-${{ matrix.ghidra_version }}-${{ steps.ghidra-asset.outputs.asset_name }}
 
     - name: Install Ghidra
       run: |
@@ -181,39 +204,41 @@ jobs:
         path: |
           ~/.cache/uv
           cli/.venv
-        key: ${{ runner.os }}-uv-${{ hashFiles('cli/uv.lock') }}
+        key: ${{ runner.os }}-uv-${{ matrix.ghidra_version }}-${{ matrix.python_version }}-${{ hashFiles('cli/uv.lock') }}
 
     - name: Install CLI dependencies
       working-directory: cli
-      run: uv sync --extra dev
+      run: |
+        uv sync --extra dev
+
+        if [[ "${{ matrix.ghidra_version }}" == 11.* ]]; then
+          uv run pip install "pyghidra==2.2.1"
+        fi
 
     - name: Run CLI unit tests on macOS
       working-directory: cli
       run: |
         mkdir -p junit
-        uv run pytest tests/unit/ -v --doctest-modules --junitxml=junit/unit-test-results-macos.xml
+        uv run pytest tests/unit/ -v --doctest-modules --junitxml=junit/unit-test-results-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python-macos.xml
 
-    - name: Run CLI integration smoke tests on macOS
+    - name: Run CLI integration tests on macOS
       working-directory: cli
       run: |
         mkdir -p junit
-        uv run pytest tests/integration/test_cli_commands.py \
-          -v \
-          -k "test_list_binaries or test_decompile_function or test_search_symbols" \
-          --junitxml=junit/integration-smoke-test-results-macos.xml
+        uv run pytest tests/integration/ -v --doctest-modules --junitxml=junit/integration-test-results-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python-macos.xml
 
     - name: Upload CLI unit test results (macOS)
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
-        name: cli-unit-test-results-macos
-        path: cli/junit/unit-test-results-macos.xml
+        name: cli-unit-test-results-macos-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python
+        path: cli/junit/unit-test-results-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python-macos.xml
         retention-days: 7
 
-    - name: Upload CLI integration smoke test results (macOS)
+    - name: Upload CLI integration test results (macOS)
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
-        name: cli-integration-smoke-test-results-macos
-        path: cli/junit/integration-smoke-test-results-macos.xml
+        name: cli-integration-test-results-macos-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python
+        path: cli/junit/integration-test-results-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python-macos.xml
         retention-days: 7

--- a/.github/workflows/pytest-devcontainer-repo-cli.yml
+++ b/.github/workflows/pytest-devcontainer-repo-cli.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  cli-test-linux:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -88,8 +88,8 @@ jobs:
         path: junit/integration-test-results-${{ matrix.image }}.xml
         retention-days: 7
 
-  test-macos:
-    name: test-macos (${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python)
+  cli-test-macos:
+    name: cli-test-macos (${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python)
     runs-on: macos-latest
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/pytest-devcontainer-repo-cli.yml
+++ b/.github/workflows/pytest-devcontainer-repo-cli.yml
@@ -87,3 +87,133 @@ jobs:
         name: cli-integration-test-results-${{ matrix.image }}
         path: junit/integration-test-results-${{ matrix.image }}.xml
         retention-days: 7
+
+  test-macos:
+    runs-on: macos-latest
+    timeout-minutes: 90
+    env:
+      GHIDRA_RELEASE_API: https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        cache: pip
+        cache-dependency-path: |
+          cli/pyproject.toml
+          cli/uv.lock
+
+    - name: Set up Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: "21"
+
+    - name: Resolve latest Ghidra release asset
+      id: ghidra-asset
+      run: |
+        python - <<'PY'
+        import json
+        import os
+        import re
+        import urllib.request
+
+        api_url = os.environ["GHIDRA_RELEASE_API"]
+        with urllib.request.urlopen(api_url) as resp:
+            release_data = json.load(resp)
+
+        asset = next(
+            (
+                candidate
+                for candidate in release_data.get("assets", [])
+                if re.match(r"ghidra_.*_PUBLIC_.*\.zip$", candidate["name"])
+            ),
+            None,
+        )
+
+        if asset is None:
+            raise SystemExit("No Ghidra public zip asset found in latest release.")
+
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+            output.write(f"asset_name={asset['name']}\n")
+            output.write(f"download_url={asset['browser_download_url']}\n")
+        PY
+
+    - name: Cache Ghidra
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ runner.temp }}/ghidra-download
+          ${{ runner.temp }}/ghidra-install
+        key: ${{ runner.os }}-ghidra-${{ steps.ghidra-asset.outputs.asset_name }}
+
+    - name: Install Ghidra
+      run: |
+        set -euxo pipefail
+        GHIDRA_DOWNLOAD_DIR="${RUNNER_TEMP}/ghidra-download"
+        GHIDRA_INSTALL_ROOT="${RUNNER_TEMP}/ghidra-install"
+
+        mkdir -p "${GHIDRA_DOWNLOAD_DIR}" "${GHIDRA_INSTALL_ROOT}"
+
+        GHIDRA_ZIP="${GHIDRA_DOWNLOAD_DIR}/${{ steps.ghidra-asset.outputs.asset_name }}"
+        if [ ! -f "${GHIDRA_ZIP}" ]; then
+          curl -fsSL "${{ steps.ghidra-asset.outputs.download_url }}" -o "${GHIDRA_ZIP}"
+        fi
+
+        GHIDRA_DIR="$(find "${GHIDRA_INSTALL_ROOT}" -maxdepth 1 -type d -name 'ghidra_*_PUBLIC*' | head -n1 || true)"
+        if [ -z "${GHIDRA_DIR}" ]; then
+          unzip -q "${GHIDRA_ZIP}" -d "${GHIDRA_INSTALL_ROOT}"
+          GHIDRA_DIR="$(find "${GHIDRA_INSTALL_ROOT}" -maxdepth 1 -type d -name 'ghidra_*_PUBLIC*' | head -n1)"
+        fi
+
+        xattr -dr com.apple.quarantine "${GHIDRA_DIR}" || true
+        echo "GHIDRA_INSTALL_DIR=${GHIDRA_DIR}" >> "${GITHUB_ENV}"
+
+    - name: Install uv
+      run: pip install uv
+
+    - name: Cache uv
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/uv
+          cli/.venv
+        key: ${{ runner.os }}-uv-${{ hashFiles('cli/uv.lock') }}
+
+    - name: Install CLI dependencies
+      working-directory: cli
+      run: uv sync --extra dev
+
+    - name: Run CLI unit tests on macOS
+      working-directory: cli
+      run: |
+        mkdir -p junit
+        uv run pytest tests/unit/ -v --doctest-modules --junitxml=junit/unit-test-results-macos.xml
+
+    - name: Run CLI integration smoke tests on macOS
+      working-directory: cli
+      run: |
+        mkdir -p junit
+        uv run pytest tests/integration/test_cli_commands.py \
+          -v \
+          -k "test_list_binaries or test_decompile_function or test_search_symbols" \
+          --junitxml=junit/integration-smoke-test-results-macos.xml
+
+    - name: Upload CLI unit test results (macOS)
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: cli-unit-test-results-macos
+        path: cli/junit/unit-test-results-macos.xml
+        retention-days: 7
+
+    - name: Upload CLI integration smoke test results (macOS)
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: cli-integration-smoke-test-results-macos
+        path: cli/junit/integration-smoke-test-results-macos.xml
+        retention-days: 7

--- a/.github/workflows/pytest-devcontainer-repo-cli.yml
+++ b/.github/workflows/pytest-devcontainer-repo-cli.yml
@@ -129,14 +129,18 @@ jobs:
       id: ghidra-asset
       env:
         GHIDRA_VERSION: ${{ matrix.ghidra_version }}
+        GH_API_TOKEN: ${{ github.token }}
       run: |
         python - <<'PY'
         import json
         import os
         import re
+        import time
+        import urllib.error
         import urllib.request
 
         ghidra_version = os.environ["GHIDRA_VERSION"]
+        gh_api_token = os.environ.get("GH_API_TOKEN", "")
         if ghidra_version == "latest":
             api_url = "https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/latest"
         else:
@@ -145,8 +149,32 @@ jobs:
                 f"Ghidra_{ghidra_version}_build"
             )
 
-        with urllib.request.urlopen(api_url) as resp:
-            release_data = json.load(resp)
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "pyghidra-mcp-ci",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if gh_api_token:
+            headers["Authorization"] = f"Bearer {gh_api_token}"
+
+        release_data = None
+        for attempt in range(5):
+            req = urllib.request.Request(api_url, headers=headers)
+            try:
+                with urllib.request.urlopen(req) as resp:
+                    release_data = json.load(resp)
+                break
+            except urllib.error.HTTPError as err:
+                if err.code not in {403, 429, 500, 502, 503, 504} or attempt == 4:
+                    details = err.read().decode("utf-8", errors="replace")
+                    raise SystemExit(
+                        f"Failed to resolve Ghidra release asset for {ghidra_version}: "
+                        f"HTTP {err.code} {details}"
+                    )
+                time.sleep(min(30, 2 ** (attempt + 1)))
+
+        if release_data is None:
+            raise SystemExit(f"Unable to resolve Ghidra release asset for {ghidra_version}.")
 
         asset = next(
             (

--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
@@ -211,6 +211,8 @@ pyghidra_mcp_projects/**
 tests/pyghidra_mcp_projects/**
 
 # Personal
+._*
+.claude/
 ghidra
 notes-*.txt
 *.code-workspace

--- a/README.md
+++ b/README.md
@@ -318,57 +318,56 @@ Enable LLMs to perform actions, make deterministic computations, and interact wi
 
 #### Code Search
 
-- `search_code(binary_name: str, query: str, limit: int = 5)`: Search for code within a binary by similarity using vector embeddings.
+- `search_code(binary_name: str, query: str, limit: int = 5, offset: int = 0, search_mode: str = "semantic", include_full_code: bool = True, preview_length: int = 500, similarity_threshold: float = 0.0)`: Search decompiled functions semantically or by exact literal text. Responses include `literal_total`, `semantic_total`, and `total_functions` to show how many functions matched each mode.
 
 #### Cross-References
 
-- `list_cross_references(binary_name: str, name_or_address: str)`: Finds and lists all cross-references (x-refs) to a given function or address.
+- `list_cross_references(binary_name: str, name_or_address: str)`: List cross-references to one exact symbol, function, or address.
 
 #### Generate Call Graph
 
-- `gen_callgraph(binary_name: str, function_name_or_address: str, direction: str = "calling", display_type: str = "flow", include_refs: bool = True, max_depth: int | None = None, max_run_time: int = 60, condense_threshold: int = 50, top_layers: int = 5, bottom_layers: int = 5)`: Generates a MermaidJS call graph for a specified function. Supports both "calling" (functions called by the target) and "called" (functions that call the target) directions with multiple visualization types.
+- `gen_callgraph(binary_name: str, function_name: str, direction: str = "calling", display_type: str = "flow", condense_threshold: int = 50, top_layers: int = 3, bottom_layers: int = 3, max_run_time: int = 120)`: Generate a MermaidJS call graph for one exact function.
 
 #### Decompile Function
 
-- `decompile_function(binary_name: str, name: str)`: Decompile a function from a given binary.
+- `decompile_function(binary_name: str, name_or_address: str)`: Decompile one exact function or hex address from a binary.
 
 #### Import Binary
 
-- `import_binary(binary_path: str)`: Imports a binary from a designated path into the current Ghidra project. If the path is a directory, it will recursively scan and import all supported binary files, preserving the directory structure within the Ghidra project.
+- `import_binary(binary_path: str)`: Import a binary file or recursively import every supported binary inside a directory. The import runs in the background and the binary becomes usable when `list_project_binaries()` reports it as analyzed and indexed.
 
 #### List Exports
 
-- `list_exports(binary_name: str, query: str = ".*", offset: int = 0, limit: int = 25)`: Lists all exported functions and symbols from a specified binary (regex supported for query).
+- `list_exports(binary_name: str, query: str = ".*", offset: int = 0, limit: int = 25)`: List exported symbols from a binary. Use `query` to narrow large binaries before raising `limit`.
 
 #### List Imports
 
-- `list_imports(binary_name: str, query: str = ".*", offset: int = 0, limit: int = 25)`: Lists all imported functions and symbols for a specified binary (regex supported for query).
+- `list_imports(binary_name: str, query: str = ".*", offset: int = 0, limit: int = 25)`: List imported symbols from a binary. Use `query` to narrow large binaries before raising `limit`.
 
 #### List Project Binaries
 
-- `list_project_binaries()`: Lists the names of all binaries currently loaded in the Ghidra project.
+- `list_project_binaries()`: List project binaries together with `analysis_complete`, `code_collection`, and `strings_collection` readiness so clients can tell when a binary is ready for decompilation, code search, or string search.
 
 #### List Project Binary Metadata
 
-- `list_project_binary_metadata(binary_name: str)`: Retrieves detailed metadata for a specific binary, including architecture, compiler, executable format, analysis metrics, and file hashes.
+- `list_project_binary_metadata(binary_name: str)`: Retrieve metadata for one binary, including architecture, compiler, executable format, and loader properties.
 
 #### Delete Project Binary
 
-- `delete_project_binary(binary_name: str)`: Deletes a binary (program) from the Ghidra project.
+- `delete_project_binary(binary_name: str)`: Delete a binary (program) from the Ghidra project.
 
 #### Read Bytes
 
-- `read_bytes(binary_name: str, address: str, size: int = 32)`: Reads raw bytes from memory at a specified address. Returns raw hex data. Useful for inspecting memory contents, data structures, or confirming analysis findings.
-
-
+- `read_bytes(binary_name: str, address: str, size: int = 32)`: Read raw bytes from one mapped address. Returns normalized address, byte count, and hex data.
 
 #### Search Strings
 
-- `search_strings(binary_name: str, query: str, limit: int = 100)`: Searches for strings within a binary by name.
+- `search_strings(binary_name: str, query: str, limit: int = 100)`: Search extracted strings by text and return the best literal and semantic matches.
 
 #### Search Symbols
 
-- `search_symbols_by_name(binary_name: str, query: str, offset: int = 0, limit: int = 25)`: Search for symbols within a binary by name (case-insensitive substring).
+- `search_symbols_by_name(binary_name: str, query: str, offset: int = 0, limit: int = 25)`: Search symbols by case-insensitive substring.
+- `search_functions_by_name(binary_name: str, query: str, offset: int = 0, limit: int = 25)`: Search only functions by case-insensitive substring before switching to exact-match tools such as `decompile_function`, `list_cross_references`, or `gen_callgraph`.
 
 ### Prompts
 

--- a/cli/src/pyghidra_mcp_cli/client.py
+++ b/cli/src/pyghidra_mcp_cli/client.py
@@ -82,11 +82,11 @@ class PyGhidraMcpClient:
     async def _connect_internal(self) -> None:
         """Internal connection logic - establish connection to the pyghidra-mcp server."""
         from mcp.client.session import ClientSession
-        from mcp.client.streamable_http import streamablehttp_client
+        from mcp.client.streamable_http import streamable_http_client
 
         url = f"http://{self.host}:{self.port}/mcp"
 
-        transport_gen = streamablehttp_client(url)
+        transport_gen = streamable_http_client(url)
         try:
             read, write, _ = await asyncio.wait_for(transport_gen.__aenter__(), timeout=5.0)
         except asyncio.TimeoutError:

--- a/cli/tests/integration/test_cli_commands.py
+++ b/cli/tests/integration/test_cli_commands.py
@@ -31,7 +31,8 @@ def ghidra_env():
         env["GHIDRA_INSTALL_DIR"] = "/ghidra"
         return env
     pytest.skip(
-        "GHIDRA installation not found. Set GHIDRA_INSTALL_DIR to a valid Ghidra install, or ensure /ghidra exists."
+        "GHIDRA installation not found. Set GHIDRA_INSTALL_DIR to a valid Ghidra install, "
+        "or ensure /ghidra exists."
     )
 
 
@@ -100,7 +101,8 @@ def streamable_server(test_binary, test_dir, ghidra_env):
     if proc.poll() is not None:
         out, err = proc.communicate(timeout=5)
         raise RuntimeError(
-            f"pyghidra-mcp exited early with code {proc.returncode}.\nSTDOUT:\n{out}\nSTDERR:\n{err}"
+            f"pyghidra-mcp exited early with code {proc.returncode}.\n"
+            f"STDOUT:\n{out}\nSTDERR:\n{err}"
         )
 
     async def wait_for_server(timeout=120):

--- a/cli/tests/integration/test_cli_commands.py
+++ b/cli/tests/integration/test_cli_commands.py
@@ -188,19 +188,22 @@ async def test_search_symbols(client, binary_name):
     """Test searching for symbols."""
     async with client:
         result = await client.search_symbols(binary_name, "function", offset=0, limit=10)
+        name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
+        name_two = "_function_two" if platform.system() == "Darwin" else "function_two"
         assert "symbols" in result
         assert len(result["symbols"]) >= 2
-        assert any("function_one" in s["name"] for s in result["symbols"])
-        assert any("function_two" in s["name"] for s in result["symbols"])
+        assert any(name_one in s["name"] for s in result["symbols"])
+        assert any(name_two in s["name"] for s in result["symbols"])
 
 
 @pytest.mark.asyncio
 async def test_search_code(client, binary_name):
     """Test searching code."""
+    name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
     async with client:
         result = await client.search_code(
             binary_name,
-            query="function_one",
+            query=name_one,
             limit=5,
             offset=0,
             search_mode="semantic",
@@ -211,7 +214,7 @@ async def test_search_code(client, binary_name):
         assert "results" in result
         assert len(result["results"]) > 0
         assert (
-            "function_one" in result["results"][0]["function_name"]
+            name_one in result["results"][0]["function_name"]
             or result["results"][0]["function_name"]
         )
 
@@ -239,18 +242,20 @@ async def test_list_imports(client, binary_name):
 @pytest.mark.asyncio
 async def test_list_exports(client, binary_name):
     """Test listing exports."""
+    name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
     async with client:
         result = await client.list_exports(binary_name, query=".*function.*", offset=0, limit=10)
         assert "exports" in result
         assert len(result["exports"]) > 0
-        assert any("function_one" in exp["name"] for exp in result["exports"])
+        assert any(name_one in exp["name"] for exp in result["exports"])
 
 
 @pytest.mark.asyncio
 async def test_list_cross_references(client, binary_name):
     """Test listing cross-references."""
+    name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
     async with client:
-        result = await client.list_cross_references(binary_name, "function_one")
+        result = await client.list_cross_references(binary_name, name_one)
         assert "cross_references" in result
         assert len(result["cross_references"]) > 0
 

--- a/cli/tests/integration/test_cli_commands.py
+++ b/cli/tests/integration/test_cli_commands.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import platform
 import shutil
 import subprocess
 import tempfile
@@ -11,6 +12,27 @@ import aiohttp
 import pytest
 
 base_url = os.getenv("MCP_BASE_URL", "http://127.0.0.1:8000")
+
+
+@pytest.fixture(scope="session")
+def ghidra_env():
+    """Derive a valid environment for locating Ghidra or skip if unavailable.
+
+    Policy:
+    - If GHIDRA_INSTALL_DIR is set and is a valid directory, use it.
+    - Else if /ghidra exists, set GHIDRA_INSTALL_DIR to /ghidra.
+    - Else skip tests that require a Ghidra installation.
+    """
+    env = os.environ.copy()
+    ghidra_dir = env.get("GHIDRA_INSTALL_DIR")
+    if ghidra_dir and os.path.isdir(ghidra_dir):
+        return env
+    if os.path.isdir("/ghidra"):
+        env["GHIDRA_INSTALL_DIR"] = "/ghidra"
+        return env
+    pytest.skip(
+        "GHIDRA installation not found. Set GHIDRA_INSTALL_DIR to a valid Ghidra install, or ensure /ghidra exists."
+    )
 
 
 @pytest.fixture(scope="module")
@@ -56,7 +78,7 @@ int main() {
 
 
 @pytest.fixture(scope="module")
-def streamable_server(test_binary, test_dir):
+def streamable_server(test_binary, test_dir, ghidra_env):
     """Fixture to start the pyghidra-mcp server in a separate process with isolated project."""
     project_dir = os.path.join(test_dir, "project.gpr")
 
@@ -65,14 +87,21 @@ def streamable_server(test_binary, test_dir):
             "pyghidra-mcp",
             "--transport",
             "streamable-http",
+            "--wait-for-analysis",
             "--project-path",
             project_dir,
             test_binary,
         ],
-        env={**os.environ, "GHIDRA_INSTALL_DIR": "/ghidra"},
+        env=ghidra_env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
+
+    if proc.poll() is not None:
+        out, err = proc.communicate(timeout=5)
+        raise RuntimeError(
+            f"pyghidra-mcp exited early with code {proc.returncode}.\nSTDOUT:\n{out}\nSTDERR:\n{err}"
+        )
 
     async def wait_for_server(timeout=120):
         async with aiohttp.ClientSession() as session:
@@ -90,10 +119,17 @@ def streamable_server(test_binary, test_dir):
 
     time.sleep(10)
 
-    yield test_binary
-
-    proc.terminate()
-    proc.wait(timeout=10)
+    try:
+        yield test_binary
+    finally:
+        try:
+            proc.terminate()
+            proc.wait(timeout=10)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
 
 
 @pytest.fixture
@@ -139,9 +175,10 @@ async def test_list_binaries(client, streamable_server):
 async def test_decompile_function(client, binary_name):
     """Test decompiling a function."""
     async with client:
-        result = await client.decompile_function(binary_name, "main")
+        name = "entry" if platform.system() == "Darwin" else "main"
+        result = await client.decompile_function(binary_name, name)
         assert "code" in result
-        assert "main" in result["code"]
+        assert name in result["code"]
 
 
 @pytest.mark.asyncio
@@ -219,8 +256,9 @@ async def test_list_cross_references(client, binary_name):
 @pytest.mark.asyncio
 async def test_read_bytes(client, binary_name):
     """Test reading bytes from memory."""
+    address = "100000000" if platform.system() == "Darwin" else "100000"
     async with client:
-        result = await client.read_bytes(binary_name, address="100000", size=32)
+        result = await client.read_bytes(binary_name, address=address, size=32)
         assert "data" in result
         assert "address" in result
         assert result["size"] == 32
@@ -230,9 +268,10 @@ async def test_read_bytes(client, binary_name):
 async def test_gen_callgraph(client, binary_name):
     """Test generating a call graph."""
     async with client:
+        name = "entry" if platform.system() == "Darwin" else "main"
         result = await client.gen_callgraph(
             binary_name,
-            function_name="main",
+            function_name=name,
             direction="calling",
             display_type="flow",
             condense_threshold=50,
@@ -242,7 +281,7 @@ async def test_gen_callgraph(client, binary_name):
         )
         assert "graph" in result
         assert "function_name" in result
-        assert "main" in result["function_name"]
+        assert name in result["function_name"]
 
 
 @pytest.mark.asyncio

--- a/src/pyghidra_mcp/context.py
+++ b/src/pyghidra_mcp/context.py
@@ -39,11 +39,25 @@ class ProgramInfo:
     load_time: float | None = None
     code_collection: chromadb.Collection | None = None
     strings_collection: chromadb.Collection | None = None
+    ghidra_tools: GhidraTools | None = None
+    derived_cache_version: int = 0
 
     @property
     def analysis_complete(self) -> bool:
         """Check if Ghidra analysis is complete."""
         return self.ghidra_analysis_complete
+
+    def get_tools(self) -> GhidraTools:
+        """Return the shared GhidraTools instance for this program."""
+        if self.ghidra_tools is None:
+            self.ghidra_tools = GhidraTools(self)
+        return self.ghidra_tools
+
+    def invalidate_derived_caches(self) -> None:
+        """Invalidate cached lookup data for this program."""
+        self.derived_cache_version += 1
+        if self.ghidra_tools is not None:
+            self.ghidra_tools.invalidate_derived_caches(self.derived_cache_version)
 
 
 class PyGhidraContext:
@@ -249,6 +263,7 @@ class PyGhidraContext:
         else:
             logger.info(f"Deleting program: {program_name}")
             try:
+                self.invalidate_program_derived_caches(program_info=program_info)
                 program_to_delete: Program = program_info.program
                 program_to_delete_df: DomainFile = program_to_delete.getDomainFile()
                 self.project.close(program_to_delete)
@@ -309,6 +324,8 @@ class PyGhidraContext:
 
         if not program:
             raise ImportError(f"Failed to import binary: {binary_path}")
+
+        self.invalidate_program_derived_caches(program_info=program_info)
 
         if analyze:
             self.analyze_program(program_info.program)
@@ -477,11 +494,27 @@ class PyGhidraContext:
                         "ghidra_analysis_complete": program_info.ghidra_analysis_complete,
                         "code_collection": program_info.code_collection is not None,
                         "strings_collection": program_info.strings_collection is not None,
-                        "suggestion": "Wait and try tool call again.",
+                        "suggestion": (
+                            "Wait for list_project_binaries() to report the binary as ready, "
+                            "then retry the tool call."
+                        ),
                     }
                 )
             )
         return program_info
+
+    def invalidate_program_derived_caches(
+        self,
+        *,
+        program_info: ProgramInfo | None = None,
+        binary_name: str | None = None,
+    ) -> None:
+        """Invalidate cached lookup data for a program."""
+        if program_info is None:
+            if binary_name is None:
+                raise ValueError("Either program_info or binary_name is required")
+            program_info = self.get_program_info(binary_name)
+        program_info.invalidate_derived_caches()
 
     def _init_program_info(self, program):
         from ghidra.program.flatapi import FlatProgramAPI
@@ -535,9 +568,10 @@ class PyGhidraContext:
             collection = self.chroma_client.get_collection(name=program_info.name)
             logger.info(f"Collection '{program_info.name}' exists; skipping code ingest.")
             program_info.code_collection = collection
+            self.invalidate_program_derived_caches(program_info=program_info)
         except Exception:
             logger.info(f"Creating new code collection '{program_info.name}'")
-            tools = GhidraTools(program_info)
+            tools = program_info.get_tools()
             functions = tools.get_all_functions()
             decompiles = []
             ids = []
@@ -572,6 +606,7 @@ class PyGhidraContext:
 
             logger.info(f"Code analysis complete for collection '{program_info.name}'")
             program_info.code_collection = collection
+            self.invalidate_program_derived_caches(program_info=program_info)
 
     def _init_chroma_strings_collection_for_program(self, program_info: ProgramInfo):
         """
@@ -583,9 +618,10 @@ class PyGhidraContext:
             strings_collection = self.chroma_client.get_collection(name=collection_name)
             logger.info(f"Collection '{collection_name}' exists; skipping strings ingest.")
             program_info.strings_collection = strings_collection
+            self.invalidate_program_derived_caches(program_info=program_info)
         except Exception:
             logger.info(f"Creating new strings collection '{collection_name}'")
-            tools = GhidraTools(program_info)
+            tools = program_info.get_tools()
 
             ids = []
             strings = tools.get_all_strings()
@@ -605,6 +641,7 @@ class PyGhidraContext:
 
             logger.info(f"Strings analysis complete for collection '{collection_name}'")
             program_info.strings_collection = strings_collection
+            self.invalidate_program_derived_caches(program_info=program_info)
 
     def _init_chroma_collections_for_program(self, program_info: ProgramInfo):
         """
@@ -836,7 +873,9 @@ class PyGhidraContext:
             self.project.saveAsPackedFile(program, File(str(gzf_file.absolute())), True)
 
         logger.info(f"Analysis for {df_or_prog.getName()} complete")
-        self.programs[df.pathname].ghidra_analysis_complete = True
+        program_info = self.programs[df.pathname]
+        program_info.ghidra_analysis_complete = True
+        self.invalidate_program_derived_caches(program_info=program_info)
         return df_or_prog
 
     def set_analysis_option(  # noqa: C901

--- a/src/pyghidra_mcp/context.py
+++ b/src/pyghidra_mcp/context.py
@@ -398,8 +398,7 @@ class PyGhidraContext:
                 # continue importing remaining files
 
     def _is_binary_file(self, path: Path) -> bool:
-        # return self._detect_binary_format(path) is not None
-        return True
+        return self._detect_binary_format(path) is not None
 
     def _detect_binary_format(self, path: Path) -> str | None:
         # loader = pyghidra.program_loader()

--- a/src/pyghidra_mcp/mcp_tools.py
+++ b/src/pyghidra_mcp/mcp_tools.py
@@ -122,6 +122,29 @@ def search_symbols_by_name(
 
 
 @mcp_error_handler
+def search_functions_by_name(
+    binary_name: str, query: str, ctx: Context, offset: int = 0, limit: int = 25
+) -> SymbolSearchResults:
+    """Searches for functions, excluding non-function symbols, within a binary by name.
+
+    This tool searches for functions by a case-insensitive substring. Unlike
+    `search_symbols_by_name`, it does not return labels, namespaces, variables,
+    or other non-function symbol types.
+
+    Args:
+        binary_name: The name of the binary to search within.
+        query: The substring to search for in function names (case-insensitive).
+        offset: The number of results to skip.
+        limit: The maximum number of results to return.
+    """
+    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
+    program_info = pyghidra_context.get_program_info(binary_name)
+    tools = GhidraTools(program_info)
+    symbols = tools.search_functions_by_name(query, offset, limit)
+    return SymbolSearchResults(symbols=symbols)
+
+
+@mcp_error_handler
 def search_code(
     binary_name: str,
     query: str,

--- a/src/pyghidra_mcp/mcp_tools.py
+++ b/src/pyghidra_mcp/mcp_tools.py
@@ -6,13 +6,16 @@ This module contains all MCP tool implementations with centralized error handlin
 
 import functools
 import logging
+from typing import Annotated
 
 from mcp.server.fastmcp import Context
 from mcp.shared.exceptions import McpError
 from mcp.types import INTERNAL_ERROR, INVALID_PARAMS, ErrorData
+from pydantic import Field
 
 from pyghidra_mcp.context import PyGhidraContext
 from pyghidra_mcp.models import (
+    BinaryMetadata,
     BytesReadResult,
     CallGraphDirection,
     CallGraphDisplayType,
@@ -31,6 +34,18 @@ from pyghidra_mcp.models import (
 from pyghidra_mcp.tools import GhidraTools
 
 logger = logging.getLogger(__name__)
+
+
+def _get_pyghidra_context(ctx: Context) -> PyGhidraContext:
+    return ctx.request_context.lifespan_context
+
+
+def _get_program_info(ctx: Context, binary_name: str):
+    return _get_pyghidra_context(ctx).get_program_info(binary_name)
+
+
+def _get_program_tools(ctx: Context, binary_name: str) -> GhidraTools:
+    return _get_program_info(ctx, binary_name).get_tools()
 
 
 def _get_action_name(func_name: str) -> str:
@@ -84,7 +99,12 @@ def mcp_error_handler(func):
 
 @mcp_error_handler
 async def decompile_function(
-    binary_name: str, name_or_address: str, ctx: Context
+    binary_name: str,
+    name_or_address: Annotated[
+        str,
+        Field(description="Exact name or hex address."),
+    ],
+    ctx: Context,
 ) -> DecompiledFunction:
     """Decompiles a function in a specified binary and returns its pseudo-C code.
 
@@ -92,9 +112,7 @@ async def decompile_function(
         binary_name: The name of the binary containing the function.
         name_or_address: The name or address of the function to decompile.
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
-    program_info = pyghidra_context.get_program_info(binary_name)
-    tools = GhidraTools(program_info)
+    tools = _get_program_tools(ctx, binary_name)
     return tools.decompile_function_by_name_or_addr(name_or_address)
 
 
@@ -114,9 +132,7 @@ def search_symbols_by_name(
         offset: The number of results to skip.
         limit: The maximum number of results to return.
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
-    program_info = pyghidra_context.get_program_info(binary_name)
-    tools = GhidraTools(program_info)
+    tools = _get_program_tools(ctx, binary_name)
     symbols = tools.search_symbols_by_name(query, offset, limit)
     return SymbolSearchResults(symbols=symbols)
 
@@ -137,9 +153,7 @@ def search_functions_by_name(
         offset: The number of results to skip.
         limit: The maximum number of results to return.
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
-    program_info = pyghidra_context.get_program_info(binary_name)
-    tools = GhidraTools(program_info)
+    tools = _get_program_tools(ctx, binary_name)
     symbols = tools.search_functions_by_name(query, offset, limit)
     return SymbolSearchResults(symbols=symbols)
 
@@ -147,11 +161,17 @@ def search_functions_by_name(
 @mcp_error_handler
 def search_code(
     binary_name: str,
-    query: str,
+    query: Annotated[
+        str,
+        Field(description="Code snippet or exact text."),
+    ],
     ctx: Context,
     limit: int = 5,
     offset: int = 0,
-    search_mode: SearchMode = SearchMode.SEMANTIC,
+    search_mode: Annotated[
+        SearchMode,
+        Field(description="semantic or literal."),
+    ] = SearchMode.SEMANTIC,
     include_full_code: bool = True,
     preview_length: int = 500,
     similarity_threshold: float = 0.0,
@@ -180,9 +200,7 @@ def search_code(
         similarity_threshold: Minimum similarity score (0.0-1.0) for semantic results
             (default: 0.0).
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
-    program_info = pyghidra_context.get_program_info(binary_name)
-    tools = GhidraTools(program_info)
+    tools = _get_program_tools(ctx, binary_name)
     return tools.search_code(
         query=query,
         limit=limit,
@@ -228,7 +246,10 @@ def list_project_binaries(ctx: Context) -> ProgramInfos:
 
 
 @mcp_error_handler
-def list_project_binary_metadata(binary_name: str, ctx: Context) -> dict:
+def list_project_binary_metadata(
+    binary_name: Annotated[str, Field(description="Project binary name.")],
+    ctx: Context,
+) -> BinaryMetadata:
     """
     Retrieve detailed metadata for a specified binary.
 
@@ -238,9 +259,8 @@ def list_project_binary_metadata(binary_name: str, ctx: Context) -> dict:
     Args:
         binary_name: The name of the binary to retrieve metadata for.
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
-    program_info = pyghidra_context.get_program_info(binary_name)
-    return program_info.metadata
+    program_info = _get_program_info(ctx, binary_name)
+    return BinaryMetadata(program_info.metadata)
 
 
 @mcp_error_handler
@@ -250,7 +270,7 @@ async def delete_project_binary(binary_name: str, ctx: Context) -> str:
     Args:
         binary_name: The name of the binary to delete.
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
+    pyghidra_context = _get_pyghidra_context(ctx)
     if pyghidra_context.delete_program(binary_name):
         return f"Successfully deleted binary: {binary_name}"
     else:
@@ -266,7 +286,10 @@ async def delete_project_binary(binary_name: str, ctx: Context) -> str:
 def list_exports(
     binary_name: str,
     ctx: Context,
-    query: str = ".*",
+    query: Annotated[
+        str,
+        Field(description="Regex filter."),
+    ] = ".*",
     offset: int = 0,
     limit: int = 25,
 ) -> ExportInfos:
@@ -287,9 +310,7 @@ def list_exports(
         offset: Number of matching results to skip (for pagination).
         limit: Maximum number of results to return.
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
-    program_info = pyghidra_context.get_program_info(binary_name)
-    tools = GhidraTools(program_info)
+    tools = _get_program_tools(ctx, binary_name)
     exports = tools.list_exports(query=query, offset=offset, limit=limit)
     return ExportInfos(exports=exports)
 
@@ -298,7 +319,10 @@ def list_exports(
 def list_imports(
     binary_name: str,
     ctx: Context,
-    query: str = ".*",
+    query: Annotated[
+        str,
+        Field(description="Regex filter."),
+    ] = ".*",
     offset: int = 0,
     limit: int = 25,
 ) -> ImportInfos:
@@ -319,9 +343,7 @@ def list_imports(
         offset: Number of matching results to skip (for pagination).
         limit: Maximum number of results to return.
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
-    program_info = pyghidra_context.get_program_info(binary_name)
-    tools = GhidraTools(program_info)
+    tools = _get_program_tools(ctx, binary_name)
     imports = tools.list_imports(query=query, offset=offset, limit=limit)
     return ImportInfos(imports=imports)
 
@@ -340,9 +362,7 @@ def list_cross_references(
         name_or_address: The name of the function, symbol, or a specific address (e.g., '0x1004010')
         to find cross-references to.
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
-    program_info = pyghidra_context.get_program_info(binary_name)
-    tools = GhidraTools(program_info)
+    tools = _get_program_tools(ctx, binary_name)
     cross_references = tools.list_cross_references(name_or_address)
     return CrossReferenceInfos(cross_references=cross_references)
 
@@ -362,9 +382,7 @@ def search_strings(
         query: A query to filter strings by.
         limit: The maximum number of results to return.
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
-    program_info = pyghidra_context.get_program_info(binary_name)
-    tools = GhidraTools(program_info)
+    tools = _get_program_tools(ctx, binary_name)
     strings = tools.search_strings(query=query, limit=limit)
     return StringSearchResults(strings=strings)
 
@@ -378,9 +396,7 @@ def read_bytes(binary_name: str, ctx: Context, address: str, size: int = 32) -> 
         address: The memory address to read from (supports hex format with or without 0x prefix).
         size: The number of bytes to read (default: 32, max: 8192).
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
-    program_info = pyghidra_context.get_program_info(binary_name)
-    tools = GhidraTools(program_info)
+    tools = _get_program_tools(ctx, binary_name)
     return tools.read_bytes(address=address, size=size)
 
 
@@ -413,9 +429,7 @@ def gen_callgraph(
         bottom_layers: Number of bottom layers to show in a condensed graph.
         max_run_time: Maximum run time in seconds (default: 120).
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
-    program_info = pyghidra_context.get_program_info(binary_name)
-    tools = GhidraTools(program_info)
+    tools = _get_program_tools(ctx, binary_name)
     return tools.gen_callgraph(
         function_name_or_address=function_name,
         cg_direction=direction,
@@ -430,7 +444,13 @@ def gen_callgraph(
 
 
 @mcp_error_handler
-def import_binary(binary_path: str, ctx: Context) -> str:
+def import_binary(
+    binary_path: Annotated[
+        str,
+        Field(description="Binary file or directory path."),
+    ],
+    ctx: Context,
+) -> str:
     """Imports a binary from a designated path into the current Ghidra project.
 
     Args:
@@ -438,9 +458,9 @@ def import_binary(binary_path: str, ctx: Context) -> str:
     """
     # We would like to do context progress updates, but until that is more
     # widely supported by clients, we will resort to this
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
+    pyghidra_context = _get_pyghidra_context(ctx)
     pyghidra_context.import_binary_backgrounded(binary_path)
     return (
-        f"Importing {binary_path} in the background."
-        "When ready, it will appear analyzed in binary list."
+        f"Importing {binary_path} in the background. "
+        "When ready, it will appear as analyzed in list_project_binaries()."
     )

--- a/src/pyghidra_mcp/models.py
+++ b/src/pyghidra_mcp/models.py
@@ -1,195 +1,191 @@
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, RootModel
+
+BinaryMetadataValue = str | int | float | bool | None
 
 
 class DecompiledFunction(BaseModel):
-    """Represents a single function decompiled by Ghidra."""
+    """Decompiled function."""
 
-    name: str = Field(..., description="The name of the function.")
-    code: str = Field(..., description="The decompiled pseudo-C code of the function.")
-    signature: str | None = Field(None, description="The signature of the function.")
+    name: str = Field(..., description="Function name.")
+    code: str = Field(..., description="Pseudo-C code.")
+    signature: str | None = Field(None, description="Function signature.")
 
 
 class ProgramBasicInfo(BaseModel):
-    """Basic information about a program: name and analysis status"""
+    """Basic program info."""
 
-    name: str = Field(..., description="The name of the program.")
-    analysis_complete: bool = Field(..., description="Indicates if program is ready to be used.")
+    name: str = Field(..., description="Program name.")
+    analysis_complete: bool = Field(..., description="True when analysis is finished.")
 
 
 class ProgramBasicInfos(BaseModel):
-    """A container for a list of basic program information objects."""
+    """Basic program list."""
 
-    programs: list[ProgramBasicInfo] = Field(
-        ..., description="A list of basic program information."
-    )
+    programs: list[ProgramBasicInfo] = Field(..., description="Programs.")
+
+
+class BinaryMetadata(RootModel[dict[str, BinaryMetadataValue]]):
+    """Binary metadata keyed by Ghidra property name."""
 
 
 class ProgramInfo(BaseModel):
-    """Detailed information about a program (binary) loaded in Ghidra."""
+    """Program details."""
 
-    name: str = Field(..., description="The name of the program in Ghidra.")
-    file_path: str | None = Field(None, description="The file path of the program on disk.")
-    load_time: float | None = Field(
-        None, description="The time it took to load the program in seconds."
+    name: str = Field(..., description="Program name.")
+    file_path: str | None = Field(None, description="Binary path.")
+    load_time: float | None = Field(None, description="Load timestamp.")
+    analysis_complete: bool = Field(..., description="True when analysis is finished.")
+    metadata: dict = Field(
+        ...,
+        description="Empty here; call list_project_binary_metadata for details.",
     )
-    analysis_complete: bool = Field(
-        ..., description="Indicates if Ghidra's analysis of the program has completed."
-    )
-    metadata: dict = Field(..., description="A dictionary of metadata associated with the program.")
-    code_collection: bool = Field(..., description="True if the chromadb code collection is ready")
-    strings_collection: bool = Field(
-        ..., description="True if the chromadb strings collection is ready"
-    )
+    code_collection: bool = Field(..., description="Semantic code search ready.")
+    strings_collection: bool = Field(..., description="String search ready.")
 
 
 class ProgramInfos(BaseModel):
-    """A container for a list of program information objects."""
+    """Program details list."""
 
-    programs: list[ProgramInfo] = Field(..., description="A list of program information objects.")
+    programs: list[ProgramInfo] = Field(..., description="Programs.")
 
 
 class ExportInfo(BaseModel):
-    """Represents a single exported function or symbol from a binary."""
+    """Exported symbol."""
 
-    name: str = Field(..., description="The name of the export.")
-    address: str = Field(..., description="The address of the export.")
+    name: str = Field(..., description="Export name.")
+    address: str = Field(..., description="Export address.")
 
 
 class ExportInfos(BaseModel):
-    """A container for a list of exports from a binary."""
+    """Export list."""
 
-    exports: list[ExportInfo] = Field(..., description="A list of exports.")
+    exports: list[ExportInfo] = Field(..., description="Exports.")
 
 
 class ImportInfo(BaseModel):
-    """Represents a single imported function or symbol."""
+    """Imported symbol."""
 
-    name: str = Field(..., description="The name of the import.")
-    library: str = Field(
-        ..., description="The name of the library from which the symbol is imported."
-    )
+    name: str = Field(..., description="Import name.")
+    library: str = Field(..., description="Import library.")
 
 
 class ImportInfos(BaseModel):
-    """A container for a list of imports."""
+    """Import list."""
 
-    imports: list[ImportInfo] = Field(..., description="A list of imports.")
+    imports: list[ImportInfo] = Field(..., description="Imports.")
 
 
 class CrossReferenceInfo(BaseModel):
-    """Represents a cross-reference to a specific address in the binary."""
+    """Cross-reference."""
 
-    function_name: str | None = Field(
-        None, description="The name of the function containing the cross-reference."
-    )
-    from_address: str = Field(..., description="The address where the cross-reference originates.")
-    to_address: str = Field(..., description="The address that is being referenced.")
-    type: str = Field(..., description="The type of the cross-reference.")
+    function_name: str | None = Field(None, description="Containing function.")
+    from_address: str = Field(..., description="Source address.")
+    to_address: str = Field(..., description="Target address.")
+    type: str = Field(..., description="Reference type.")
 
 
 class CrossReferenceInfos(BaseModel):
-    """A container for a list of cross-references."""
+    """Cross-reference list."""
 
-    cross_references: list[CrossReferenceInfo] = Field(
-        ..., description="A list of cross-references."
-    )
+    cross_references: list[CrossReferenceInfo] = Field(..., description="Cross-references.")
 
 
 class SymbolInfo(BaseModel):
-    """Represents a symbol within the binary."""
+    """Binary symbol."""
 
-    name: str = Field(..., description="The name of the symbol.")
-    address: str = Field(..., description="The address of the symbol.")
-    type: str = Field(..., description="The type of the symbol.")
-    namespace: str = Field(..., description="The namespace of the symbol.")
-    source: str = Field(..., description="The source of the symbol.")
-    refcount: int = Field(..., description="The reference count of the symbol.")
-    external: bool = Field(..., description="Is symbol external.")
+    name: str = Field(..., description="Symbol name.")
+    address: str = Field(..., description="Symbol address.")
+    type: str = Field(..., description="Symbol type.")
+    namespace: str = Field(..., description="Symbol namespace.")
+    source: str = Field(..., description="Symbol source.")
+    refcount: int = Field(..., description="Reference count.")
+    external: bool = Field(..., description="External symbol.")
 
 
 class SymbolSearchResults(BaseModel):
-    """A container for a list of symbols found during a search."""
+    """Symbol search results."""
 
-    symbols: list[SymbolInfo] = Field(
-        ..., description="A list of symbols that match the search criteria."
-    )
+    symbols: list[SymbolInfo] = Field(..., description="Matching symbols.")
 
 
 class SearchMode(str, Enum):
-    """Search mode for code search."""
+    """Code search mode."""
 
-    SEMANTIC = "semantic"  # Vector similarity search
-    LITERAL = "literal"  # Exact string match ($contains)
+    SEMANTIC = "semantic"
+    LITERAL = "literal"
 
 
 class CodeSearchResult(BaseModel):
-    """Represents a single search result from the codebase."""
+    """Code search hit."""
 
-    function_name: str = Field(
-        ..., description="The name of the function where the code was found."
+    function_name: str = Field(..., description="Function name.")
+    code: str = Field(..., description="Matched code.")
+    similarity: float = Field(..., description="Similarity score.")
+    search_mode: SearchMode = Field(
+        ...,
+        description="semantic = similarity, literal = exact text.",
     )
-    code: str = Field(..., description="The psuedo-c code snippet")
-    similarity: float = Field(..., description="The similarity score of the search result.")
-    search_mode: SearchMode = Field(..., description="The search mode used for this result.")
-    preview: str | None = Field(None, description="Truncated preview when include_full_code=False.")
+    preview: str | None = Field(None, description="Truncated code preview.")
 
 
 class CodeSearchResults(BaseModel):
-    """A container for a list of code search results"""
+    """Code search response."""
 
-    results: list[CodeSearchResult] = Field(..., description="A list of code search results.")
-    query: str = Field(..., description="The query used for the search.")
-    search_mode: SearchMode = Field(..., description="The search mode used.")
-    # Pagination
-    returned_count: int = Field(..., description="Number of results returned in this response.")
-    offset: int = Field(..., description="Offset used for pagination.")
-    limit: int = Field(..., description="Limit used for pagination.")
-    # Dual-mode counts - ALWAYS populated to help LLM decide on mode switching
-    literal_total: int = Field(
-        ..., description="Total functions containing literal match. 0 if none found."
+    results: list[CodeSearchResult] = Field(..., description="Search results.")
+    query: str = Field(..., description="Search query.")
+    search_mode: SearchMode = Field(
+        ...,
+        description="semantic = similarity, literal = exact text.",
     )
-    semantic_total: int = Field(..., description="Estimated total for semantic search.")
-    total_functions: int = Field(..., description="Total number of functions in the binary.")
+    returned_count: int = Field(..., description="Returned results.")
+    offset: int = Field(..., description="Pagination offset.")
+    limit: int = Field(..., description="Pagination limit.")
+    literal_total: int = Field(
+        ...,
+        description="Functions containing the literal query, even in semantic mode.",
+    )
+    semantic_total: int = Field(..., description="Estimated semantic matches.")
+    total_functions: int = Field(..., description="Indexed functions.")
 
 
 class StringInfo(BaseModel):
-    """Represents a string found within the binary."""
+    """Binary string."""
 
-    value: str = Field(..., description="The value of the string.")
-    address: str = Field(..., description="The address of the string.")
+    value: str = Field(..., description="String value.")
+    address: str = Field(..., description="String address.")
 
 
 class StringSearchResult(StringInfo):
-    """Represents a string search result found within the binary."""
+    """String search hit."""
 
-    similarity: float = Field(..., description="The similarity score of the search result.")
+    similarity: float = Field(..., description="Similarity score.")
 
 
 class StringSearchResults(BaseModel):
-    """A container for a list of string search results."""
+    """String search response."""
 
-    strings: list[StringSearchResult] = Field(..., description="A list of string search results.")
+    strings: list[StringSearchResult] = Field(..., description="Matching strings.")
 
 
 class BytesReadResult(BaseModel):
-    """Represents the result of reading raw bytes from memory."""
+    """Raw byte read."""
 
-    address: str = Field(..., description="The normalized address where bytes were read from.")
-    size: int = Field(..., description="The actual number of bytes read.")
-    data: str = Field(..., description="The raw bytes as a hexadecimal string.")
+    address: str = Field(..., description="Normalized address.")
+    size: int = Field(..., description="Bytes returned.")
+    data: str = Field(..., description="Hex bytes.")
 
 
 class CallGraphDirection(str, Enum):
-    """Represents the direction of the call graph."""
+    """Call graph direction."""
 
     CALLING = "calling"
     CALLED = "called"
 
 
 class CallGraphDisplayType(str, Enum):
-    """Represents the display type of the call graph."""
+    """Call graph display type."""
 
     FLOW = "flow"
     FLOW_ENDS = "flow_ends"
@@ -197,16 +193,13 @@ class CallGraphDisplayType(str, Enum):
 
 
 class CallGraphResult(BaseModel):
-    """Represents the result of a mermaidjs call graph generation."""
+    """Call graph response."""
 
-    function_name: str = Field(
-        ..., description="The name of the function for which the call graph was generated."
+    function_name: str = Field(..., description="Function name.")
+    direction: CallGraphDirection = Field(..., description="Call graph direction.")
+    display_type: CallGraphDisplayType = Field(..., description="Graph display type.")
+    graph: str = Field(..., description="Mermaid graph.")
+    mermaid_url: str = Field(
+        ...,
+        description="URL for rendering the Mermaid graph output.",
     )
-    direction: CallGraphDirection = Field(
-        ..., description="The direction of the call graph (calling or called)."
-    )
-    display_type: CallGraphDisplayType = Field(
-        ..., description="The type of the call graph visualization."
-    )
-    graph: str = Field(..., description="The MermaidJS markdown string for the call graph.")
-    mermaid_url: str = Field(..., description="The MermaidJS image url")

--- a/src/pyghidra_mcp/server.py
+++ b/src/pyghidra_mcp/server.py
@@ -43,20 +43,24 @@ mcp = FastMCP("pyghidra-mcp", lifespan=server_lifespan)  # type: ignore
 # MCP Tools
 # ---------------------------------------------------------------------------------
 # Register tools from mcp_tools module
-mcp.tool()(mcp_tools.decompile_function)
-mcp.tool()(mcp_tools.search_symbols_by_name)
-mcp.tool()(mcp_tools.search_functions_by_name)
-mcp.tool()(mcp_tools.search_code)
-mcp.tool()(mcp_tools.list_project_binaries)
-mcp.tool()(mcp_tools.list_project_binary_metadata)
-mcp.tool()(mcp_tools.delete_project_binary)
-mcp.tool()(mcp_tools.list_exports)
-mcp.tool()(mcp_tools.list_imports)
-mcp.tool()(mcp_tools.list_cross_references)
-mcp.tool()(mcp_tools.search_strings)
-mcp.tool()(mcp_tools.read_bytes)
-mcp.tool()(mcp_tools.gen_callgraph)
-mcp.tool()(mcp_tools.import_binary)
+mcp.tool(description="Decompile one exact function or address.")(mcp_tools.decompile_function)
+mcp.tool(description="Search symbols by partial name.")(mcp_tools.search_symbols_by_name)
+mcp.tool(description="Search functions by partial name.")(mcp_tools.search_functions_by_name)
+mcp.tool(description="Search code semantically or literally.")(mcp_tools.search_code)
+mcp.tool(description="List project binaries and readiness.")(mcp_tools.list_project_binaries)
+mcp.tool(description="Get metadata for one project binary.")(mcp_tools.list_project_binary_metadata)
+mcp.tool(description="Delete a project binary.")(mcp_tools.delete_project_binary)
+mcp.tool(description="List exports; narrow with query.")(mcp_tools.list_exports)
+mcp.tool(description="List imports; narrow with query.")(mcp_tools.list_imports)
+mcp.tool(description="List xrefs to one symbol or address.")(mcp_tools.list_cross_references)
+mcp.tool(description="Search extracted strings by text.")(mcp_tools.search_strings)
+mcp.tool(description="Read raw bytes at one address.")(mcp_tools.read_bytes)
+mcp.tool(description="Generate a Mermaid call graph.")(mcp_tools.gen_callgraph)
+mcp.tool(description="Import a binary or directory in background.")(mcp_tools.import_binary)
+
+list_project_binaries_tool = mcp._tool_manager.get_tool("list_project_binaries")
+if list_project_binaries_tool is not None:
+    list_project_binaries_tool.parameters["additionalProperties"] = False
 
 
 def init_pyghidra_context(

--- a/src/pyghidra_mcp/server.py
+++ b/src/pyghidra_mcp/server.py
@@ -45,6 +45,7 @@ mcp = FastMCP("pyghidra-mcp", lifespan=server_lifespan)  # type: ignore
 # Register tools from mcp_tools module
 mcp.tool()(mcp_tools.decompile_function)
 mcp.tool()(mcp_tools.search_symbols_by_name)
+mcp.tool()(mcp_tools.search_functions_by_name)
 mcp.tool()(mcp_tools.search_code)
 mcp.tool()(mcp_tools.list_project_binaries)
 mcp.tool()(mcp_tools.list_project_binary_metadata)

--- a/src/pyghidra_mcp/tools.py
+++ b/src/pyghidra_mcp/tools.py
@@ -93,7 +93,7 @@ class GhidraTools:
         name_lc = name_or_address.lower()
         functions = self.get_all_functions(include_externals=include_externals)
         seen: set = set()
-        matches: list["Function"] = []
+        matches: list[Function] = []
 
         if exact:
             for f in functions:

--- a/src/pyghidra_mcp/tools.py
+++ b/src/pyghidra_mcp/tools.py
@@ -64,6 +64,53 @@ class GhidraTools:
         max_path_len = 50
         return f"{func.getSymbol().getName(True)[:max_path_len]}-{func.entryPoint}"
 
+    def _lookup_functions(
+        self,
+        name_or_address: str,
+        *,
+        exact: bool = True,
+        partial: bool = False,
+        include_externals: bool = True,
+    ) -> list["Function"]:
+        """
+        Resolve functions by name or address.
+        Returns a flat list of unique Function objects.
+        Search modes (exact, partial) are optional and only applied if enabled.
+        """
+        af = self.program.getAddressFactory()
+        fm = self.program.getFunctionManager()
+
+        # Try interpreting as an address first
+        try:
+            addr = af.getAddress(name_or_address)
+            if addr:
+                func = fm.getFunctionAt(addr)
+                if func:
+                    return [func]
+        except Exception:
+            pass  # Not an address, fall back to name search
+
+        name_lc = name_or_address.lower()
+        functions = self.get_all_functions(include_externals=include_externals)
+        seen: set = set()
+        matches: list["Function"] = []
+
+        if exact:
+            for f in functions:
+                key = f.getEntryPoint()
+                if key not in seen and name_lc == f.getSymbol().getName(True).lower():
+                    seen.add(key)
+                    matches.append(f)
+
+        if partial:
+            for f in functions:
+                key = f.getEntryPoint()
+                if key not in seen and name_lc in f.getSymbol().getName(True).lower():
+                    seen.add(key)
+                    matches.append(f)
+
+        return matches
+
     @handle_exceptions
     def find_function(
         self,
@@ -71,57 +118,26 @@ class GhidraTools:
         include_externals: bool = True,
     ) -> "Function":
         """
-        Resolve a function by name or address.
-        - If name_or_address is an address, return the function at that entry point.
-        - If it's a name, return exact match if unique.
-        - If multiple exact matches, raise with suggestions (signature + entry point).
-        - If none, raise with 'Did you mean...' suggestions from partial matches.
+        Resolve a single function by name or address.
+        Raises if ambiguous or not found.
         """
-        af = self.program.getAddressFactory()
-        fm = self.program.getFunctionManager()
+        matches = self._lookup_functions(
+            name_or_address, exact=True, partial=True, include_externals=include_externals
+        )
 
-        # Try interpreting as an address
-        try:
-            addr = af.getAddress(name_or_address)
-            if addr:
-                func = fm.getFunctionAt(addr)
-                if func:
-                    return func
-        except Exception:
-            pass  # Not an address, continue with name search
-
-        # Name-based search
-        functions = self.get_all_functions(include_externals=include_externals)
-        exact_matches = [
-            f for f in functions if name_or_address.lower() == f.getSymbol().getName(True).lower()
-        ]
-
-        if len(exact_matches) == 1:
-            return exact_matches[0]
-        elif len(exact_matches) > 1:
+        if len(matches) == 1:
+            return matches[0]
+        elif len(matches) > 1:
             suggestions = [
                 f"{f.getSymbol().getName(True)}({f.getSignature()}) @ {f.getEntryPoint()}"
-                for f in exact_matches
+                for f in matches
             ]
             raise ValueError(
                 f"Ambiguous match for '{name_or_address}'. Did you mean one of these: "
                 + ", ".join(suggestions)
             )
-
-        # No exact matches → suggest partials
-        partial_matches = [
-            f for f in functions if name_or_address.lower() in f.getSymbol().getName(True).lower()
-        ]
-        if partial_matches:
-            suggestions = [
-                f"{f.getSymbol().getName(True)} @ {f.getEntryPoint()}" for f in partial_matches
-            ]
-            raise ValueError(
-                f"Function '{name_or_address}' not found. Did you mean one of these: "
-                + ", ".join(suggestions)
-            )
-
-        raise ValueError(f"Function or symbol '{name_or_address}' not found.")
+        else:
+            raise ValueError(f"Function or symbol '{name_or_address}' not found.")
 
     def _lookup_symbols(
         self,

--- a/src/pyghidra_mcp/tools.py
+++ b/src/pyghidra_mcp/tools.py
@@ -118,11 +118,11 @@ class GhidraTools:
         include_externals: bool = True,
     ) -> "Function":
         """
-        Resolve a single function by name or address.
+        Resolve a single function by name or address (exact match only).
         Raises if ambiguous or not found.
         """
         matches = self._lookup_functions(
-            name_or_address, exact=True, partial=True, include_externals=include_externals
+            name_or_address, exact=True, partial=False, include_externals=include_externals
         )
 
         if len(matches) == 1:
@@ -138,6 +138,20 @@ class GhidraTools:
             )
         else:
             raise ValueError(f"Function or symbol '{name_or_address}' not found.")
+
+    @handle_exceptions
+    def find_functions(
+        self,
+        name_or_address: str,
+        include_externals: bool = True,
+    ) -> list["Function"]:
+        """
+        Return all functions that match name_or_address (exact or partial).
+        Never raises; returns empty list if none.
+        """
+        return self._lookup_functions(
+            name_or_address, exact=True, partial=True, include_externals=include_externals
+        )
 
     def _lookup_symbols(
         self,
@@ -197,10 +211,10 @@ class GhidraTools:
     @handle_exceptions
     def find_symbol(self, name_or_address: str) -> "Symbol":
         """
-        Resolve a single symbol by name or address.
+        Resolve a single symbol by name or address (exact match only).
         Raises if ambiguous or not found.
         """
-        matches = self._lookup_symbols(name_or_address, exact=True, partial=True)
+        matches = self._lookup_symbols(name_or_address, exact=True, partial=False)
 
         if len(matches) == 1:
             return matches[0]
@@ -321,6 +335,37 @@ class GhidraTools:
                 symbols_info.append(
                     SymbolInfo(
                         name=symbol.name,
+                        address=str(symbol.getAddress()),
+                        type=str(symbol.getSymbolType()),
+                        namespace=str(symbol.getParentNamespace()),
+                        source=str(symbol.getSource()),
+                        refcount=ref_count,
+                        external=symbol.isExternal(),
+                    )
+                )
+        return symbols_info[offset : limit + offset]
+
+    @handle_exceptions
+    def search_functions_by_name(
+        self, query: str, offset: int = 0, limit: int = 100
+    ) -> list[SymbolInfo]:
+        """Searches for functions within a binary by name."""
+
+        if not query:
+            raise ValueError("Query string is required")
+
+        symbols_info = []
+        functions = self.find_functions(query)
+        rm = self.program.getReferenceManager()
+
+        # Search for functions containing the query string
+        for func in functions:
+            symbol = func.getSymbol()
+            if query.lower() in symbol.getName(True).lower():
+                ref_count = len(list(rm.getReferencesTo(symbol.getAddress())))
+                symbols_info.append(
+                    SymbolInfo(
+                        name=symbol.getName(),
                         address=str(symbol.getAddress()),
                         type=str(symbol.getSymbolType()),
                         namespace=str(symbol.getParentNamespace()),

--- a/src/pyghidra_mcp/tools.py
+++ b/src/pyghidra_mcp/tools.py
@@ -2,6 +2,8 @@
 Comprehensive tool implementations for pyghidra-mcp.
 """
 
+from __future__ import annotations
+
 import functools
 import logging
 import re
@@ -54,13 +56,59 @@ def handle_exceptions(func):
 class GhidraTools:
     """Comprehensive tool handler for Ghidra MCP tools"""
 
-    def __init__(self, program_info: "ProgramInfo"):
+    def __init__(self, program_info: ProgramInfo):
         """Initialize with a Ghidra ProgramInfo object"""
         self.program_info = program_info
         self.program = program_info.program
         self.decompiler = program_info.decompiler
+        self._cache_version = getattr(program_info, "derived_cache_version", 0)
+        self._functions_cache: dict[bool, list[Function]] = {}
+        self._symbols_cache: dict[tuple[bool, bool], list[Symbol]] = {}
+        self._strings_cache: list[StringInfo] | None = None
+        self._export_symbols_cache: list[Symbol] | None = None
+        self._import_symbols_cache: list[Symbol] | None = None
+        self._code_collection_count: int | None = None
 
-    def _get_filename(self, func: "Function"):
+    def _ensure_cache_version(self) -> None:
+        current_version = getattr(self.program_info, "derived_cache_version", 0)
+        if current_version != self._cache_version:
+            self.invalidate_derived_caches(current_version)
+
+    def invalidate_derived_caches(self, version: int | None = None) -> None:
+        """Invalidate cached lookup data derived from the program."""
+        self._functions_cache.clear()
+        self._symbols_cache.clear()
+        self._strings_cache = None
+        self._export_symbols_cache = None
+        self._import_symbols_cache = None
+        self._code_collection_count = None
+        if version is None:
+            version = getattr(self.program_info, "derived_cache_version", 0)
+        self._cache_version = version
+
+    def _get_code_collection_count(self) -> int:
+        self._ensure_cache_version()
+        if self._code_collection_count is None:
+            assert self.program_info.code_collection is not None
+            self._code_collection_count = self.program_info.code_collection.count()
+        return self._code_collection_count
+
+    def _get_export_symbols(self) -> list[Symbol]:
+        self._ensure_cache_version()
+        if self._export_symbols_cache is None:
+            symbols = self.program.getSymbolTable().getAllSymbols(True)
+            self._export_symbols_cache = [
+                symbol for symbol in symbols if symbol.isExternalEntryPoint()
+            ]
+        return self._export_symbols_cache
+
+    def _get_import_symbols(self) -> list[Symbol]:
+        self._ensure_cache_version()
+        if self._import_symbols_cache is None:
+            self._import_symbols_cache = list(self.program.getSymbolTable().getExternalSymbols())
+        return self._import_symbols_cache
+
+    def _get_filename(self, func: Function):
         max_path_len = 50
         return f"{func.getSymbol().getName(True)[:max_path_len]}-{func.entryPoint}"
 
@@ -71,7 +119,7 @@ class GhidraTools:
         exact: bool = True,
         partial: bool = False,
         include_externals: bool = True,
-    ) -> list["Function"]:
+    ) -> list[Function]:
         """
         Resolve functions by name or address.
         Returns a flat list of unique Function objects.
@@ -116,7 +164,7 @@ class GhidraTools:
         self,
         name_or_address: str,
         include_externals: bool = True,
-    ) -> "Function":
+    ) -> Function:
         """
         Resolve a single function by name or address (exact match only).
         Raises if ambiguous or not found.
@@ -144,7 +192,7 @@ class GhidraTools:
         self,
         name_or_address: str,
         include_externals: bool = True,
-    ) -> list["Function"]:
+    ) -> list[Function]:
         """
         Return all functions that match name_or_address (exact or partial).
         Never raises; returns empty list if none.
@@ -160,7 +208,7 @@ class GhidraTools:
         exact: bool = True,
         partial: bool = False,
         dynamic: bool = False,
-    ) -> list["Symbol"]:
+    ) -> list[Symbol]:
         """
         Resolve symbols by name or address.
         Returns a single flat list of unique Symbol objects.
@@ -201,7 +249,7 @@ class GhidraTools:
         return list(matches)
 
     @handle_exceptions
-    def find_symbols(self, name_or_address: str) -> list["Symbol"]:
+    def find_symbols(self, name_or_address: str) -> list[Symbol]:
         """
         Return all symbols that match name_or_address (exact or partial).
         Never raises; returns empty list if none.
@@ -209,7 +257,7 @@ class GhidraTools:
         return self._lookup_symbols(name_or_address, exact=True, partial=True)
 
     @handle_exceptions
-    def find_symbol(self, name_or_address: str) -> "Symbol":
+    def find_symbol(self, name_or_address: str) -> Symbol:
         """
         Resolve a single symbol by name or address (exact match only).
         Raises if ambiguous or not found.
@@ -236,7 +284,7 @@ class GhidraTools:
         func = self.find_function(name_or_address)
         return self.decompile_function(func)
 
-    def decompile_function(self, func: "Function", timeout: int = 0) -> DecompiledFunction:
+    def decompile_function(self, func: Function, timeout: int = 0) -> DecompiledFunction:
         """Decompiles a function in a specified binary and returns its pseudo-C code."""
         from ghidra.util.task import ConsoleTaskMonitor
 
@@ -251,13 +299,18 @@ class GhidraTools:
         return DecompiledFunction(name=self._get_filename(func), code=code, signature=sig)
 
     @handle_exceptions
-    def get_all_functions(self, include_externals=False) -> list["Function"]:
+    def get_all_functions(self, include_externals=False) -> list[Function]:
         """
         Gets all functions within a binary.
         Returns a python list that doesn't need to be re-intialized
         """
+        self._ensure_cache_version()
+        cached = self._functions_cache.get(include_externals)
+        if cached is not None:
+            return cached
 
-        funcs = set()
+        funcs = []
+        seen = set()
         fm = self.program.getFunctionManager()
         functions = fm.getFunctions(True)
         for func in functions:
@@ -266,35 +319,53 @@ class GhidraTools:
                 continue
             if not include_externals and func.thunk:
                 continue
-            funcs.add(func)
-        return list(funcs)
+            key = func.getEntryPoint()
+            if key in seen:
+                continue
+            seen.add(key)
+            funcs.append(func)
+
+        self._functions_cache[include_externals] = funcs
+        return funcs
 
     @handle_exceptions
     def get_all_symbols(
         self, include_externals: bool = False, include_dynamic=False
-    ) -> list["Symbol"]:
+    ) -> list[Symbol]:
         """
         Gets all symbols within a binary.
         Returns a python list that doesn't need to be re-initialized.
         """
+        self._ensure_cache_version()
+        cache_key = (include_externals, include_dynamic)
+        cached = self._symbols_cache.get(cache_key)
+        if cached is not None:
+            return cached
 
-        symbols = set()
-        from ghidra.program.model.symbol import SymbolTable
-
-        st: SymbolTable = self.program.getSymbolTable()
+        symbols = []
+        seen = set()
+        st = self.program.getSymbolTable()
         all_symbols = st.getAllSymbols(include_dynamic)
 
         for sym in all_symbols:
             sym: Symbol
             if not include_externals and sym.isExternal():
                 continue
-            symbols.add(sym)
+            if sym in seen:
+                continue
+            seen.add(sym)
+            symbols.append(sym)
 
-        return list(symbols)
+        self._symbols_cache[cache_key] = symbols
+        return symbols
 
     @handle_exceptions
     def get_all_strings(self) -> list[StringInfo]:
         """Gets all defined strings for a binary"""
+        self._ensure_cache_version()
+        if self._strings_cache is not None:
+            return self._strings_cache
+
         try:
             from ghidra.program.util import DefinedStringIterator  # type: ignore
 
@@ -313,6 +384,7 @@ class GhidraTools:
             except Exception as e:
                 logger.debug(f"Could not get string value from data at {data.getAddress()}: {e}")
 
+        self._strings_cache = strings
         return strings
 
     @handle_exceptions
@@ -324,26 +396,27 @@ class GhidraTools:
         if not query:
             raise ValueError("Query string is required")
 
-        symbols_info = []
-        symbols = self.find_symbols(query)
+        query_lc = query.lower()
+        symbols = [
+            symbol
+            for symbol in self.get_all_symbols(include_externals=True)
+            if query_lc in symbol.getName(True).lower()
+        ]
+        paginated_symbols = symbols[offset : offset + limit]
         rm = self.program.getReferenceManager()
 
-        # Search for symbols containing the query string
-        for symbol in symbols:
-            if query.lower() in symbol.getName(True).lower():
-                ref_count = len(list(rm.getReferencesTo(symbol.getAddress())))
-                symbols_info.append(
-                    SymbolInfo(
-                        name=symbol.name,
-                        address=str(symbol.getAddress()),
-                        type=str(symbol.getSymbolType()),
-                        namespace=str(symbol.getParentNamespace()),
-                        source=str(symbol.getSource()),
-                        refcount=ref_count,
-                        external=symbol.isExternal(),
-                    )
-                )
-        return symbols_info[offset : limit + offset]
+        return [
+            SymbolInfo(
+                name=symbol.name,
+                address=str(symbol.getAddress()),
+                type=str(symbol.getSymbolType()),
+                namespace=str(symbol.getParentNamespace()),
+                source=str(symbol.getSource()),
+                refcount=len(list(rm.getReferencesTo(symbol.getAddress()))),
+                external=symbol.isExternal(),
+            )
+            for symbol in paginated_symbols
+        ]
 
     @handle_exceptions
     def search_functions_by_name(
@@ -354,56 +427,80 @@ class GhidraTools:
         if not query:
             raise ValueError("Query string is required")
 
-        symbols_info = []
-        functions = self.find_functions(query)
+        query_lc = query.lower()
+        functions = [
+            func
+            for func in self.get_all_functions()
+            if query_lc in func.getSymbol().getName(True).lower()
+        ]
+        paginated_functions = functions[offset : offset + limit]
         rm = self.program.getReferenceManager()
 
-        # Search for functions containing the query string
-        for func in functions:
-            symbol = func.getSymbol()
-            if query.lower() in symbol.getName(True).lower():
-                ref_count = len(list(rm.getReferencesTo(symbol.getAddress())))
-                symbols_info.append(
-                    SymbolInfo(
-                        name=symbol.getName(),
-                        address=str(symbol.getAddress()),
-                        type=str(symbol.getSymbolType()),
-                        namespace=str(symbol.getParentNamespace()),
-                        source=str(symbol.getSource()),
-                        refcount=ref_count,
-                        external=symbol.isExternal(),
-                    )
-                )
-        return symbols_info[offset : limit + offset]
+        return [
+            SymbolInfo(
+                name=symbol.getName(),
+                address=str(symbol.getAddress()),
+                type=str(symbol.getSymbolType()),
+                namespace=str(symbol.getParentNamespace()),
+                source=str(symbol.getSource()),
+                refcount=len(list(rm.getReferencesTo(symbol.getAddress()))),
+                external=symbol.isExternal(),
+            )
+            for func in paginated_functions
+            for symbol in [func.getSymbol()]
+        ]
 
     @handle_exceptions
     def list_exports(
         self, query: str | None = None, offset: int = 0, limit: int = 25
     ) -> list[ExportInfo]:
         """Lists all exported functions and symbols from a specified binary."""
+        if limit <= 0:
+            return []
+
+        pattern = re.compile(query, re.IGNORECASE) if query else None
         exports = []
-        symbols = self.program.getSymbolTable().getAllSymbols(True)
-        for symbol in symbols:
-            if symbol.isExternalEntryPoint():
-                if query and not re.search(query, symbol.getName(), re.IGNORECASE):
-                    continue
-                exports.append(ExportInfo(name=symbol.getName(), address=str(symbol.getAddress())))
-        return exports[offset : limit + offset]
+        matches_seen = 0
+
+        for symbol in self._get_export_symbols():
+            if pattern and not pattern.search(symbol.getName()):
+                continue
+            if matches_seen < offset:
+                matches_seen += 1
+                continue
+            exports.append(ExportInfo(name=symbol.getName(), address=str(symbol.getAddress())))
+            matches_seen += 1
+            if len(exports) >= limit:
+                break
+
+        return exports
 
     @handle_exceptions
     def list_imports(
         self, query: str | None = None, offset: int = 0, limit: int = 25
     ) -> list[ImportInfo]:
         """Lists all imported functions and symbols for a specified binary."""
+        if limit <= 0:
+            return []
+
+        pattern = re.compile(query, re.IGNORECASE) if query else None
         imports = []
-        symbols = self.program.getSymbolTable().getExternalSymbols()
-        for symbol in symbols:
-            if query and not re.search(query, symbol.getName(), re.IGNORECASE):
+        matches_seen = 0
+
+        for symbol in self._get_import_symbols():
+            if pattern and not pattern.search(symbol.getName()):
+                continue
+            if matches_seen < offset:
+                matches_seen += 1
                 continue
             imports.append(
                 ImportInfo(name=symbol.getName(), library=str(symbol.getParentNamespace()))
             )
-        return imports[offset : limit + offset]
+            matches_seen += 1
+            if len(imports) >= limit:
+                break
+
+        return imports
 
     @handle_exceptions
     def list_cross_references(self, name_or_address: str) -> list[CrossReferenceInfo]:
@@ -432,28 +529,34 @@ class GhidraTools:
             )
         return cross_references
 
+    def _get_literal_match_ids(self, query: str) -> typing.Any:
+        assert self.program_info.code_collection is not None
+        return self.program_info.code_collection.get(
+            where_document={"$contains": query},
+            include=[],
+        )
+
+    def _get_literal_result_page(self, query: str, limit: int, offset: int) -> typing.Any:
+        assert self.program_info.code_collection is not None
+        return self.program_info.code_collection.get(
+            where_document={"$contains": query},
+            limit=limit,
+            offset=offset,
+        )
+
     def _search_code_literal(
         self,
         literal_results: typing.Any,
-        limit: int,
-        offset: int,
         include_full_code: bool,
         preview_length: int,
     ) -> list[CodeSearchResult]:
         search_results: list[CodeSearchResult] = []
         if literal_results and literal_results.get("documents"):
-            # Apply offset and limit
             docs = literal_results["documents"] or []
-            metadatas = literal_results["metadatas"] or []
+            metadatas = literal_results.get("metadatas") or []
 
-            # Paginate
-            start_idx = offset
-            end_idx = offset + limit
-            paginated_docs = docs[start_idx:end_idx]
-            paginated_meta = metadatas[start_idx:end_idx] if metadatas else []
-
-            for i, doc in enumerate(paginated_docs):
-                metadata = paginated_meta[i] if i < len(paginated_meta) else {}
+            for i, doc in enumerate(docs):
+                metadata = metadatas[i] if i < len(metadatas) else {}
                 code = doc
                 preview = None
 
@@ -469,7 +572,7 @@ class GhidraTools:
                             else "unknown"
                         ),
                         code=code,
-                        similarity=1.0,  # Exact match
+                        similarity=1.0,
                         search_mode=SearchMode.LITERAL,
                         preview=preview,
                     )
@@ -582,30 +685,25 @@ class GhidraTools:
         """
         if not self.program_info.code_collection:
             raise ValueError(
-                "Code indexing is not complete for this binary. Please try again later."
+                "Code indexing is not complete for this binary. Wait for "
+                "list_project_binaries() to show code_collection=true, then retry search_code."
             )
 
-        # ALWAYS get literal count (reuse for literal mode search)
-        literal_results = self.program_info.code_collection.get(where_document={"$contains": query})
+        literal_id_results = self._get_literal_match_ids(query)
         literal_total = (
-            len(literal_results["ids"]) if literal_results and literal_results.get("ids") else 0
+            len(literal_id_results["ids"])
+            if literal_id_results and literal_id_results.get("ids")
+            else 0
         )
-
-        # Total functions in collection (absolute total)
-        total_functions = self.program_info.code_collection.count()
-
-        # Default semantic total to "available" (filtered by limit)
-        # If we filter and get FEWER than requested, we effectively found "all" above threshold
-        # in this range.
-        # But we don't know beyond the limit.
-        # So we default to total_functions as "estimated matches" if we hit the limit.
+        total_functions = self._get_code_collection_count()
         semantic_total = total_functions
 
-        search_results: list[CodeSearchResult] = []
-
         if search_mode == SearchMode.LITERAL:
+            literal_page = self._get_literal_result_page(query, limit, offset)
             search_results = self._search_code_literal(
-                literal_results, limit, offset, include_full_code, preview_length
+                literal_page,
+                include_full_code,
+                preview_length,
             )
         else:
             search_results, estimated_total = self._search_code_semantic(
@@ -638,13 +736,16 @@ class GhidraTools:
 
         if not self.program_info.strings_collection:
             raise ValueError(
-                "String indexing is not complete for this binary. Please try again later."
+                "String indexing is not complete for this binary. Wait for "
+                "list_project_binaries() to show strings_collection=true, then retry "
+                "search_strings."
             )
 
         search_results = []
         results = self.program_info.strings_collection.get(
             where_document={"$contains": query}, limit=limit
         )
+        remaining_limit = limit
         if results and results["documents"]:
             for i, doc in enumerate(results["documents"]):
                 metadata = results["metadatas"][i]  # type: ignore
@@ -655,9 +756,14 @@ class GhidraTools:
                         similarity=1,
                     )
                 )
-            limit -= len(results["documents"])
+            remaining_limit -= len(results["documents"])
 
-        results = self.program_info.strings_collection.query(query_texts=[query], n_results=limit)
+        if remaining_limit <= 0:
+            return search_results
+
+        results = self.program_info.strings_collection.query(
+            query_texts=[query], n_results=remaining_limit
+        )
         if results and results["documents"]:
             for i, doc in enumerate(results["documents"][0]):
                 metadata = results["metadatas"][0][i]  # type: ignore

--- a/src/pyghidra_mcp/tools.py
+++ b/src/pyghidra_mcp/tools.py
@@ -317,7 +317,10 @@ class GhidraTools:
             func: Function
             if not include_externals and func.isExternal():
                 continue
-            if not include_externals and func.thunk:
+            is_thunk = (
+                func.isThunk() if hasattr(func, "isThunk") else bool(getattr(func, "thunk", False))
+            )
+            if not include_externals and is_thunk:
                 continue
             key = func.getEntryPoint()
             if key in seen:

--- a/tests/benchmark_helpers.py
+++ b/tests/benchmark_helpers.py
@@ -1,0 +1,954 @@
+# ruff: noqa: N802
+
+from __future__ import annotations
+
+import asyncio
+import json
+import platform
+import statistics
+import subprocess
+import sys
+import time
+import types
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, TypeVar
+
+from mcp import ClientSession
+
+from pyghidra_mcp.context import ProgramInfo as RuntimeProgramInfo, PyGhidraContext
+from pyghidra_mcp.models import (
+    CodeSearchResults,
+    ProgramInfo as PublicProgramInfo,
+    ProgramInfos,
+    SearchMode,
+)
+from pyghidra_mcp.tools import GhidraTools
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class ToolSurfaceMetrics:
+    name: str
+    description_length: int
+    input_schema_bytes: int
+    output_schema_bytes: int
+    total_json_bytes: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ToolTimingMetrics:
+    scenario: str
+    tool_name: str
+    first_call_seconds: float
+    warm_call_median_seconds: float
+    all_call_seconds: list[float]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class InternalCallCounts:
+    chroma_count_calls: int = 0
+    chroma_get_calls: int = 0
+    chroma_query_calls: int = 0
+    symbol_table_all_symbols_calls: int = 0
+    symbol_table_external_symbols_calls: int = 0
+    function_manager_get_functions_calls: int = 0
+    reference_lookup_calls: int = 0
+
+    def to_dict(self) -> dict[str, int]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class GeneratedBinarySpec:
+    stem: str
+    function_count: int = 96
+    string_count: int = 96
+    global_count: int = 64
+    call_fanout: int = 2
+    exported_function_count: int = 16
+    sentinel_function_stem: str = "sentinel_target_function"
+    sentinel_symbol_stem: str = "sentinel_global_state"
+    sentinel_export_stem: str = "sentinel_export_entry"
+    sentinel_string: str = "SENTINEL_RUNTIME_STRING"
+    sentinel_code_literal: str = "SENTINEL_CODE_LITERAL"
+    import_query: str = "printf"
+
+
+@dataclass(frozen=True)
+class GeneratedBinaryArtifact:
+    binary_path: Path
+    source_path: Path
+    spec: GeneratedBinarySpec
+
+
+def json_size(payload: object) -> int:
+    return len(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+
+
+def tool_surface_metrics(tool) -> ToolSurfaceMetrics:
+    tool_entry = tool.model_dump(mode="json", by_alias=True, exclude_none=True)
+    return ToolSurfaceMetrics(
+        name=tool.name,
+        description_length=len(tool.description or ""),
+        input_schema_bytes=json_size(tool_entry["inputSchema"]),
+        output_schema_bytes=json_size(tool_entry.get("outputSchema") or {}),
+        total_json_bytes=json_size(tool_entry),
+    )
+
+
+def collect_list_tools_metrics(tools_response) -> tuple[int, dict[str, ToolSurfaceMetrics]]:
+    payload_bytes = json_size(
+        tools_response.model_dump(mode="json", by_alias=True, exclude_none=True)
+    )
+    return payload_bytes, {tool.name: tool_surface_metrics(tool) for tool in tools_response.tools}
+
+
+async def call_tool_text(session: ClientSession, tool_name: str, arguments: dict[str, Any]) -> str:
+    response = await session.call_tool(tool_name, arguments)
+    if response.isError:
+        raise RuntimeError(response.content[0].text)
+    if not response.content:
+        raise RuntimeError(f"Tool {tool_name} returned no content")
+    return response.content[0].text
+
+
+async def call_tool_json(
+    session: ClientSession, tool_name: str, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    return json.loads(await call_tool_text(session, tool_name, arguments))
+
+
+async def call_tool_model(
+    session: ClientSession,
+    tool_name: str,
+    arguments: dict[str, Any],
+    model_cls: type[T],
+) -> T:
+    return model_cls.model_validate_json(await call_tool_text(session, tool_name, arguments))
+
+
+def warm_call_median(samples: list[float]) -> float:
+    if not samples:
+        raise ValueError("Expected at least one timing sample")
+    warm_samples = samples[1:] if len(samples) > 1 else samples
+    return statistics.median(warm_samples)
+
+
+async def measure_tool_call(
+    session: ClientSession,
+    tool_name: str,
+    arguments: dict[str, Any],
+    *,
+    validator: Any | None = None,
+) -> tuple[float, Any]:
+    start = time.perf_counter()
+    text = await call_tool_text(session, tool_name, arguments)
+    elapsed = time.perf_counter() - start
+    return elapsed, validator(text) if validator else text
+
+
+async def benchmark_repeated_tool_call(
+    session: ClientSession,
+    tool_name: str,
+    arguments: dict[str, Any],
+    *,
+    scenario: str,
+    runs: int = 4,
+    validator: Any | None = None,
+) -> tuple[ToolTimingMetrics, list[Any]]:
+    timings: list[float] = []
+    results: list[Any] = []
+    for _ in range(runs):
+        elapsed, parsed = await measure_tool_call(
+            session,
+            tool_name,
+            arguments,
+            validator=validator,
+        )
+        timings.append(elapsed)
+        results.append(parsed)
+
+    return (
+        ToolTimingMetrics(
+            scenario=scenario,
+            tool_name=tool_name,
+            first_call_seconds=timings[0],
+            warm_call_median_seconds=warm_call_median(timings),
+            all_call_seconds=timings,
+        ),
+        results,
+    )
+
+
+async def list_project_programs(session: ClientSession) -> ProgramInfos:
+    return await call_tool_model(session, "list_project_binaries", {}, ProgramInfos)
+
+
+def resolve_program_name_by_path(program_infos: ProgramInfos, file_path: str | Path) -> str:
+    target_path = Path(file_path).resolve()
+    for program in program_infos.programs:
+        if program.file_path and Path(program.file_path).resolve() == target_path:
+            return program.name
+    return PyGhidraContext._gen_unique_bin_name(target_path)
+
+
+def _program_matches_target(
+    program: PublicProgramInfo,
+    *,
+    binary_name: str | None,
+    target_path: Path | None,
+) -> bool:
+    if binary_name and program.name == binary_name:
+        return True
+    if target_path and program.file_path and Path(program.file_path).resolve() == target_path:
+        return True
+    return False
+
+
+def _program_is_ready(
+    program: PublicProgramInfo,
+    *,
+    require_code_collection: bool,
+    require_strings_collection: bool,
+) -> bool:
+    ready = program.analysis_complete
+    if require_code_collection:
+        ready = ready and program.code_collection
+    if require_strings_collection:
+        ready = ready and program.strings_collection
+    return ready
+
+
+async def wait_for_binary_readiness(
+    session: ClientSession,
+    *,
+    file_path: str | Path | None = None,
+    binary_name: str | None = None,
+    require_code_collection: bool = False,
+    require_strings_collection: bool = False,
+    timeout_seconds: int = 120,
+    poll_interval_seconds: float = 1.0,
+) -> PublicProgramInfo:
+    if file_path is None and binary_name is None:
+        raise ValueError("Either file_path or binary_name is required")
+
+    deadline = time.time() + timeout_seconds
+    target_path = Path(file_path).resolve() if file_path is not None else None
+
+    while True:
+        program_infos = await list_project_programs(session)
+        candidate = next(
+            (
+                program
+                for program in program_infos.programs
+                if _program_matches_target(
+                    program,
+                    binary_name=binary_name,
+                    target_path=target_path,
+                )
+            ),
+            None,
+        )
+
+        if candidate is not None and _program_is_ready(
+            candidate,
+            require_code_collection=require_code_collection,
+            require_strings_collection=require_strings_collection,
+        ):
+            return candidate
+
+        if time.time() > deadline:
+            raise RuntimeError(
+                f"Binary readiness timeout for {binary_name or file_path}. "
+                f"Last seen state: {candidate}"
+            )
+
+        await asyncio.sleep(poll_interval_seconds)
+
+
+async def wait_for_binaries_readiness(
+    session: ClientSession,
+    file_paths: list[str | Path],
+    *,
+    require_code_collection: bool = False,
+    require_strings_collection: bool = False,
+    timeout_seconds: int = 120,
+    poll_interval_seconds: float = 1.0,
+) -> dict[str, PublicProgramInfo]:
+    deadline = time.time() + timeout_seconds
+    targets = {str(Path(path).resolve()): Path(path).resolve() for path in file_paths}
+
+    while True:
+        program_infos = await list_project_programs(session)
+        ready_programs: dict[str, PublicProgramInfo] = {}
+
+        for raw_path, target_path in targets.items():
+            for program in program_infos.programs:
+                if program.file_path and Path(program.file_path).resolve() == target_path:
+                    ready = program.analysis_complete
+                    if require_code_collection:
+                        ready = ready and program.code_collection
+                    if require_strings_collection:
+                        ready = ready and program.strings_collection
+                    if ready:
+                        ready_programs[raw_path] = program
+                    break
+
+        if len(ready_programs) == len(targets):
+            return ready_programs
+
+        if time.time() > deadline:
+            raise RuntimeError(
+                f"Binary readiness timeout for {sorted(targets)}. Ready: {sorted(ready_programs)}"
+            )
+
+        await asyncio.sleep(poll_interval_seconds)
+
+
+def default_executable_entry_lookup() -> str:
+    return "entry" if platform.system() == "Darwin" else "main"
+
+
+def platform_function_name(name: str) -> str:
+    return f"_{name}" if platform.system() == "Darwin" else name
+
+
+def _compile_generated_c(source_path: Path, output_path: Path, *, shared: bool) -> Path:
+    is_macos = platform.system() == "Darwin"
+    compile_cmd = ["gcc", "-O0", "-fno-inline", "-fno-builtin"]
+    if shared:
+        compile_cmd.extend(["-dynamiclib"] if is_macos else ["-fPIC", "-shared"])
+    compile_cmd.extend(["-o", str(output_path), str(source_path)])
+
+    result = subprocess.run(compile_cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        command_text = " ".join(compile_cmd)
+        raise RuntimeError(f"Compilation failed: {command_text}\nSTDERR:\n{result.stderr}")
+
+    return output_path
+
+
+def _render_generated_c_source(spec: GeneratedBinarySpec, *, shared: bool) -> str:
+    literal_mod = max(1, spec.function_count // max(1, spec.string_count))
+    call_fanout = max(1, spec.call_fanout)
+    exported_count = min(spec.exported_function_count, spec.function_count)
+    shared_prefix = "EXPORT " if shared else ""
+
+    lines = [
+        "#include <stdio.h>",
+        "#include <stdlib.h>",
+        "#include <string.h>",
+        "",
+        "#if defined(__GNUC__)",
+        "#define NOINLINE __attribute__((noinline))",
+        "#define USED __attribute__((used))",
+        '#define EXPORT __attribute__((visibility("default")))',
+        "#else",
+        "#define NOINLINE",
+        "#define USED",
+        "#define EXPORT",
+        "#endif",
+        "",
+        "volatile int g_keepalive_sink = 0;",
+        f"volatile int {spec.sentinel_symbol_stem} = 7;",
+    ]
+
+    for index in range(spec.global_count):
+        lines.append(f"volatile int noise_global_{index:04d} = {index};")
+
+    lines.extend(
+        [
+            "",
+            "NOINLINE USED void record_side_effect(int value) {",
+            "    g_keepalive_sink += value;",
+            "}",
+            "",
+            "NOINLINE USED int allocate_and_measure(const char *text, int seed) {",
+            "    size_t text_len = strlen(text);",
+            "    char *buffer = (char *)malloc(text_len + 32);",
+            "    if (!buffer) {",
+            "        return seed;",
+            "    }",
+            '    snprintf(buffer, text_len + 32, "%s-%d", text, seed);',
+            '    printf("%s\\n", buffer);',
+            "    puts(buffer);",
+            "    int result = (int)strlen(buffer);",
+            "    free(buffer);",
+            "    return result;",
+            "}",
+            "",
+        ]
+    )
+
+    for index in range(spec.function_count):
+        export_prefix = "EXPORT " if shared and index < exported_count else ""
+        lines.append(f"{export_prefix}NOINLINE USED int noise_function_{index:04d}(int depth);")
+
+    lines.extend(
+        [
+            f"{shared_prefix}NOINLINE USED int {spec.sentinel_function_stem}(int seed);",
+            f"{shared_prefix}NOINLINE USED int {spec.sentinel_export_stem}(int seed);",
+            "",
+        ]
+    )
+
+    for index in range(spec.function_count):
+        literal_text = (
+            f"{spec.sentinel_code_literal} function {index:04d}"
+            if index % literal_mod == 0
+            else f"noise string {index:04d}"
+        )
+        next_calls = []
+        for fanout_index in range(1, call_fanout + 1):
+            target = index + fanout_index
+            if target < spec.function_count:
+                next_calls.append(
+                    f"    total += noise_function_{target:04d}(depth + {fanout_index});"
+                )
+
+        lines.extend(
+            [
+                f"{('EXPORT ' if shared and index < exported_count else '')}"
+                f"NOINLINE USED int noise_function_{index:04d}(int depth) {{",
+                f'    const char *message = "{literal_text}";',
+                f"    int total = noise_global_{index % max(1, spec.global_count):04d} + depth;",
+                f"    total += allocate_and_measure(message, {index});",
+                f"    record_side_effect(total + {spec.sentinel_symbol_stem});",
+                *next_calls,
+                "    return total;",
+                "}",
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            f"{shared_prefix}NOINLINE USED int {spec.sentinel_function_stem}(int seed) {{",
+            f'    const char *message = "{spec.sentinel_string}";',
+            "    int total = seed;",
+            "    total += allocate_and_measure(message, seed);",
+            (
+                f"    total += noise_function_"
+                f"{min(1, max(0, spec.function_count - 1)):04d}(seed + 1);"
+            ),
+            (
+                f"    total += noise_function_"
+                f"{min(5, max(0, spec.function_count - 1)):04d}(seed + 2);"
+            ),
+            (
+                f"    total += noise_function_"
+                f"{min(9, max(0, spec.function_count - 1)):04d}(seed + 3);"
+            ),
+            f"    record_side_effect(total + {spec.sentinel_symbol_stem});",
+            "    return total;",
+            "}",
+            "",
+            f"{shared_prefix}NOINLINE USED int {spec.sentinel_export_stem}(int seed) {{",
+            f"    return {spec.sentinel_function_stem}(seed + 11);",
+            "}",
+            "",
+        ]
+    )
+
+    if shared:
+        lines.extend(
+            [
+                "NOINLINE USED int library_entry_point(void) {",
+                f"    return {spec.sentinel_export_stem}(3);",
+                "}",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "int main(void) {",
+                f"    return {spec.sentinel_function_stem}(5) == 0;",
+                "}",
+            ]
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def build_generated_binary(
+    output_dir: Path,
+    spec: GeneratedBinarySpec,
+    *,
+    shared: bool,
+) -> GeneratedBinaryArtifact:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    source_path = output_dir / f"{spec.stem}.c"
+    binary_suffix = (
+        ".dylib" if shared and platform.system() == "Darwin" else ".so" if shared else ""
+    )
+    binary_path = output_dir / f"{spec.stem}{binary_suffix}"
+    source_path.write_text(_render_generated_c_source(spec, shared=shared))
+    _compile_generated_c(source_path, binary_path, shared=shared)
+    return GeneratedBinaryArtifact(binary_path=binary_path, source_path=source_path, spec=spec)
+
+
+class FakeMcpTool:
+    def __init__(self, name: str, description: str, input_schema: dict, output_schema: dict):
+        self.name = name
+        self.description = description
+        self._payload = {
+            "name": name,
+            "description": description,
+            "inputSchema": input_schema,
+            "outputSchema": output_schema,
+        }
+
+    def model_dump(self, **_kwargs):
+        return self._payload
+
+
+class FakeCodeCollection:
+    def __init__(self, documents: list[dict], query_results: list[dict] | None = None):
+        self.documents = documents
+        self.query_results = query_results or documents
+        self.get_calls: list[dict] = []
+        self.query_calls: list[dict] = []
+        self.count_calls = 0
+
+    def _matching_documents(self, where_document: dict | None) -> list[dict]:
+        if not where_document:
+            return self.documents
+        needle = where_document.get("$contains", "")
+        return [document for document in self.documents if needle in document["document"]]
+
+    def get(
+        self,
+        ids=None,
+        where=None,
+        limit: int | None = None,
+        offset: int | None = None,
+        where_document: dict | None = None,
+        include=("metadatas", "documents"),
+    ) -> dict:
+        include_list = list(include)
+        self.get_calls.append(
+            {
+                "ids": ids,
+                "where": where,
+                "limit": limit,
+                "offset": offset,
+                "where_document": where_document,
+                "include": include_list,
+            }
+        )
+        matches = self._matching_documents(where_document)
+        start = offset or 0
+        end = None if limit is None else start + limit
+        page = matches[start:end]
+        result = {"ids": [item["id"] for item in page]}
+        if "documents" in include_list:
+            result["documents"] = [item["document"] for item in page]
+        if "metadatas" in include_list:
+            result["metadatas"] = [item["metadata"] for item in page]
+        return result
+
+    def query(
+        self,
+        query_texts=None,
+        n_results: int = 10,
+        where=None,
+        where_document=None,
+        include=("metadatas", "documents", "distances"),
+    ) -> dict:
+        include_list = list(include)
+        self.query_calls.append(
+            {
+                "query_texts": query_texts,
+                "n_results": n_results,
+                "where": where,
+                "where_document": where_document,
+                "include": include_list,
+            }
+        )
+        rows = self.query_results[:n_results]
+        result = {"ids": [[row["id"] for row in rows]]}
+        if "documents" in include_list:
+            result["documents"] = [[row["document"] for row in rows]]
+        if "metadatas" in include_list:
+            result["metadatas"] = [[row["metadata"] for row in rows]]
+        if "distances" in include_list:
+            result["distances"] = [[row["distance"] for row in rows]]
+        return result
+
+    def count(self) -> int:
+        self.count_calls += 1
+        return len(self.documents)
+
+
+class FakeReferenceManager:
+    def __init__(self, references_by_address: dict[str, list[object]] | None = None):
+        self.references_by_address = references_by_address or {}
+        self.calls: list[str] = []
+
+    def getReferencesTo(self, address: str):
+        self.calls.append(address)
+        return list(self.references_by_address.get(address, []))
+
+
+class FakeSymbol:
+    def __init__(
+        self,
+        name: str,
+        address: str,
+        *,
+        symbol_type: str = "Function",
+        namespace: str = "Global",
+        source: str = "Analysis",
+        external: bool = False,
+        external_entry: bool = False,
+    ):
+        self.name = name
+        self._address = address
+        self._symbol_type = symbol_type
+        self._namespace = namespace
+        self._source = source
+        self._external = external
+        self._external_entry = external_entry
+
+    def __hash__(self) -> int:
+        return hash((self.name, self._address))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, FakeSymbol):
+            return False
+        return (self.name, self._address) == (other.name, other._address)
+
+    def getName(self, _include_namespace: bool = False) -> str:
+        return self.name
+
+    def getAddress(self) -> str:
+        return self._address
+
+    def getSymbolType(self) -> str:
+        return self._symbol_type
+
+    def getParentNamespace(self) -> str:
+        return self._namespace
+
+    def getSource(self) -> str:
+        return self._source
+
+    def isExternal(self) -> bool:
+        return self._external
+
+    def isExternalEntryPoint(self) -> bool:
+        return self._external_entry
+
+
+class FakeFunction:
+    def __init__(self, symbol: FakeSymbol, entry_point: str, *, external: bool = False):
+        self._symbol = symbol
+        self._entry_point = entry_point
+        self._external = external
+        self.thunk = False
+
+    def getSymbol(self) -> FakeSymbol:
+        return self._symbol
+
+    def getEntryPoint(self) -> str:
+        return self._entry_point
+
+    def getSignature(self) -> str:
+        return f"{self._symbol.name}()"
+
+    def isExternal(self) -> bool:
+        return self._external
+
+
+class FakeFunctionManager:
+    def __init__(self, functions: list[FakeFunction]):
+        self.functions = functions
+        self.get_functions_calls = 0
+
+    def getFunctions(self, _forward: bool):
+        self.get_functions_calls += 1
+        return list(self.functions)
+
+    def getFunctionAt(self, address: str):
+        for function in self.functions:
+            if function.getEntryPoint() == address:
+                return function
+        return None
+
+
+class FakeSymbolTable:
+    def __init__(self, symbols: list[FakeSymbol], external_symbols: list[FakeSymbol] | None = None):
+        self.symbols = symbols
+        self.external_symbols = external_symbols or [
+            symbol for symbol in symbols if symbol.isExternal()
+        ]
+        self.all_symbols_calls = 0
+        self.external_symbols_calls = 0
+
+    def getAllSymbols(self, _include_dynamic: bool):
+        self.all_symbols_calls += 1
+        return list(self.symbols)
+
+    def getExternalSymbols(self):
+        self.external_symbols_calls += 1
+        return list(self.external_symbols)
+
+    def getSymbols(self, address: str):
+        return [symbol for symbol in self.symbols if symbol.getAddress() == address]
+
+
+class FakeAddressFactory:
+    def getAddress(self, value: str) -> str:
+        return value
+
+
+class FakeProgram:
+    def __init__(
+        self,
+        *,
+        symbols: list[FakeSymbol] | None = None,
+        functions: list[FakeFunction] | None = None,
+        external_symbols: list[FakeSymbol] | None = None,
+        references_by_address: dict[str, list[object]] | None = None,
+    ):
+        self.symbol_table = FakeSymbolTable(symbols or [], external_symbols=external_symbols)
+        self.function_manager = FakeFunctionManager(functions or [])
+        self.reference_manager = FakeReferenceManager(references_by_address)
+        self.address_factory = FakeAddressFactory()
+
+    def getSymbolTable(self) -> FakeSymbolTable:
+        return self.symbol_table
+
+    def getFunctionManager(self) -> FakeFunctionManager:
+        return self.function_manager
+
+    def getReferenceManager(self) -> FakeReferenceManager:
+        return self.reference_manager
+
+    def getAddressFactory(self) -> FakeAddressFactory:
+        return self.address_factory
+
+
+def _install_legacy_ghidra_runtime_shims() -> None:
+    """Install minimal ghidra modules needed by legacy benchmark code paths."""
+    if "ghidra.program.model.symbol" in sys.modules:
+        return
+
+    ghidra_module = sys.modules.setdefault("ghidra", types.ModuleType("ghidra"))
+    program_module = sys.modules.setdefault("ghidra.program", types.ModuleType("ghidra.program"))
+    model_module = sys.modules.setdefault(
+        "ghidra.program.model", types.ModuleType("ghidra.program.model")
+    )
+    symbol_module = sys.modules.setdefault(
+        "ghidra.program.model.symbol", types.ModuleType("ghidra.program.model.symbol")
+    )
+
+    if not hasattr(symbol_module, "SymbolTable"):
+
+        class SymbolTable:
+            pass
+
+        symbol_module.SymbolTable = SymbolTable  # type: ignore[attr-defined]
+
+    ghidra_module.program = program_module  # type: ignore[attr-defined]
+    program_module.model = model_module  # type: ignore[attr-defined]
+    model_module.symbol = symbol_module  # type: ignore[attr-defined]
+
+
+def make_runtime_program_info(
+    *,
+    program: FakeProgram | None = None,
+    code_collection: FakeCodeCollection | None = None,
+    strings_collection: FakeCodeCollection | None = None,
+) -> RuntimeProgramInfo:
+    dataclass_fields = getattr(RuntimeProgramInfo, "__dataclass_fields__", {})
+    kwargs = {
+        "name": "fake-bin",
+        "program": program or FakeProgram(),
+        "flat_api": None,
+        "decompiler": SimpleNamespace(),
+        "metadata": {},
+        "ghidra_analysis_complete": True,
+        "file_path": None,
+        "load_time": None,
+        "code_collection": code_collection,
+        "strings_collection": strings_collection,
+    }
+    if "ghidra_tools" in dataclass_fields:
+        kwargs["ghidra_tools"] = None
+    if "derived_cache_version" in dataclass_fields:
+        kwargs["derived_cache_version"] = 0
+    return RuntimeProgramInfo(**kwargs)
+
+
+def get_program_tools(program_info: RuntimeProgramInfo) -> GhidraTools:
+    if hasattr(program_info, "get_tools"):
+        return program_info.get_tools()
+
+    _install_legacy_ghidra_runtime_shims()
+    tools = getattr(program_info, "_benchmark_tools", None)
+    if tools is None:
+        tools = GhidraTools(program_info)
+        program_info._benchmark_tools = tools  # type: ignore[attr-defined]
+    return tools
+
+
+def _build_code_documents(total: int = 512) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    documents = []
+    query_results = []
+    for index in range(total):
+        function_name = f"match_func_{index:04d}"
+        literal = "printf hot path" if index % 2 == 0 else "branch without literal match"
+        document = f"{literal} block {index:04d} with extra text"
+        row = {
+            "id": function_name,
+            "document": document,
+            "metadata": {"function_name": function_name},
+        }
+        documents.append(row)
+        query_results.append({**row, "distance": float(index) / 10.0})
+    return documents, query_results
+
+
+def _build_symbol_program(total: int = 512) -> FakeProgram:
+    symbols = [
+        FakeSymbol(f"match_symbol_{index:04d}", f"0x{index + 1:x}") for index in range(total)
+    ]
+    references = {
+        symbol.getAddress(): [object() for _ in range((index % 4) + 1)]
+        for index, symbol in enumerate(symbols)
+    }
+    return FakeProgram(symbols=symbols, references_by_address=references)
+
+
+def _build_function_program(total: int = 512) -> FakeProgram:
+    functions = []
+    references = {}
+    for index in range(total):
+        address = f"0x{index + 16:x}"
+        symbol = FakeSymbol(f"match_function_{index:04d}", address)
+        functions.append(FakeFunction(symbol, address))
+        references[address] = [object() for _ in range((index % 5) + 1)]
+    return FakeProgram(functions=functions, references_by_address=references)
+
+
+def _build_import_export_program(total: int = 256) -> FakeProgram:
+    exports = [
+        FakeSymbol(f"sentinel_export_{index:04d}", f"0x{index + 1:x}", external_entry=True)
+        for index in range(total)
+    ]
+    helper_symbols = [
+        FakeSymbol(f"helper_{index:04d}", f"0x{index + total + 1:x}") for index in range(total)
+    ]
+    imports = [
+        FakeSymbol(
+            f"printf_variant_{index:04d}",
+            f"0x{index + (2 * total) + 1:x}",
+            external=True,
+            namespace="libc",
+        )
+        for index in range(total)
+    ]
+    return FakeProgram(symbols=exports + helper_symbols, external_symbols=imports)
+
+
+def collect_internal_call_counts() -> dict[str, InternalCallCounts]:
+    documents, query_results = _build_code_documents()
+
+    semantic_collection = FakeCodeCollection(documents=documents, query_results=query_results)
+    semantic_info = make_runtime_program_info(code_collection=semantic_collection)
+    semantic_tools = get_program_tools(semantic_info)
+    semantic_tools.search_code(
+        query="printf",
+        limit=25,
+        offset=5,
+        search_mode=SearchMode.SEMANTIC,
+        include_full_code=False,
+        preview_length=32,
+        similarity_threshold=0.1,
+    )
+    semantic_tools.search_code(
+        query="printf",
+        limit=10,
+        offset=0,
+        search_mode=SearchMode.SEMANTIC,
+    )
+
+    literal_collection = FakeCodeCollection(documents=documents, query_results=query_results)
+    literal_info = make_runtime_program_info(code_collection=literal_collection)
+    literal_tools = get_program_tools(literal_info)
+    literal_tools.search_code(
+        query="printf",
+        limit=20,
+        offset=10,
+        search_mode=SearchMode.LITERAL,
+        include_full_code=False,
+        preview_length=24,
+    )
+
+    symbol_program = _build_symbol_program()
+    symbol_info = make_runtime_program_info(program=symbol_program)
+    symbol_tools = get_program_tools(symbol_info)
+    symbol_tools.search_symbols_by_name("match_symbol_", offset=200, limit=25)
+    symbol_tools.search_symbols_by_name("match_symbol_", offset=0, limit=25)
+
+    function_program = _build_function_program()
+    function_info = make_runtime_program_info(program=function_program)
+    function_tools = get_program_tools(function_info)
+    function_tools.search_functions_by_name("match_function_", offset=200, limit=25)
+    function_tools.search_functions_by_name("match_function_", offset=0, limit=25)
+
+    import_export_program = _build_import_export_program()
+    import_export_info = make_runtime_program_info(program=import_export_program)
+    import_export_tools = get_program_tools(import_export_info)
+    import_export_tools.list_exports(query="sentinel_export_", offset=0, limit=25)
+    import_export_tools.list_exports(query="sentinel_export_", offset=25, limit=25)
+    import_export_tools.list_imports(query="printf_variant_", offset=0, limit=25)
+    import_export_tools.list_imports(query="printf_variant_", offset=25, limit=25)
+
+    return {
+        "search_code_semantic": InternalCallCounts(
+            chroma_count_calls=semantic_collection.count_calls,
+            chroma_get_calls=len(semantic_collection.get_calls),
+            chroma_query_calls=len(semantic_collection.query_calls),
+        ),
+        "search_code_literal": InternalCallCounts(
+            chroma_count_calls=literal_collection.count_calls,
+            chroma_get_calls=len(literal_collection.get_calls),
+            chroma_query_calls=len(literal_collection.query_calls),
+        ),
+        "search_symbols_by_name": InternalCallCounts(
+            symbol_table_all_symbols_calls=symbol_program.symbol_table.all_symbols_calls,
+            reference_lookup_calls=len(symbol_program.reference_manager.calls),
+        ),
+        "search_functions_by_name": InternalCallCounts(
+            function_manager_get_functions_calls=function_program.function_manager.get_functions_calls,
+            reference_lookup_calls=len(function_program.reference_manager.calls),
+        ),
+        "list_exports": InternalCallCounts(
+            symbol_table_all_symbols_calls=import_export_program.symbol_table.all_symbols_calls,
+        ),
+        "list_imports": InternalCallCounts(
+            symbol_table_external_symbols_calls=import_export_program.symbol_table.external_symbols_calls,
+        ),
+    }
+
+
+def collect_internal_call_counts_json() -> str:
+    counts = {
+        scenario: metrics.to_dict() for scenario, metrics in collect_internal_call_counts().items()
+    }
+    return json.dumps(counts, sort_keys=True)
+
+
+def validate_code_search_result(text: str) -> CodeSearchResults:
+    return CodeSearchResults.model_validate_json(text)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -111,42 +111,77 @@ void shared_func_two() {
     os.unlink(so_file)
 
 
+def _isolated_project_args(project_root: Path, fixture_name: str) -> list[str]:
+    project_path = project_root / fixture_name
+    project_name = f"{fixture_name}_project"
+    return ["--project-path", str(project_path), "--project-name", project_name]
+
+
 @pytest.fixture(scope="module")
-def server_params_no_input(ghidra_env):
+def isolated_project_root(tmp_path_factory, request):
+    module_name = Path(str(request.node.path)).stem
+    return tmp_path_factory.mktemp(f"{module_name}-projects")
+
+
+@pytest.fixture(scope="module")
+def server_params_no_input(ghidra_env, isolated_project_root):
     """Get server parameters with no test binary."""
     return StdioServerParameters(
         command="python",
-        args=["-m", "pyghidra_mcp", "--wait-for-analysis"],
+        args=[
+            "-m",
+            "pyghidra_mcp",
+            *_isolated_project_args(isolated_project_root, "server_params_no_input"),
+            "--wait-for-analysis",
+        ],
         env=ghidra_env,
     )
 
 
 @pytest.fixture(scope="module")
-def server_params(test_binary, ghidra_env):
+def server_params(test_binary, ghidra_env, isolated_project_root):
     """Get server parameters with a test binary."""
     return StdioServerParameters(
         command="python",
-        args=["-m", "pyghidra_mcp", "--wait-for-analysis", test_binary],
+        args=[
+            "-m",
+            "pyghidra_mcp",
+            *_isolated_project_args(isolated_project_root, "server_params"),
+            "--wait-for-analysis",
+            test_binary,
+        ],
         env=ghidra_env,
     )
 
 
 @pytest.fixture(scope="module")
-def server_params_no_thread(test_binary, ghidra_env):
+def server_params_no_thread(test_binary, ghidra_env, isolated_project_root):
     """Get server parameters with a test binary."""
     return StdioServerParameters(
         command="python",
-        args=["-m", "pyghidra_mcp", "--no-threaded", test_binary],
+        args=[
+            "-m",
+            "pyghidra_mcp",
+            *_isolated_project_args(isolated_project_root, "server_params_no_thread"),
+            "--no-threaded",
+            test_binary,
+        ],
         env=ghidra_env,
     )
 
 
 @pytest.fixture(scope="module")
-def server_params_shared_object(test_shared_object, ghidra_env):
+def server_params_shared_object(test_shared_object, ghidra_env, isolated_project_root):
     """Get server parameters with a test binary."""
     return StdioServerParameters(
         command="python",
-        args=["-m", "pyghidra_mcp", "--wait-for-analysis", test_shared_object],
+        args=[
+            "-m",
+            "pyghidra_mcp",
+            *_isolated_project_args(isolated_project_root, "server_params_shared_object"),
+            "--wait-for-analysis",
+            test_shared_object,
+        ],
         env=ghidra_env,
     )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,5 @@
 import json
 import os
-import platform
 import tempfile
 from pathlib import Path
 
@@ -25,7 +24,8 @@ def ghidra_env():
         env["GHIDRA_INSTALL_DIR"] = "/ghidra"
         return env
     pytest.skip(
-        "GHIDRA installation not found. Set GHIDRA_INSTALL_DIR to a valid Ghidra install, or ensure /ghidra exists."
+        "GHIDRA installation not found. Set GHIDRA_INSTALL_DIR to a valid Ghidra install, "
+        "or ensure /ghidra exists."
     )
 
 
@@ -184,6 +184,7 @@ def custom_project_directory():
     """Create temporary directory for custom named projects"""
     with tempfile.TemporaryDirectory() as temp_dir:
         yield Path(temp_dir)
+
 
 @pytest.fixture(scope="module")
 def server_params_custom_project_name(custom_project_directory, ghidra_env):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,7 @@
 import json
 import os
+import platform
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -96,19 +98,26 @@ void shared_func_two() {
         )
         c_file = f.name
 
-    # 2. Compile as a shared object
-    so_file = c_file.replace(".c", ".so")
-    cmd = f"gcc -fPIC -shared -o {so_file} {c_file}"
-    ret = os.system(cmd)
-    if ret != 0:
-        raise RuntimeError(f"Compilation failed: {cmd}")
+    # 2. Compile as a shared object (Mach-O on macOS, ELF shared object on Linux)
+    is_macos = platform.system() == "Darwin"
+    shared_ext = ".dylib" if is_macos else ".so"
+    shared_file = c_file.replace(".c", shared_ext)
+    compile_cmd = (
+        ["gcc", "-dynamiclib", "-o", shared_file, c_file]
+        if is_macos
+        else ["gcc", "-fPIC", "-shared", "-o", shared_file, c_file]
+    )
+    result = subprocess.run(compile_cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        cmd_text = " ".join(compile_cmd)
+        raise RuntimeError(f"Compilation failed: {cmd_text}\nSTDERR:\n{result.stderr}")
 
-    # 3. Yield path to .so for tests
-    yield so_file
+    # 3. Yield path to shared library for tests
+    yield shared_file
 
     # 4. Clean up
     os.unlink(c_file)
-    os.unlink(so_file)
+    os.unlink(shared_file)
 
 
 def _isolated_project_args(project_root: Path, fixture_name: str) -> list[str]:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 import tempfile
 from pathlib import Path
 
@@ -7,9 +8,34 @@ import pytest
 from mcp import StdioServerParameters
 
 
+@pytest.fixture(scope="session")
+def ghidra_env():
+    """Derive a valid environment for locating Ghidra or skip if unavailable.
+
+    Policy:
+    - If GHIDRA_INSTALL_DIR is set and is a valid directory, use it.
+    - Else if /ghidra exists, set GHIDRA_INSTALL_DIR to /ghidra.
+    - Else skip tests that require a Ghidra installation.
+    """
+    env = os.environ.copy()
+    ghidra_dir = env.get("GHIDRA_INSTALL_DIR")
+    if ghidra_dir and os.path.isdir(ghidra_dir):
+        return env
+    if os.path.isdir("/ghidra"):
+        env["GHIDRA_INSTALL_DIR"] = "/ghidra"
+        return env
+    pytest.skip(
+        "GHIDRA installation not found. Set GHIDRA_INSTALL_DIR to a valid Ghidra install, or ensure /ghidra exists."
+    )
+
+
 @pytest.fixture(scope="module")
 def test_binary():
-    """Create a simple test binary for testing."""
+    """Create a simple test binary for testing.
+
+    On macOS produce a Mach-O; on Linux, produce an ELF. The main symbol name and base
+    address differ by platform and are handled downstream by tests.
+    """
     with tempfile.NamedTemporaryFile(mode="w", suffix=".c", delete=False) as f:
         f.write(
             """
@@ -53,12 +79,15 @@ def test_shared_object():
         f.write(
             """
 #include <stdio.h>
+#include <stdlib.h>
 
-void function_one() {
-    printf("Function One");
+void shared_func_one() {
+    char *buf = malloc(10);
+    printf("Function One: %p", (void *)buf);
+    free(buf);
 }
 
-void function_two() {
+void shared_func_two() {
     printf("Function Two");
 }
 
@@ -83,50 +112,42 @@ void function_two() {
 
 
 @pytest.fixture(scope="module")
-def server_params_no_input():
+def server_params_no_input(ghidra_env):
     """Get server parameters with no test binary."""
     return StdioServerParameters(
-        command="python",  # Executable
-        # Run with test binary
+        command="python",
         args=["-m", "pyghidra_mcp", "--wait-for-analysis"],
-        # Optional environment variables
-        env={"GHIDRA_INSTALL_DIR": "/ghidra"},
+        env=ghidra_env,
     )
 
 
 @pytest.fixture(scope="module")
-def server_params(test_binary):
+def server_params(test_binary, ghidra_env):
     """Get server parameters with a test binary."""
     return StdioServerParameters(
-        command="python",  # Executable
-        # Run with test binary
+        command="python",
         args=["-m", "pyghidra_mcp", "--wait-for-analysis", test_binary],
-        # Optional environment variables
-        env={"GHIDRA_INSTALL_DIR": "/ghidra"},
+        env=ghidra_env,
     )
 
 
 @pytest.fixture(scope="module")
-def server_params_no_thread(test_binary):
+def server_params_no_thread(test_binary, ghidra_env):
     """Get server parameters with a test binary."""
     return StdioServerParameters(
-        command="python",  # Executable
-        # Run with test binary
-        args=["-m", "pyghidra_mcp", "--no-threaded", test_binary],  # no-thread for chromadb_testing
-        # Optional environment variables
-        env={"GHIDRA_INSTALL_DIR": "/ghidra"},
+        command="python",
+        args=["-m", "pyghidra_mcp", "--no-threaded", test_binary],
+        env=ghidra_env,
     )
 
 
 @pytest.fixture(scope="module")
-def server_params_shared_object(test_shared_object):
+def server_params_shared_object(test_shared_object, ghidra_env):
     """Get server parameters with a test binary."""
     return StdioServerParameters(
-        command="python",  # Executable
-        # Run with test binary
+        command="python",
         args=["-m", "pyghidra_mcp", "--wait-for-analysis", test_shared_object],
-        # Optional environment variables
-        env={"GHIDRA_INSTALL_DIR": "/ghidra"},
+        env=ghidra_env,
     )
 
 
@@ -148,13 +169,13 @@ def find_binary_in_list_response():
 
 
 @pytest.fixture(scope="module")
-def server_params_existing_notepad_project():
+def server_params_existing_notepad_project(ghidra_env):
     """Server with existing notepad project from other_projects/"""
     project_path = Path(__file__).parent.parent.parent / "other_projects" / "notepad.gpr"
     return StdioServerParameters(
         command="python",
         args=["-m", "pyghidra_mcp", "--project-path", str(project_path), "--wait-for-analysis"],
-        env={"GHIDRA_INSTALL_DIR": "/ghidra"},
+        env=ghidra_env,
     )
 
 
@@ -164,24 +185,23 @@ def custom_project_directory():
     with tempfile.TemporaryDirectory() as temp_dir:
         yield Path(temp_dir)
 
-
 @pytest.fixture(scope="module")
-def server_params_custom_project_name(custom_project_directory):
+def server_params_custom_project_name(custom_project_directory, ghidra_env):
     """Server with custom project path and name"""
     custom_project = custom_project_directory / "my_analysis_project"
     return StdioServerParameters(
         command="python",
         args=["-m", "pyghidra_mcp", "--project-path", str(custom_project), "--wait-for-analysis"],
-        env={"GHIDRA_INSTALL_DIR": "/ghidra"},
+        env=ghidra_env,
     )
 
 
 @pytest.fixture(scope="module")
-def server_params_nested_project_location(custom_project_directory):
+def server_params_nested_project_location(custom_project_directory, ghidra_env):
     """Server with nested project location"""
     nested_project = custom_project_directory / "deeply/nested/location/test_project"
     return StdioServerParameters(
         command="python",
         args=["-m", "pyghidra_mcp", "--project-path", str(nested_project), "--wait-for-analysis"],
-        env={"GHIDRA_INSTALL_DIR": "/ghidra"},
+        env=ghidra_env,
     )

--- a/tests/integration/test_concurrent_streamable_client.py
+++ b/tests/integration/test_concurrent_streamable_client.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import platform
 import subprocess
 import time
 from pathlib import Path
@@ -8,7 +9,7 @@ from pathlib import Path
 import aiohttp
 import pytest
 from mcp.client.session import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 from pyghidra_mcp.context import PyGhidraContext
 from pyghidra_mcp.models import (
@@ -28,7 +29,7 @@ base_url = os.getenv("MCP_BASE_URL", "http://127.0.0.1:8000")
 
 
 @pytest.fixture(scope="module")
-def streamable_server(test_binary):
+def streamable_server(test_binary, ghidra_env):
     """Fixture to start the pyghidra-mcp server in a separate process."""
     proc = subprocess.Popen(
         [
@@ -40,12 +41,12 @@ def streamable_server(test_binary):
             "streamable-http",
             test_binary,
         ],
-        env={**os.environ, "GHIDRA_INSTALL_DIR": "/ghidra"},
+        env=ghidra_env,
     )
 
     async def wait_for_server(timeout=120):
         async with aiohttp.ClientSession() as session:
-            for _ in range(timeout):  # Poll for 20 seconds
+            for _ in range(timeout):
                 try:
                     async with session.get(f"{base_url}/mcp") as response:
                         if response.status == 406:
@@ -55,7 +56,12 @@ def streamable_server(test_binary):
                 await asyncio.sleep(1)
             raise RuntimeError("Server did not start in time")
 
-    asyncio.run(wait_for_server())
+    try:
+        asyncio.run(wait_for_server())
+    except Exception:
+        proc.terminate()
+        proc.wait()
+        raise
 
     time.sleep(3)
 
@@ -66,8 +72,7 @@ def streamable_server(test_binary):
         """
         deadline = time.time() + timeout
 
-        # Open a single persistent connection - re-using it keeps the overhead low.
-        async with streamablehttp_client(f"{base_url}/mcp") as (read, write, _):
+        async with streamable_http_client(f"{base_url}/mcp") as (read, write, _):
             async with ClientSession(read, write) as session:
                 await session.initialize()
 
@@ -94,9 +99,14 @@ def streamable_server(test_binary):
                     if time.time() > deadline:  # pragma: no cover
                         raise RuntimeError(f"Collections still missing after {timeout}s: ")
 
-                    await asyncio.sleep(1)  # Wait a bit before the next call
+                    await asyncio.sleep(1)
 
-    asyncio.run(wait_for_collections(test_binary))
+    try:
+        asyncio.run(wait_for_collections(test_binary))
+    except Exception:
+        proc.terminate()
+        proc.wait()
+        raise
 
     time.sleep(2)
 
@@ -106,14 +116,16 @@ def streamable_server(test_binary):
 
 
 async def invoke_tool_concurrently(server_binary_path):
-    async with streamablehttp_client(f"{base_url}/mcp") as (read, write, _):
+    async with streamable_http_client(f"{base_url}/mcp") as (read, write, _):
         async with ClientSession(read, write) as session:
             await session.initialize()
             binary_name = PyGhidraContext._gen_unique_bin_name(Path(server_binary_path))
 
+            read_addr = "100000000" if platform.system() == "Darwin" else "100000"
+            decomp_name = "entry" if platform.system() == "Darwin" else "main"
             tasks = [
                 session.call_tool(
-                    "decompile_function", {"binary_name": binary_name, "name_or_address": "main"}
+                    "decompile_function", {"binary_name": binary_name, "name_or_address": decomp_name}
                 ),
                 session.call_tool(
                     "search_symbols_by_name", {"binary_name": binary_name, "query": "function"}
@@ -136,10 +148,10 @@ async def invoke_tool_concurrently(server_binary_path):
                     "search_strings", {"binary_name": binary_name, "query": "hello", "limit": 1}
                 ),
                 session.call_tool(
-                    "read_bytes", {"binary_name": binary_name, "address": "100000", "size": 4}
+                    "read_bytes", {"binary_name": binary_name, "address": read_addr, "size": 4}
                 ),
                 session.call_tool(
-                    "gen_callgraph", {"binary_name": binary_name, "function_name": "main"}
+                    "gen_callgraph", {"binary_name": binary_name, "function_name": decomp_name}
                 ),
             ]
 
@@ -154,6 +166,7 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
     using streamable-http transport.
     """
     num_clients = 6
+    expected_main = "entry" if platform.system() == "Darwin" else "main"
     tasks = [invoke_tool_concurrently(streamable_server) for _ in range(num_clients)]
     results = await asyncio.gather(*tasks)
 
@@ -165,8 +178,8 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
         # Decompiled function
         decompiled_func_result = json.loads(client_responses[0].content[0].text)
         decompiled_function = DecompiledFunction(**decompiled_func_result)
-        assert "main" in decompiled_function.name
-        assert "main" in decompiled_function.code
+        assert expected_main in decompiled_function.name
+        assert expected_main in decompiled_function.code
 
         # Symbol search results (formerly function search results)
         search_results_result = json.loads(client_responses[1].content[0].text)
@@ -210,7 +223,7 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
         cross_references_result = json.loads(client_responses[6].content[0].text)
         cross_reference_infos = CrossReferenceInfos(**cross_references_result)
         assert len(cross_reference_infos.cross_references) > 0
-        assert any([ref.function_name == "main" for ref in cross_reference_infos.cross_references])
+        assert any(ref.function_name == expected_main for ref in cross_reference_infos.cross_references)
 
         # Search symbols results
         search_symbols_result = json.loads(client_responses[7].content[0].text)
@@ -236,21 +249,26 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
         search_string_result = json.loads(client_responses[9].content[0].text)
         string_search_results = StringSearchResults(**search_string_result)
         assert len(string_search_results.strings) > 0
-        assert "World" in string_search_results.strings[0].value
+        assert any("World" in s.value for s in string_search_results.strings)
 
         # Read bytes
         read_bytes_result = json.loads(client_responses[10].content[0].text)
         bytes_result = BytesReadResult(**read_bytes_result)
         assert bytes_result.size == 4
-        assert bytes_result.data == "7f454c46"  # ELF magic
-        assert bytes_result.address == "00100000"
+        if platform.system() == "Darwin":
+            assert bytes_result.data.lower() == "cffaedfe"  # Mach-O 64-bit magic (little-endian)
+            assert bytes_result.address == "100000000"
+        else:
+            assert bytes_result.data == "7f454c46"  # ELF magic
+            assert bytes_result.address == "00100000"
 
         # Call graph
         call_graph_result = json.loads(client_responses[11].content[0].text)
         call_graph = CallGraphResult(**call_graph_result)
         assert len(call_graph.graph) > 0
-        assert "main" in call_graph.function_name
-        assert "_start" in call_graph.graph
+        assert expected_main in call_graph.function_name
+        # Graph should be non-empty; entry node name may vary by platform/toolchain
+        assert len(call_graph.graph.strip()) > 0
 
         # Delete binary
         # This test is omitted due to complexity in concurrent scenarios

--- a/tests/integration/test_concurrent_streamable_client.py
+++ b/tests/integration/test_concurrent_streamable_client.py
@@ -28,6 +28,54 @@ from pyghidra_mcp.models import (
 base_url = os.getenv("MCP_BASE_URL", "http://127.0.0.1:8000")
 
 
+async def wait_for_server(timeout=120):
+    async with aiohttp.ClientSession() as session:
+        for _ in range(timeout):
+            try:
+                async with session.get(f"{base_url}/mcp") as response:
+                    if response.status == 406:
+                        return
+            except aiohttp.ClientConnectorError:
+                pass
+            await asyncio.sleep(1)
+        raise RuntimeError("Server did not start in time")
+
+
+async def wait_for_collections(test_binary, timeout: int = 120) -> None:
+    """
+    Repeatedly call `list_project_binaries` until all programs have both
+    collections populated, or until *timeout* seconds elapse.
+    """
+    deadline = time.time() + timeout
+
+    async with streamable_http_client(f"{base_url}/mcp") as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            while True:
+                tool_resp = await session.call_tool("list_project_binaries", {})
+                program_infos_result = json.loads(tool_resp.content[0].text)
+                program_infos = ProgramInfos(**program_infos_result)
+
+                has_test_binary = any(
+                    PyGhidraContext._gen_unique_bin_name(Path(test_binary)) in pi.name
+                    for pi in program_infos.programs
+                )
+
+                has_missing = any(
+                    pi.code_collection is False or pi.strings_collection is False
+                    for pi in program_infos.programs
+                )
+
+                if not has_missing and has_test_binary:  # All collections are present - success!
+                    return
+
+                if time.time() > deadline:  # pragma: no cover
+                    raise RuntimeError(f"Collections still missing after {timeout}s: ")
+
+                await asyncio.sleep(1)
+
+
 @pytest.fixture(scope="module")
 def streamable_server(test_binary, ghidra_env):
     """Fixture to start the pyghidra-mcp server in a separate process."""
@@ -44,18 +92,6 @@ def streamable_server(test_binary, ghidra_env):
         env=ghidra_env,
     )
 
-    async def wait_for_server(timeout=120):
-        async with aiohttp.ClientSession() as session:
-            for _ in range(timeout):
-                try:
-                    async with session.get(f"{base_url}/mcp") as response:
-                        if response.status == 406:
-                            return
-                except aiohttp.ClientConnectorError:
-                    pass
-                await asyncio.sleep(1)
-            raise RuntimeError("Server did not start in time")
-
     try:
         asyncio.run(wait_for_server())
     except Exception:
@@ -64,42 +100,6 @@ def streamable_server(test_binary, ghidra_env):
         raise
 
     time.sleep(3)
-
-    async def wait_for_collections(test_binary, timeout: int = 120) -> None:
-        """
-        Repeatedly call `list_project_binaries` until all programs have both
-        collections populated, or until *timeout* seconds elapse.
-        """
-        deadline = time.time() + timeout
-
-        async with streamable_http_client(f"{base_url}/mcp") as (read, write, _):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-
-                while True:
-                    tool_resp = await session.call_tool("list_project_binaries", {})
-                    program_infos_result = json.loads(tool_resp.content[0].text)
-                    program_infos = ProgramInfos(**program_infos_result)
-
-                    has_test_binary = any(
-                        PyGhidraContext._gen_unique_bin_name(Path(test_binary)) in pi.name
-                        for pi in program_infos.programs
-                    )
-
-                    has_missing = any(
-                        pi.code_collection is False or pi.strings_collection is False
-                        for pi in program_infos.programs
-                    )
-
-                    if (
-                        not has_missing and has_test_binary
-                    ):  # All collections are present - success!
-                        return
-
-                    if time.time() > deadline:  # pragma: no cover
-                        raise RuntimeError(f"Collections still missing after {timeout}s: ")
-
-                    await asyncio.sleep(1)
 
     try:
         asyncio.run(wait_for_collections(test_binary))
@@ -125,7 +125,8 @@ async def invoke_tool_concurrently(server_binary_path):
             decomp_name = "entry" if platform.system() == "Darwin" else "main"
             tasks = [
                 session.call_tool(
-                    "decompile_function", {"binary_name": binary_name, "name_or_address": decomp_name}
+                    "decompile_function",
+                    {"binary_name": binary_name, "name_or_address": decomp_name},
                 ),
                 session.call_tool(
                     "search_symbols_by_name", {"binary_name": binary_name, "query": "function"}
@@ -223,7 +224,9 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
         cross_references_result = json.loads(client_responses[6].content[0].text)
         cross_reference_infos = CrossReferenceInfos(**cross_references_result)
         assert len(cross_reference_infos.cross_references) > 0
-        assert any(ref.function_name == expected_main for ref in cross_reference_infos.cross_references)
+        assert any(
+            ref.function_name == expected_main for ref in cross_reference_infos.cross_references
+        )
 
         # Search symbols results
         search_symbols_result = json.loads(client_responses[7].content[0].text)

--- a/tests/integration/test_concurrent_streamable_client.py
+++ b/tests/integration/test_concurrent_streamable_client.py
@@ -122,13 +122,26 @@ def streamable_server(test_binary, ghidra_env, streamable_project_args):
     proc.wait()
 
 
-async def invoke_tool_concurrently(server_binary_path):
+async def discover_mapped_string_address(server_binary_path: str) -> str:
+    async with streamable_http_client(f"{base_url}/mcp") as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            binary_name = PyGhidraContext._gen_unique_bin_name(Path(server_binary_path))
+            response = await session.call_tool(
+                "search_strings",
+                {"binary_name": binary_name, "query": "Hello, World!", "limit": 1},
+            )
+            string_results = StringSearchResults.model_validate_json(response.content[0].text)
+            assert len(string_results.strings) == 1
+            return string_results.strings[0].address
+
+
+async def invoke_tool_concurrently(server_binary_path, read_addr):
     async with streamable_http_client(f"{base_url}/mcp") as (read, write, _):
         async with ClientSession(read, write) as session:
             await session.initialize()
             binary_name = PyGhidraContext._gen_unique_bin_name(Path(server_binary_path))
 
-            read_addr = "100000000" if platform.system() == "Darwin" else "100000"
             decomp_name = "entry" if platform.system() == "Darwin" else "main"
             name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
             tasks = [
@@ -157,7 +170,8 @@ async def invoke_tool_concurrently(server_binary_path):
                     "search_strings", {"binary_name": binary_name, "query": "hello", "limit": 1}
                 ),
                 session.call_tool(
-                    "read_bytes", {"binary_name": binary_name, "address": read_addr, "size": 4}
+                    "read_bytes",
+                    {"binary_name": binary_name, "address": read_addr, "size": len("Hello")},
                 ),
                 session.call_tool(
                     "gen_callgraph", {"binary_name": binary_name, "function_name": decomp_name}
@@ -178,7 +192,8 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
     expected_main = "entry" if platform.system() == "Darwin" else "main"
     name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
     name_two = "_function_two" if platform.system() == "Darwin" else "function_two"
-    tasks = [invoke_tool_concurrently(streamable_server) for _ in range(num_clients)]
+    read_addr = await discover_mapped_string_address(streamable_server)
+    tasks = [invoke_tool_concurrently(streamable_server, read_addr) for _ in range(num_clients)]
     results = await asyncio.gather(*tasks)
 
     assert len(results) == num_clients
@@ -267,13 +282,8 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
         # Read bytes
         read_bytes_result = json.loads(client_responses[10].content[0].text)
         bytes_result = BytesReadResult(**read_bytes_result)
-        assert bytes_result.size == 4
-        if platform.system() == "Darwin":
-            assert bytes_result.data.lower() == "cffaedfe"  # Mach-O 64-bit magic (little-endian)
-            assert bytes_result.address == "100000000"
-        else:
-            assert bytes_result.data == "7f454c46"  # ELF magic
-            assert bytes_result.address == "00100000"
+        assert bytes_result.size == len("Hello")
+        assert bytes_result.data == "48656c6c6f"
 
         # Call graph
         call_graph_result = json.loads(client_responses[11].content[0].text)

--- a/tests/integration/test_concurrent_streamable_client.py
+++ b/tests/integration/test_concurrent_streamable_client.py
@@ -77,13 +77,20 @@ async def wait_for_collections(test_binary, timeout: int = 120) -> None:
 
 
 @pytest.fixture(scope="module")
-def streamable_server(test_binary, ghidra_env):
+def streamable_project_args(tmp_path_factory):
+    project_path = tmp_path_factory.mktemp("concurrent-streamable-project")
+    return ["--project-path", str(project_path), "--project-name", "concurrent_streamable_project"]
+
+
+@pytest.fixture(scope="module")
+def streamable_server(test_binary, ghidra_env, streamable_project_args):
     """Fixture to start the pyghidra-mcp server in a separate process."""
     proc = subprocess.Popen(
         [
             "python",
             "-m",
             "pyghidra_mcp",
+            *streamable_project_args,
             "--wait-for-analysis",
             "--transport",
             "streamable-http",
@@ -123,6 +130,7 @@ async def invoke_tool_concurrently(server_binary_path):
 
             read_addr = "100000000" if platform.system() == "Darwin" else "100000"
             decomp_name = "entry" if platform.system() == "Darwin" else "main"
+            name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
             tasks = [
                 session.call_tool(
                     "decompile_function",
@@ -137,7 +145,7 @@ async def invoke_tool_concurrently(server_binary_path):
                 session.call_tool("list_imports", {"binary_name": binary_name}),
                 session.call_tool(
                     "list_cross_references",
-                    {"binary_name": binary_name, "name_or_address": "function_one"},
+                    {"binary_name": binary_name, "name_or_address": name_one},
                 ),
                 session.call_tool(
                     "search_symbols_by_name", {"binary_name": binary_name, "query": "function"}
@@ -168,6 +176,8 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
     """
     num_clients = 6
     expected_main = "entry" if platform.system() == "Darwin" else "main"
+    name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
+    name_two = "_function_two" if platform.system() == "Darwin" else "function_two"
     tasks = [invoke_tool_concurrently(streamable_server) for _ in range(num_clients)]
     results = await asyncio.gather(*tasks)
 
@@ -186,8 +196,8 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
         search_results_result = json.loads(client_responses[1].content[0].text)
         search_results = SymbolSearchResults(**search_results_result)
         assert len(search_results.symbols) >= 2
-        assert any("function_one" in s.name for s in search_results.symbols)
-        assert any("function_two" in s.name for s in search_results.symbols)
+        assert any(name_one in s.name for s in search_results.symbols)
+        assert any(name_two in s.name for s in search_results.symbols)
 
         # List project binaries
         program_infos_result = json.loads(client_responses[2].content[0].text)
@@ -212,7 +222,7 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
         export_infos_result = json.loads(client_responses[4].content[0].text)
         export_infos = ExportInfos(**export_infos_result)
         assert len(export_infos.exports) > 0
-        assert any(["function_one" in export.name for export in export_infos.exports])
+        assert any([name_one in export.name for export in export_infos.exports])
 
         # List imports
         import_infos_result = json.loads(client_responses[5].content[0].text)
@@ -232,14 +242,14 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
         search_symbols_result = json.loads(client_responses[7].content[0].text)
         search_symbols = SymbolSearchResults(**search_symbols_result)
         assert len(search_symbols.symbols) >= 2
-        assert any("function_one" in s.name for s in search_symbols.symbols)
-        assert any("function_two" in s.name for s in search_symbols.symbols)
+        assert any(name_one in s.name for s in search_symbols.symbols)
+        assert any(name_two in s.name for s in search_symbols.symbols)
 
         # Search code results
         search_code_result = json.loads(client_responses[8].content[0].text)
         code_search_results = CodeSearchResults(**search_code_result)
         assert len(code_search_results.results) > 0
-        assert "function_one" in code_search_results.results[0].function_name
+        assert name_one in code_search_results.results[0].function_name
         # Verify new fields
         assert code_search_results.query == "Function One"
         assert code_search_results.search_mode.value == "semantic"  # Default mode

--- a/tests/integration/test_decompile_function.py
+++ b/tests/integration/test_decompile_function.py
@@ -1,8 +1,11 @@
+import platform
+
 import pytest
 from mcp import ClientSession
 from mcp.client.stdio import stdio_client
 
 from pyghidra_mcp.context import PyGhidraContext
+from tests.benchmark_helpers import benchmark_repeated_tool_call
 
 
 @pytest.mark.asyncio
@@ -11,30 +14,85 @@ async def test_decompile_function_tool(server_params, test_binary):
 
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
-            # Initialize the connection
             await session.initialize()
 
-            # Call the decompile_function tool
             try:
                 binary_name = PyGhidraContext._gen_unique_bin_name(server_params.args[-1])
                 results = await session.call_tool(
                     "decompile_function", {"binary_name": binary_name, "name_or_address": "main"}
                 )
 
-                # Check that we got results
                 assert results is not None
                 assert results.content is not None
                 assert len(results.content) > 0
 
-                # Check that the result contains decompiled code
-                # (this might vary depending on the binary and Ghidra's analysis)
-                # We'll just check that it's not empty
                 text_content = results.content[0].text
                 assert text_content is not None
                 assert len(text_content) > 0
                 assert "main" in text_content
             except Exception as e:
-                # If we get an error, it might be because the function wasn't found
-                # or because of issues with the binary analysis
-                # We'll just check that we got a proper error response
                 assert e is not None
+
+
+@pytest.mark.asyncio
+async def test_decompile_function_repeated_call_timings(server_params):
+    """Measure repeated decompile_function timings for the same binary."""
+
+    name_or_address = "entry" if platform.system() == "Darwin" else "main"
+
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            binary_name = PyGhidraContext._gen_unique_bin_name(server_params.args[-1])
+
+            timing_metrics, results = await benchmark_repeated_tool_call(
+                session,
+                "decompile_function",
+                {"binary_name": binary_name, "name_or_address": name_or_address},
+                scenario="decompile_function",
+            )
+
+            assert timing_metrics.first_call_seconds > 0
+            assert timing_metrics.warm_call_median_seconds > 0
+            assert len(timing_metrics.all_call_seconds[1:]) == 3
+            assert all(timing > 0 for timing in timing_metrics.all_call_seconds[1:])
+            assert all(result for result in results)
+
+
+@pytest.mark.asyncio
+async def test_partial_name_rejected_by_singular_tools(server_params):
+    """Test that singular lookup tools reject partial function names."""
+
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            binary_name = PyGhidraContext._gen_unique_bin_name(server_params.args[-1])
+
+            decompile_response = await session.call_tool(
+                "decompile_function", {"binary_name": binary_name, "name_or_address": "function"}
+            )
+            expected_decompile_error = (
+                "Error executing tool decompile_function: Function or symbol 'function' not found."
+            )
+            assert decompile_response.isError is True
+            assert decompile_response.content[0].text == expected_decompile_error
+
+            xref_response = await session.call_tool(
+                "list_cross_references",
+                {"binary_name": binary_name, "name_or_address": "function"},
+            )
+            assert xref_response.isError is True
+            assert (
+                xref_response.content[0].text
+                == "Error executing tool list_cross_references: Symbol 'function' not found."
+            )
+
+            callgraph_response = await session.call_tool(
+                "gen_callgraph", {"binary_name": binary_name, "function_name": "function"}
+            )
+            assert callgraph_response.isError is True
+            assert (
+                callgraph_response.content[0].text
+                == "Error executing tool gen_callgraph: Function or symbol 'function' not found."
+            )

--- a/tests/integration/test_gen_callgraph.py
+++ b/tests/integration/test_gen_callgraph.py
@@ -38,14 +38,11 @@ async def test_gen_callgraph_tool(server_params, test_binary):
             assert text_content is not None
             assert len(text_content) > 0
 
-            # Check that the content is valid JSON and deserializes to CallGraph
             data = text_content.strip()
             assert data.startswith("{") and data.endswith("}")
             call_graph_data = CallGraphResult.model_validate_json(data)
 
-            assert (
-                call_graph_data.function_name == "function_two"
-            )  # Assuming 'main' is always present/searched for default
+            assert "function_two" in call_graph_data.function_name
             assert call_graph_data.direction == "calling"
             assert call_graph_data.display_type == "flow"
             assert len(call_graph_data.graph) > 0

--- a/tests/integration/test_gen_callgraph.py
+++ b/tests/integration/test_gen_callgraph.py
@@ -1,3 +1,5 @@
+import platform
+
 import pytest
 from mcp import ClientSession
 from mcp.client.stdio import stdio_client
@@ -10,6 +12,7 @@ from pyghidra_mcp.models import CallGraphResult
 async def test_gen_callgraph_tool(server_params, test_binary):
     """Test the gen_callgraph tool."""
 
+    name_two = "_function_two" if platform.system() == "Darwin" else "function_two"
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
             # Initialize the connection
@@ -22,7 +25,7 @@ async def test_gen_callgraph_tool(server_params, test_binary):
                 "gen_callgraph",
                 {
                     "binary_name": binary_name,
-                    "function_name": "function_two",
+                    "function_name": name_two,
                     "direction": "calling",
                     "display_type": "flow",
                 },
@@ -42,7 +45,7 @@ async def test_gen_callgraph_tool(server_params, test_binary):
             assert data.startswith("{") and data.endswith("}")
             call_graph_data = CallGraphResult.model_validate_json(data)
 
-            assert "function_two" in call_graph_data.function_name
+            assert name_two in call_graph_data.function_name
             assert call_graph_data.direction == "calling"
             assert call_graph_data.display_type == "flow"
             assert len(call_graph_data.graph) > 0

--- a/tests/integration/test_import_binaries.py
+++ b/tests/integration/test_import_binaries.py
@@ -1,5 +1,6 @@
 import asyncio
-import os
+import platform
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -8,6 +9,13 @@ from mcp import ClientSession
 from mcp.client.stdio import stdio_client
 
 from pyghidra_mcp.context import PyGhidraContext
+
+
+def _run_compile_command(compile_cmd: list[str]) -> None:
+    result = subprocess.run(compile_cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        cmd_text = " ".join(compile_cmd)
+        raise RuntimeError(f"Compilation failed: {cmd_text}\nSTDERR:\n{result.stderr}")
 
 
 @pytest.fixture()
@@ -33,7 +41,7 @@ int main() {
 """
         )
         bin_file_1 = bin_dir / "program1"
-        os.system(f"gcc -o {bin_file_1} {c_file_1}")
+        _run_compile_command(["gcc", "-o", str(bin_file_1), str(c_file_1)])
 
         # Create second binary in lib/
         c_file_2 = lib_dir / "program2.c"
@@ -46,8 +54,14 @@ void hello() {
 }
 """
         )
-        bin_file_2 = lib_dir / "program2.so"
-        os.system(f"gcc -shared -o {bin_file_2} {c_file_2}")
+        shared_ext = ".dylib" if platform.system() == "Darwin" else ".so"
+        bin_file_2 = lib_dir / f"program2{shared_ext}"
+        compile_cmd = (
+            ["gcc", "-dynamiclib", "-o", str(bin_file_2), str(c_file_2)]
+            if platform.system() == "Darwin"
+            else ["gcc", "-fPIC", "-shared", "-o", str(bin_file_2), str(c_file_2)]
+        )
+        _run_compile_command(compile_cmd)
 
         # Create a non-binary file (should be skipped)
         readme = root / "README.txt"

--- a/tests/integration/test_list_cross_references.py
+++ b/tests/integration/test_list_cross_references.py
@@ -31,6 +31,4 @@ async def test_list_cross_references(server_params):
 
             assert len(cross_reference_infos.cross_references) > 0
             name = "entry" if platform.system() == "Darwin" else "main"
-            assert any(
-                ref.function_name == name for ref in cross_reference_infos.cross_references
-            )
+            assert any(ref.function_name == name for ref in cross_reference_infos.cross_references)

--- a/tests/integration/test_list_cross_references.py
+++ b/tests/integration/test_list_cross_references.py
@@ -1,4 +1,5 @@
 import json
+import platform
 
 import pytest
 from mcp import ClientSession
@@ -29,6 +30,7 @@ async def test_list_cross_references(server_params):
             cross_reference_infos = CrossReferenceInfos(**cross_reference_infos_result)
 
             assert len(cross_reference_infos.cross_references) > 0
+            name = "entry" if platform.system() == "Darwin" else "main"
             assert any(
-                [ref.function_name == "main" for ref in cross_reference_infos.cross_references]
+                ref.function_name == name for ref in cross_reference_infos.cross_references
             )

--- a/tests/integration/test_list_cross_references.py
+++ b/tests/integration/test_list_cross_references.py
@@ -15,6 +15,7 @@ async def test_list_cross_references(server_params):
     Tests the list_cross_references tool to ensure it returns
     a list of cross-references from the binary.
     """
+    name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
@@ -23,7 +24,7 @@ async def test_list_cross_references(server_params):
 
             response = await session.call_tool(
                 "list_cross_references",
-                {"binary_name": binary_name, "name_or_address": "function_one"},
+                {"binary_name": binary_name, "name_or_address": name_one},
             )
 
             cross_reference_infos_result = json.loads(response.content[0].text)

--- a/tests/integration/test_list_exports.py
+++ b/tests/integration/test_list_exports.py
@@ -4,6 +4,7 @@ from mcp.client.stdio import stdio_client
 
 from pyghidra_mcp.context import PyGhidraContext
 from pyghidra_mcp.models import ExportInfos
+from tests.benchmark_helpers import benchmark_repeated_tool_call
 
 
 @pytest.mark.asyncio
@@ -55,3 +56,27 @@ async def test_list_exports(server_params_shared_object):
             )
             export_infos = ExportInfos.model_validate_json(response.content[0].text)
             assert len(export_infos.exports) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_exports_repeated_call_timings(server_params_shared_object):
+    """Measure repeated list_exports timings for the same binary."""
+    async with stdio_client(server_params_shared_object) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            binary_name = PyGhidraContext._gen_unique_bin_name(server_params_shared_object.args[-1])
+
+            timing_metrics, results = await benchmark_repeated_tool_call(
+                session,
+                "list_exports",
+                {"binary_name": binary_name, "query": "shared"},
+                scenario="list_exports",
+                validator=ExportInfos.model_validate_json,
+            )
+
+            assert timing_metrics.first_call_seconds > 0
+            assert timing_metrics.warm_call_median_seconds > 0
+            assert len(timing_metrics.all_call_seconds[1:]) == 3
+            assert all(timing > 0 for timing in timing_metrics.all_call_seconds[1:])
+            assert len(results) == 4
+            assert all(len(export_infos.exports) >= 2 for export_infos in results)

--- a/tests/integration/test_list_exports.py
+++ b/tests/integration/test_list_exports.py
@@ -22,8 +22,8 @@ async def test_list_exports(server_params_shared_object):
             response = await session.call_tool("list_exports", {"binary_name": binary_name})
             export_infos = ExportInfos.model_validate_json(response.content[0].text)
             assert len(export_infos.exports) >= 2
-            assert any("function_one" in export.name for export in export_infos.exports)
-            assert any("function_two" in export.name for export in export_infos.exports)
+            assert any("shared_func_one" in export.name for export in export_infos.exports)
+            assert any("shared_func_two" in export.name for export in export_infos.exports)
             all_exports_list = export_infos.exports
 
             # Test limit
@@ -43,11 +43,11 @@ async def test_list_exports(server_params_shared_object):
 
             # Test query
             response = await session.call_tool(
-                "list_exports", {"binary_name": binary_name, "query": "function_one"}
+                "list_exports", {"binary_name": binary_name, "query": "shared_func_one"}
             )
             export_infos = ExportInfos.model_validate_json(response.content[0].text)
             assert len(export_infos.exports) >= 1
-            assert "function_one" in export_infos.exports[0].name
+            assert "shared_func_one" in export_infos.exports[0].name
 
             # Test query with no results
             response = await session.call_tool(

--- a/tests/integration/test_list_imports.py
+++ b/tests/integration/test_list_imports.py
@@ -12,16 +12,16 @@ async def test_list_imports(server_params_shared_object, test_shared_object):
     async with stdio_client(server_params_shared_object) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
-            binary_name = PyGhidraContext._gen_unique_bin_name(
-                server_params_shared_object.args[-1]
-            )
+            binary_name = PyGhidraContext._gen_unique_bin_name(server_params_shared_object.args[-1])
 
             # Test without params
             response = await session.call_tool("list_imports", {"binary_name": binary_name})
             import_infos = ImportInfos.model_validate_json(response.content[0].text)
             assert len(import_infos.imports) > 0
             assert any("printf" in imp.name for imp in import_infos.imports)
-            assert any("malloc" in imp.name for imp in import_infos.imports) # in shared object but not in binary
+            assert any(
+                "malloc" in imp.name for imp in import_infos.imports
+            )  # in shared object but not in binary
             all_import_names = [imp.name for imp in import_infos.imports]
 
             # Test limit (filter to a known import for determinism)

--- a/tests/integration/test_list_imports.py
+++ b/tests/integration/test_list_imports.py
@@ -4,6 +4,7 @@ from mcp.client.stdio import stdio_client
 
 from pyghidra_mcp.context import PyGhidraContext
 from pyghidra_mcp.models import ImportInfos
+from tests.benchmark_helpers import benchmark_repeated_tool_call
 
 
 @pytest.mark.asyncio
@@ -53,3 +54,27 @@ async def test_list_imports(server_params_shared_object, test_shared_object):
             )
             import_infos = ImportInfos.model_validate_json(response.content[0].text)
             assert len(import_infos.imports) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_imports_repeated_call_timings(server_params_shared_object):
+    """Measure repeated list_imports timings for the same binary."""
+    async with stdio_client(server_params_shared_object) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            binary_name = PyGhidraContext._gen_unique_bin_name(server_params_shared_object.args[-1])
+
+            timing_metrics, results = await benchmark_repeated_tool_call(
+                session,
+                "list_imports",
+                {"binary_name": binary_name, "query": "printf"},
+                scenario="list_imports",
+                validator=ImportInfos.model_validate_json,
+            )
+
+            assert timing_metrics.first_call_seconds > 0
+            assert timing_metrics.warm_call_median_seconds > 0
+            assert len(timing_metrics.all_call_seconds[1:]) == 3
+            assert all(timing > 0 for timing in timing_metrics.all_call_seconds[1:])
+            assert len(results) == 4
+            assert all(len(import_infos.imports) >= 1 for import_infos in results)

--- a/tests/integration/test_list_imports.py
+++ b/tests/integration/test_list_imports.py
@@ -5,63 +5,28 @@ from mcp.client.stdio import stdio_client
 from pyghidra_mcp.context import PyGhidraContext
 from pyghidra_mcp.models import ImportInfos
 
-# @pytest.fixture(scope="module")
-# def test_shared_object():
-#     """
-#     Create a simple shared object for testing.
-#     """
-#     # 1. Write the C source to a temp file
-#     with tempfile.NamedTemporaryFile(mode="w", suffix=".c", delete=False) as f:
-#         f.write(
-#             """
-# #include <stdio.h>
-
-# void function_one() {
-#     printf("Function One");
-# }
-
-# void function_two() {
-#     printf("Function Two");
-# }
-
-# // No main() needed for a shared library
-# """
-#         )
-#         c_file = f.name
-
-#     # 2. Compile as a shared object
-#     so_file = c_file.replace(".c", ".so")
-#     cmd = f"gcc -fPIC -shared -o {so_file} {c_file}"
-#     ret = os.system(cmd)
-#     if ret != 0:
-#         raise RuntimeError(f"Compilation failed: {cmd}")
-
-#     # 3. Yield path to .so for tests
-#     yield so_file
-
-#     # 4. Clean up
-#     os.unlink(c_file)
-#     os.unlink(so_file)
-
 
 @pytest.mark.asyncio
-async def test_list_imports(server_params, test_shared_object):
-    """Test listing imports from a binary."""
-    async with stdio_client(server_params) as (read, write):
+async def test_list_imports(server_params_shared_object, test_shared_object):
+    """Test listing imports from a shared object."""
+    async with stdio_client(server_params_shared_object) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
-            binary_name = PyGhidraContext._gen_unique_bin_name(server_params.args[-1])
+            binary_name = PyGhidraContext._gen_unique_bin_name(
+                server_params_shared_object.args[-1]
+            )
 
             # Test without params
             response = await session.call_tool("list_imports", {"binary_name": binary_name})
             import_infos = ImportInfos.model_validate_json(response.content[0].text)
             assert len(import_infos.imports) > 0
             assert any("printf" in imp.name for imp in import_infos.imports)
-            all_imports_list = import_infos.imports
+            assert any("malloc" in imp.name for imp in import_infos.imports) # in shared object but not in binary
+            all_import_names = [imp.name for imp in import_infos.imports]
 
-            # Test limit
+            # Test limit (filter to a known import for determinism)
             response = await session.call_tool(
-                "list_imports", {"binary_name": binary_name, "limit": 1}
+                "list_imports", {"binary_name": binary_name, "query": "printf", "limit": 1}
             )
             import_infos = ImportInfos.model_validate_json(response.content[0].text)
             assert len(import_infos.imports) == 1
@@ -72,7 +37,7 @@ async def test_list_imports(server_params, test_shared_object):
             )
             import_infos = ImportInfos.model_validate_json(response.content[0].text)
             assert len(import_infos.imports) == 1
-            assert import_infos.imports[0].name == all_imports_list[1].name
+            assert import_infos.imports[0].name in all_import_names
 
             # Test query
             response = await session.call_tool(

--- a/tests/integration/test_multiple_gpr_projects.py
+++ b/tests/integration/test_multiple_gpr_projects.py
@@ -16,7 +16,7 @@ def multi_project_directory():
 
 
 @pytest.fixture(scope="module")
-def server_params_specific_project(multi_project_directory):
+def server_params_specific_project(multi_project_directory, ghidra_env):
     """Server pointing to specific project directory in multi-project directory"""
     project_dir = multi_project_directory / "afd-11"
     return StdioServerParameters(
@@ -30,12 +30,12 @@ def server_params_specific_project(multi_project_directory):
             "afd-11",
             "--wait-for-analysis",
         ],
-        env={"GHIDRA_INSTALL_DIR": "/ghidra"},
+        env=ghidra_env,
     )
 
 
 @pytest.fixture(scope="module")
-def server_params_other_project(multi_project_directory):
+def server_params_other_project(multi_project_directory, ghidra_env):
     """Server pointing to different project directory in same directory"""
     project_dir = multi_project_directory / "macos-test"
     return StdioServerParameters(
@@ -49,7 +49,7 @@ def server_params_other_project(multi_project_directory):
             "macos-test",
             "--wait-for-analysis",
         ],
-        env={"GHIDRA_INSTALL_DIR": "/ghidra"},
+        env=ghidra_env,
     )
 
 
@@ -147,7 +147,7 @@ async def test_projects_are_isolated(
 
 
 @pytest.mark.asyncio
-async def test_shared_base_directory_projects():
+async def test_shared_base_directory_projects(ghidra_env):
     """Test that multiple .gpr projects in same base directory get separate artifact directories"""
     with tempfile.TemporaryDirectory() as temp_dir:
         base_dir = Path(temp_dir)
@@ -167,7 +167,7 @@ async def test_shared_base_directory_projects():
                 "proj1",
                 "--no-threaded",
             ],
-            env={"GHIDRA_INSTALL_DIR": "/ghidra"},
+            env=ghidra_env,
         )
 
         server_params2 = StdioServerParameters(
@@ -181,7 +181,7 @@ async def test_shared_base_directory_projects():
                 "proj2",
                 "--no-threaded",
             ],
-            env={"GHIDRA_INSTALL_DIR": "/ghidra"},
+            env=ghidra_env,
         )
 
         # Start first project

--- a/tests/integration/test_project_path_isolation.py
+++ b/tests/integration/test_project_path_isolation.py
@@ -1,0 +1,42 @@
+import os
+from pathlib import Path
+
+import pytest
+
+SHARED_SERVER_PARAMS_FIXTURES = (
+    "server_params_no_input",
+    "server_params",
+    "server_params_no_thread",
+    "server_params_shared_object",
+)
+
+
+@pytest.fixture(scope="module")
+def ghidra_env():
+    return os.environ.copy()
+
+
+@pytest.fixture(scope="module")
+def test_binary(tmp_path_factory):
+    fake_binary = tmp_path_factory.mktemp("fake-binary") / "fake.bin"
+    fake_binary.write_bytes(b"\x7fELF")
+    return str(fake_binary)
+
+
+@pytest.fixture(scope="module")
+def test_shared_object(tmp_path_factory):
+    fake_shared_object = tmp_path_factory.mktemp("fake-shared-object") / "fake.so"
+    fake_shared_object.write_bytes(b"\x7fELF")
+    return str(fake_shared_object)
+
+
+@pytest.mark.parametrize("fixture_name", SHARED_SERVER_PARAMS_FIXTURES)
+def test_shared_fixtures_use_explicit_project_path(request, fixture_name):
+    server_params = request.getfixturevalue(fixture_name)
+
+    assert "--project-path" in server_params.args
+    project_path_index = server_params.args.index("--project-path") + 1
+    project_path = Path(server_params.args[project_path_index])
+
+    assert project_path.is_absolute()
+    assert project_path.name != "pyghidra_mcp_projects"

--- a/tests/integration/test_read_bytes.py
+++ b/tests/integration/test_read_bytes.py
@@ -4,39 +4,41 @@ Integration test for the read_bytes functionality.
 Simple smoke test to verify read_bytes works through the MCP interface.
 """
 
-import platform
-
 import pytest
 from mcp import ClientSession
 from mcp.client.stdio import stdio_client
 
 from pyghidra_mcp.context import PyGhidraContext
-from pyghidra_mcp.models import BytesReadResult
+from pyghidra_mcp.models import BytesReadResult, StringSearchResults
 
 
 @pytest.mark.asyncio
-async def test_read_bytes_tool(server_params):
+async def test_read_bytes_tool(server_params_no_thread):
     """Test that read_bytes works - basic smoke test."""
-    async with stdio_client(server_params) as (read, write):
+    async with stdio_client(server_params_no_thread) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
 
-            binary_name = PyGhidraContext._gen_unique_bin_name(server_params.args[-1])
+            binary_name = PyGhidraContext._gen_unique_bin_name(server_params_no_thread.args[-1])
 
-            # Try reading from platform-default base addresses
-            address = "100000000" if platform.system() == "Darwin" else "100000"
+            string_response = await session.call_tool(
+                "search_strings",
+                {"binary_name": binary_name, "query": "Hello, World!", "limit": 1},
+            )
+            string_results = StringSearchResults.model_validate_json(
+                string_response.content[0].text
+            )
+            assert len(string_results.strings) == 1
+
             response = await session.call_tool(
-                "read_bytes", {"binary_name": binary_name, "address": address, "size": 4}
+                "read_bytes",
+                {
+                    "binary_name": binary_name,
+                    "address": string_results.strings[0].address,
+                    "size": len("Hello"),
+                },
             )
 
             result = BytesReadResult.model_validate_json(response.content[0].text)
-
-            # Check magic bytes by platform
-            if platform.system() == "Darwin":
-                # Accept either MH_MAGIC_64 (feedfacf) or byte-swapped MH_CIGAM_64 (cffaedfe)
-                assert result.data.lower() in {"feedfacf", "cffaedfe"}
-                assert result.address == "100000000"
-            else:
-                assert result.data == "7f454c46"  # 0x7F + "ELF" in hex
-                assert result.address == "00100000"
-            assert result.size == 4
+            assert result.data == "48656c6c6f"
+            assert result.size == len("Hello")

--- a/tests/integration/test_read_bytes.py
+++ b/tests/integration/test_read_bytes.py
@@ -4,6 +4,7 @@ Integration test for the read_bytes functionality.
 Simple smoke test to verify read_bytes works through the MCP interface.
 """
 
+import platform
 import pytest
 from mcp import ClientSession
 from mcp.client.stdio import stdio_client
@@ -21,13 +22,20 @@ async def test_read_bytes_tool(server_params):
 
             binary_name = PyGhidraContext._gen_unique_bin_name(server_params.args[-1])
 
-            # Try reading from 0x100000 (Ghidra's default ELF analysis base address)
+            # Try reading from platform-default base addresses
+            address = "100000000" if platform.system() == "Darwin" else "100000"
             response = await session.call_tool(
-                "read_bytes", {"binary_name": binary_name, "address": "100000", "size": 4}
+                "read_bytes", {"binary_name": binary_name, "address": address, "size": 4}
             )
 
             result = BytesReadResult.model_validate_json(response.content[0].text)
 
-            # Check if we got ELF magic bytes
-            assert result.data == "7f454c46"  # 0x7F + "ELF" in hex
+            # Check magic bytes by platform
+            if platform.system() == "Darwin":
+                # Accept either MH_MAGIC_64 (feedfacf) or byte-swapped MH_CIGAM_64 (cffaedfe)
+                assert result.data.lower() in {"feedfacf", "cffaedfe"}
+                assert result.address == "100000000"
+            else:
+                assert result.data == "7f454c46"  # 0x7F + "ELF" in hex
+                assert result.address == "00100000"
             assert result.size == 4

--- a/tests/integration/test_read_bytes.py
+++ b/tests/integration/test_read_bytes.py
@@ -5,6 +5,7 @@ Simple smoke test to verify read_bytes works through the MCP interface.
 """
 
 import platform
+
 import pytest
 from mcp import ClientSession
 from mcp.client.stdio import stdio_client

--- a/tests/integration/test_search_code.py
+++ b/tests/integration/test_search_code.py
@@ -1,128 +1,106 @@
-import os
-import platform
-import tempfile
-
 import pytest
-from mcp import ClientSession, StdioServerParameters
+from mcp import ClientSession
 from mcp.client.stdio import stdio_client
 
 from pyghidra_mcp.context import PyGhidraContext
 from pyghidra_mcp.models import CodeSearchResults, DecompiledFunction
-
-
-@pytest.fixture(scope="module")
-def test_binary():
-    """Create a simple test binary for testing."""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".c", delete=False) as f:
-        f.write(
-            """
-#include <stdio.h>
-
-void function_to_find() {
-    printf("This is a function to be found by search_code.");
-}
-
-int main() {
-    printf("Hello, World!");
-    function_to_find();
-    return 0;
-}
-"""
-        )
-        c_file = f.name
-
-    bin_file = c_file.replace(".c", "")
-
-    os.system(f"gcc -o {bin_file} {c_file}")
-
-    yield bin_file
-
-    os.unlink(c_file)
-    os.unlink(bin_file)
-
-
-@pytest.fixture(scope="module")
-def search_code_project_args(tmp_path_factory):
-    project_path = tmp_path_factory.mktemp("search-code-project")
-    return ["--project-path", str(project_path), "--project-name", "search_code_project"]
-
-
-@pytest.fixture(scope="module")
-def server_params(test_binary, ghidra_env, search_code_project_args):
-    """Get server parameters with a test binary."""
-    return StdioServerParameters(
-        command="python",
-        args=["-m", "pyghidra_mcp", *search_code_project_args, "--no-threaded", test_binary],
-        env=ghidra_env,
-    )
+from tests.benchmark_helpers import (
+    benchmark_repeated_tool_call,
+    call_tool_model,
+    platform_function_name,
+)
 
 
 @pytest.mark.asyncio
-async def test_search_code(server_params):
+async def test_search_code(server_params_no_thread):
     """
     Tests searching for code using similarity search.
     """
-    name = "_function_to_find" if platform.system() == "Darwin" else "function_to_find"
-    async with stdio_client(server_params) as (read, write):
+    name = platform_function_name("function_one")
+    async with stdio_client(server_params_no_thread) as (read, write):
         async with ClientSession(read, write) as session:
-            # Initialize the connection
             await session.initialize()
 
-            binary_name = PyGhidraContext._gen_unique_bin_name(server_params.args[-1])
+            binary_name = PyGhidraContext._gen_unique_bin_name(server_params_no_thread.args[-1])
 
-            # 1. Decompile a function to get its code to use as a query
-            decompile_response = await session.call_tool(
+            decompiled_function = await call_tool_model(
+                session,
                 "decompile_function",
                 {"binary_name": binary_name, "name_or_address": name},
-            )
-
-            decompiled_function = DecompiledFunction.model_validate_json(
-                decompile_response.content[0].text
+                DecompiledFunction,
             )
             query_code = decompiled_function.code
 
-            # 2. Use the decompiled code to search for the function
-            search_response = await session.call_tool(
-                "search_code", {"binary_name": binary_name, "query": query_code, "limit": 1}
+            search_results = await call_tool_model(
+                session,
+                "search_code",
+                {"binary_name": binary_name, "query": query_code, "limit": 1},
+                CodeSearchResults,
             )
 
-            search_results = CodeSearchResults.model_validate_json(search_response.content[0].text)
-
-            # 3. Assert the results
             assert len(search_results.results) > 0
-            # The top result should be the function we searched for
             assert name in search_results.results[0].function_name
 
-            # 4. Verify new fields are populated
-            # 4. Verify new fields are populated
             assert search_results.query == query_code
-            assert search_results.search_mode.value == "semantic"  # Default mode
+            assert search_results.search_mode.value == "semantic"
             assert search_results.returned_count > 0
-            assert search_results.literal_total >= 0  # Dual-mode count
+            assert search_results.literal_total >= 0
             assert search_results.semantic_total > 0
             assert search_results.total_functions > 0
-            # semantic_total should be <= total_functions
             assert search_results.semantic_total <= search_results.total_functions
 
 
 @pytest.mark.asyncio
-async def test_search_code_literal(server_params):
+async def test_search_code_repeated_semantic_timings(server_params_no_thread):
+    """Measure repeated semantic search_code timings for the same binary."""
+    name = platform_function_name("function_one")
+    async with stdio_client(server_params_no_thread) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            binary_name = PyGhidraContext._gen_unique_bin_name(server_params_no_thread.args[-1])
+
+            decompiled_function = await call_tool_model(
+                session,
+                "decompile_function",
+                {"binary_name": binary_name, "name_or_address": name},
+                DecompiledFunction,
+            )
+            query_code = decompiled_function.code
+
+            timing_metrics, results = await benchmark_repeated_tool_call(
+                session,
+                "search_code",
+                {"binary_name": binary_name, "query": query_code, "limit": 1},
+                scenario="search_code_semantic",
+                validator=CodeSearchResults.model_validate_json,
+            )
+
+            assert timing_metrics.first_call_seconds > 0
+            assert timing_metrics.warm_call_median_seconds > 0
+            assert len(timing_metrics.all_call_seconds[1:]) == 3
+            assert all(timing > 0 for timing in timing_metrics.all_call_seconds[1:])
+            assert len(results) == 4
+            for search_results in results:
+                assert len(search_results.results) > 0
+                assert name in search_results.results[0].function_name
+                assert search_results.search_mode.value == "semantic"
+
+
+@pytest.mark.asyncio
+async def test_search_code_literal(server_params_no_thread):
     """
     Tests searching for code using literal (exact string) search mode.
     """
-    async with stdio_client(server_params) as (read, write):
+    async with stdio_client(server_params_no_thread) as (read, write):
         async with ClientSession(read, write) as session:
-            # Initialize the connection
             await session.initialize()
 
-            binary_name = PyGhidraContext._gen_unique_bin_name(server_params.args[-1])
+            binary_name = PyGhidraContext._gen_unique_bin_name(server_params_no_thread.args[-1])
 
-            # Search for a literal string that should be in the decompiled code
-            # "printf" should appear in the decompiled output
-            literal_query = "printf"
+            literal_query = "Function One"
 
-            # Use literal search mode
-            search_response = await session.call_tool(
+            search_results = await call_tool_model(
+                session,
                 "search_code",
                 {
                     "binary_name": binary_name,
@@ -130,16 +108,45 @@ async def test_search_code_literal(server_params):
                     "limit": 5,
                     "search_mode": "literal",
                 },
+                CodeSearchResults,
             )
 
-            search_results = CodeSearchResults.model_validate_json(search_response.content[0].text)
-
-            # Assert the results
             assert search_results.search_mode.value == "literal"
-            assert search_results.literal_total > 0  # Should find functions containing "printf"
+            assert search_results.literal_total > 0
 
-            # Each result should contain the literal query string
             for result in search_results.results:
                 assert literal_query in result.code
                 assert result.search_mode.value == "literal"
-                assert result.similarity == 1.0  # Literal matches have similarity 1.0
+                assert result.similarity == 1.0
+
+
+@pytest.mark.asyncio
+async def test_search_code_repeated_literal_timings(server_params_no_thread):
+    """Measure repeated literal search_code timings for the same binary."""
+    async with stdio_client(server_params_no_thread) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            binary_name = PyGhidraContext._gen_unique_bin_name(server_params_no_thread.args[-1])
+
+            timing_metrics, results = await benchmark_repeated_tool_call(
+                session,
+                "search_code",
+                {
+                    "binary_name": binary_name,
+                    "query": "Function One",
+                    "limit": 5,
+                    "search_mode": "literal",
+                },
+                scenario="search_code_literal",
+                validator=CodeSearchResults.model_validate_json,
+            )
+
+            assert timing_metrics.first_call_seconds > 0
+            assert timing_metrics.warm_call_median_seconds > 0
+            assert len(timing_metrics.all_call_seconds[1:]) == 3
+            assert all(timing > 0 for timing in timing_metrics.all_call_seconds[1:])
+            assert len(results) == 4
+            for search_results in results:
+                assert search_results.search_mode.value == "literal"
+                assert search_results.literal_total > 0
+                assert len(search_results.results) > 0

--- a/tests/integration/test_search_code.py
+++ b/tests/integration/test_search_code.py
@@ -41,14 +41,12 @@ int main() {
 
 
 @pytest.fixture(scope="module")
-def server_params(test_binary):
+def server_params(test_binary, ghidra_env):
     """Get server parameters with a test binary."""
     return StdioServerParameters(
-        command="python",  # Executable
-        # Run with test binary
-        args=["-m", "pyghidra_mcp", "--no-threaded", test_binary],  # no-thread for search_code
-        # Optional environment variables
-        env={"GHIDRA_INSTALL_DIR": "/ghidra"},
+        command="python",
+        args=["-m", "pyghidra_mcp", "--no-threaded", test_binary],
+        env=ghidra_env,
     )
 
 

--- a/tests/integration/test_search_code.py
+++ b/tests/integration/test_search_code.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import tempfile
 
 import pytest
@@ -41,11 +42,17 @@ int main() {
 
 
 @pytest.fixture(scope="module")
-def server_params(test_binary, ghidra_env):
+def search_code_project_args(tmp_path_factory):
+    project_path = tmp_path_factory.mktemp("search-code-project")
+    return ["--project-path", str(project_path), "--project-name", "search_code_project"]
+
+
+@pytest.fixture(scope="module")
+def server_params(test_binary, ghidra_env, search_code_project_args):
     """Get server parameters with a test binary."""
     return StdioServerParameters(
         command="python",
-        args=["-m", "pyghidra_mcp", "--no-threaded", test_binary],
+        args=["-m", "pyghidra_mcp", *search_code_project_args, "--no-threaded", test_binary],
         env=ghidra_env,
     )
 
@@ -55,6 +62,7 @@ async def test_search_code(server_params):
     """
     Tests searching for code using similarity search.
     """
+    name = "_function_to_find" if platform.system() == "Darwin" else "function_to_find"
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
             # Initialize the connection
@@ -65,7 +73,7 @@ async def test_search_code(server_params):
             # 1. Decompile a function to get its code to use as a query
             decompile_response = await session.call_tool(
                 "decompile_function",
-                {"binary_name": binary_name, "name_or_address": "function_to_find"},
+                {"binary_name": binary_name, "name_or_address": name},
             )
 
             decompiled_function = DecompiledFunction.model_validate_json(
@@ -83,7 +91,7 @@ async def test_search_code(server_params):
             # 3. Assert the results
             assert len(search_results.results) > 0
             # The top result should be the function we searched for
-            assert "function_to_find" in search_results.results[0].function_name
+            assert name in search_results.results[0].function_name
 
             # 4. Verify new fields are populated
             # 4. Verify new fields are populated

--- a/tests/integration/test_search_functions.py
+++ b/tests/integration/test_search_functions.py
@@ -9,21 +9,20 @@ from pyghidra_mcp.models import SymbolSearchResults
 
 
 @pytest.mark.asyncio
-async def test_search_symbols_by_name(server_params):
-    """
-    Tests searching for symbols by name.
-    """
+async def test_search_functions_by_name(server_params):
+    """Tests searching for functions by name."""
     name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
     name_two = "_function_two" if platform.system() == "Darwin" else "function_two"
+
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
-            # Initialize the connection
             await session.initialize()
 
             binary_name = PyGhidraContext._gen_unique_bin_name(server_params.args[-1])
 
             response = await session.call_tool(
-                "search_symbols_by_name", {"binary_name": binary_name, "query": "function"}
+                "search_functions_by_name",
+                {"binary_name": binary_name, "query": "function_"},
             )
 
             search_results = SymbolSearchResults.model_validate_json(response.content[0].text)

--- a/tests/integration/test_search_symbols.py
+++ b/tests/integration/test_search_symbols.py
@@ -6,6 +6,7 @@ from mcp.client.stdio import stdio_client
 
 from pyghidra_mcp.context import PyGhidraContext
 from pyghidra_mcp.models import SymbolSearchResults
+from tests.benchmark_helpers import benchmark_repeated_tool_call
 
 
 @pytest.mark.asyncio
@@ -30,3 +31,51 @@ async def test_search_symbols_by_name(server_params):
             assert len(search_results.symbols) >= 2
             assert any(name_one in s.name for s in search_results.symbols)
             assert any(name_two in s.name for s in search_results.symbols)
+
+
+@pytest.mark.asyncio
+async def test_search_symbols_by_name_repeated_call_timings(server_params):
+    """Measure repeated search_symbols_by_name timings for the same binary."""
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            binary_name = PyGhidraContext._gen_unique_bin_name(server_params.args[-1])
+
+            timing_metrics, results = await benchmark_repeated_tool_call(
+                session,
+                "search_symbols_by_name",
+                {"binary_name": binary_name, "query": "function"},
+                scenario="search_symbols_by_name",
+                validator=SymbolSearchResults.model_validate_json,
+            )
+
+            assert timing_metrics.first_call_seconds > 0
+            assert timing_metrics.warm_call_median_seconds > 0
+            assert len(timing_metrics.all_call_seconds[1:]) == 3
+            assert all(timing > 0 for timing in timing_metrics.all_call_seconds[1:])
+            assert len(results) == 4
+            assert all(len(search_results.symbols) >= 2 for search_results in results)
+
+
+@pytest.mark.asyncio
+async def test_search_functions_by_name(server_params):
+    """
+    Tests searching for functions by name.
+    """
+    name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
+    name_two = "_function_two" if platform.system() == "Darwin" else "function_two"
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            binary_name = PyGhidraContext._gen_unique_bin_name(server_params.args[-1])
+
+            response = await session.call_tool(
+                "search_functions_by_name", {"binary_name": binary_name, "query": "function"}
+            )
+
+            search_results = SymbolSearchResults.model_validate_json(response.content[0].text)
+            assert len(search_results.symbols) >= 2
+            assert any(name_one in s.name for s in search_results.symbols)
+            assert any(name_two in s.name for s in search_results.symbols)
+            assert all(s.type == "Function" for s in search_results.symbols)

--- a/tests/integration/test_sse_client.py
+++ b/tests/integration/test_sse_client.py
@@ -18,12 +18,19 @@ print(f"MCP_BASE_URL: {base_url}")
 
 
 @pytest.fixture(scope="module")
-def sse_server(test_binary, ghidra_env):
+def sse_project_args(tmp_path_factory):
+    project_path = tmp_path_factory.mktemp("sse-project")
+    return ["--project-path", str(project_path), "--project-name", "sse_client_project"]
+
+
+@pytest.fixture(scope="module")
+def sse_server(test_binary, ghidra_env, sse_project_args):
     proc = subprocess.Popen(
         [
             "python",
             "-m",
             "pyghidra_mcp",
+            *sse_project_args,
             "--no-threaded",
             "--wait-for-analysis",
             "--transport",

--- a/tests/integration/test_sse_client.py
+++ b/tests/integration/test_sse_client.py
@@ -21,10 +21,13 @@ print(f"MCP_BASE_URL: {base_url}")
 def sse_server(test_binary, ghidra_env):
     proc = subprocess.Popen(
         [
-            "python", "-m", "pyghidra_mcp",
+            "python",
+            "-m",
+            "pyghidra_mcp",
             "--no-threaded",
             "--wait-for-analysis",
-            "--transport", "sse",
+            "--transport",
+            "sse",
             test_binary,
         ],
         env=ghidra_env,

--- a/tests/integration/test_sse_client.py
+++ b/tests/integration/test_sse_client.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import platform
 import subprocess
 import time
 
@@ -13,24 +14,27 @@ from pyghidra_mcp.context import PyGhidraContext
 from pyghidra_mcp.models import DecompiledFunction
 
 base_url = os.getenv("MCP_BASE_URL", "http://127.0.0.1:8000")
-
 print(f"MCP_BASE_URL: {base_url}")
 
 
 @pytest.fixture(scope="module")
-def sse_server():
-    binary_name = "/bin/ls"
-    # Start the SSE server
+def sse_server(test_binary, ghidra_env):
     proc = subprocess.Popen(
-        ["python", "-m", "pyghidra_mcp", "--no-threaded", "--transport", "sse", binary_name],
-        env={**os.environ, "GHIDRA_INSTALL_DIR": "/ghidra"},
+        [
+            "python", "-m", "pyghidra_mcp",
+            "--no-threaded",
+            "--wait-for-analysis",
+            "--transport", "sse",
+            test_binary,
+        ],
+        env=ghidra_env,
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
     )
 
     async def wait_for_server(timeout=240):
         async with aiohttp.ClientSession() as session:
-            for _ in range(timeout):  # Poll for 60 seconds
+            for _ in range(timeout):
                 try:
                     async with session.get(f"{base_url}/sse") as response:
                         if response.status == 200:
@@ -40,11 +44,16 @@ def sse_server():
                 await asyncio.sleep(1)
             raise RuntimeError("Server did not start in time")
 
-    asyncio.run(wait_for_server())
+    try:
+        asyncio.run(wait_for_server())
+    except Exception:
+        proc.terminate()
+        proc.wait()
+        raise
 
     time.sleep(2)
 
-    yield binary_name
+    yield test_binary
     proc.terminate()
     proc.wait()
 
@@ -60,14 +69,15 @@ async def test_sse_client_smoke(sse_server):
             binary_name = PyGhidraContext._gen_unique_bin_name(sse_server)
 
             # Decompile a function
+            name = "entry" if platform.system() == "Darwin" else "main"
             results = await session.call_tool(
                 "decompile_function",
-                {"binary_name": binary_name, "name_or_address": "entry"},
+                {"binary_name": binary_name, "name_or_address": name},
             )
             # We have results!
             assert results is not None
             content = json.loads(results.content[0].text)
             assert isinstance(content, dict)
             assert len(content.keys()) == len(DecompiledFunction.model_fields.keys())
-            assert "entry" in content["code"]
+            assert f"{name}(" in content["code"]
             print(json.dumps(content, indent=2))

--- a/tests/integration/test_stdio_client.py
+++ b/tests/integration/test_stdio_client.py
@@ -2,16 +2,36 @@ import pytest
 from mcp import ClientSession
 from mcp.client.stdio import stdio_client
 
+from tests.benchmark_helpers import collect_list_tools_metrics
+
+TRACKED_TOOL_NAMES = {
+    "search_code",
+    "search_symbols_by_name",
+    "list_exports",
+    "list_imports",
+    "list_cross_references",
+    "gen_callgraph",
+    "list_project_binaries",
+}
+LIST_TOOLS_PAYLOAD_BYTES_BUDGET = 16000
+TOOL_TOTAL_JSON_BUDGETS = {
+    "search_code": 2900,
+    "search_symbols_by_name": 1450,
+    "list_exports": 950,
+    "list_imports": 950,
+    "list_cross_references": 1250,
+    "gen_callgraph": 2000,
+    "list_project_binaries": 1450,
+}
+
 
 @pytest.mark.asyncio
 async def test_stdio_client_initialization(server_params):
     """Test stdio client initialization."""
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
-            # Initialize the connection
             result = await session.initialize()
 
-            # Check that we got a proper response
             assert result is not None
             assert hasattr(result, "protocolVersion")
 
@@ -21,17 +41,74 @@ async def test_stdio_client_list_tools(server_params):
     """Test listing available tools."""
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
-            # Initialize the connection
             await session.initialize()
 
-            # List available tools
             tools = await session.list_tools()
 
-            # Check that we got a response
             assert tools is not None
-            # Check that we have at least the decompile_function tool
             assert any(tool.name == "decompile_function" for tool in tools.tools)
+            assert any(tool.name == "search_functions_by_name" for tool in tools.tools)
             assert any(tool.name == "list_project_binaries" for tool in tools.tools)
+
+
+@pytest.mark.asyncio
+async def test_stdio_client_list_tools_surface_metrics(server_params):
+    """Measure real MCP tool payload sizes from list_tools."""
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            tools = await session.list_tools()
+            payload_bytes, tool_metrics = collect_list_tools_metrics(tools)
+            largest_tools = [
+                metric.to_dict()
+                for metric in sorted(
+                    tool_metrics.values(),
+                    key=lambda metric: metric.total_json_bytes,
+                    reverse=True,
+                )[:7]
+            ]
+
+            assert TRACKED_TOOL_NAMES.issubset(tool_metrics)
+            assert payload_bytes <= LIST_TOOLS_PAYLOAD_BYTES_BUDGET, {
+                "payload_bytes": payload_bytes,
+                "largest_tools": largest_tools,
+            }
+            for name in TRACKED_TOOL_NAMES:
+                metrics = tool_metrics[name]
+                assert metrics.description_length > 0
+                assert metrics.input_schema_bytes > 0
+                assert metrics.output_schema_bytes > 0
+                assert metrics.total_json_bytes <= TOOL_TOTAL_JSON_BUDGETS[name], {
+                    "name": name,
+                    "metrics": metrics.to_dict(),
+                    "largest_tools": largest_tools,
+                }
+
+
+@pytest.mark.asyncio
+async def test_stdio_client_list_tools_schema_contracts(server_params):
+    """Verify compatibility-sensitive MCP schemas for tool discovery."""
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            tools = await session.list_tools()
+            tool_entries = {
+                tool.name: tool.model_dump(mode="json", by_alias=True, exclude_none=True)
+                for tool in tools.tools
+            }
+
+            list_project_binaries_schema = tool_entries["list_project_binaries"]["inputSchema"]
+            assert list_project_binaries_schema["type"] == "object"
+            assert list_project_binaries_schema.get("properties") == {}
+            assert list_project_binaries_schema.get("additionalProperties") is False
+
+            metadata_output_schema = tool_entries["list_project_binary_metadata"].get(
+                "outputSchema"
+            )
+            assert metadata_output_schema is not None
+            assert metadata_output_schema["type"] == "object"
 
 
 @pytest.mark.asyncio
@@ -39,11 +116,8 @@ async def test_stdio_client_list_resources(server_params):
     """Test listing available resources."""
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
-            # Initialize the connection
             await session.initialize()
 
-            # List available resources
             resources = await session.list_resources()
 
-            # Check that we got a response
             assert resources is not None

--- a/tests/integration/test_streamable_client.py
+++ b/tests/integration/test_streamable_client.py
@@ -17,13 +17,20 @@ base_url = os.getenv("MCP_BASE_URL", "http://127.0.0.1:8000")
 
 
 @pytest.fixture(scope="module")
-def streamable_server(test_binary, ghidra_env):
+def streamable_project_args(tmp_path_factory):
+    project_path = tmp_path_factory.mktemp("streamable-project")
+    return ["--project-path", str(project_path), "--project-name", "streamable_client_project"]
+
+
+@pytest.fixture(scope="module")
+def streamable_server(test_binary, ghidra_env, streamable_project_args):
     """Fixture to start the pyghidra-mcp server in a separate process."""
     proc = subprocess.Popen(
         [
             "python",
             "-m",
             "pyghidra_mcp",
+            *streamable_project_args,
             "--wait-for-analysis",
             "--transport",
             "streamable-http",

--- a/tests/integration/test_streamable_client.py
+++ b/tests/integration/test_streamable_client.py
@@ -1,13 +1,14 @@
 import asyncio
 import json
 import os
+import platform
 import subprocess
 import time
 
 import aiohttp
 import pytest
 from mcp.client.session import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 from pyghidra_mcp.context import PyGhidraContext
 from pyghidra_mcp.models import DecompiledFunction
@@ -16,7 +17,7 @@ base_url = os.getenv("MCP_BASE_URL", "http://127.0.0.1:8000")
 
 
 @pytest.fixture(scope="module")
-def streamable_server(test_binary):
+def streamable_server(test_binary, ghidra_env):
     """Fixture to start the pyghidra-mcp server in a separate process."""
     proc = subprocess.Popen(
         [
@@ -28,14 +29,14 @@ def streamable_server(test_binary):
             "streamable-http",
             test_binary,
         ],
-        env={**os.environ, "GHIDRA_INSTALL_DIR": "/ghidra"},
+        env=ghidra_env,
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
     )
 
     async def wait_for_server(timeout=240):
         async with aiohttp.ClientSession() as session:
-            for _ in range(timeout):  # Poll for 20 seconds
+            for _ in range(timeout):
                 try:
                     async with session.get(f"{base_url}/mcp") as response:
                         if response.status == 406:
@@ -45,7 +46,12 @@ def streamable_server(test_binary):
                 await asyncio.sleep(1)
             raise RuntimeError("Server did not start in time")
 
-    asyncio.run(wait_for_server())
+    try:
+        asyncio.run(wait_for_server())
+    except Exception:
+        proc.terminate()
+        proc.wait()
+        raise
 
     time.sleep(2)
 
@@ -56,7 +62,7 @@ def streamable_server(test_binary):
 
 @pytest.mark.asyncio
 async def test_streamable_client_smoke(streamable_server):
-    async with streamablehttp_client(f"{base_url}/mcp") as (
+    async with streamable_http_client(f"{base_url}/mcp") as (
         read_stream,
         write_stream,
         _,
@@ -69,14 +75,15 @@ async def test_streamable_client_smoke(streamable_server):
             binary_name = PyGhidraContext._gen_unique_bin_name(streamable_server)
 
             # Decompile a function
+            name = "entry" if platform.system() == "Darwin" else "main"
             results = await session.call_tool(
                 "decompile_function",
-                {"binary_name": binary_name, "name_or_address": "main"},
+                {"binary_name": binary_name, "name_or_address": name},
             )
             # We have results!
             assert results is not None
             content = json.loads(results.content[0].text)
             assert isinstance(content, dict)
             assert len(content.keys()) == len(DecompiledFunction.model_fields.keys())
-            assert "main(void)" in content["code"]
+            assert f"{name}(" in content["code"]
             print(json.dumps(content, indent=2))

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,4 +1,5 @@
 from pyghidra_mcp.models import (
+    BinaryMetadata,
     BytesReadResult,
     CodeSearchResult,
     CodeSearchResults,
@@ -53,6 +54,13 @@ def test_program_basic_infos_model():
     assert len(infos.programs) == 2
     assert infos.programs[0].name == "test_program1"
     assert infos.programs[1].analysis_complete is False
+
+
+def test_binary_metadata_model():
+    """Test the BinaryMetadata root model."""
+    metadata = BinaryMetadata({"Compiler": "gcc", "Address Size": 64})
+    assert metadata.root["Compiler"] == "gcc"
+    assert metadata.root["Address Size"] == 64
 
 
 def test_program_info_model():

--- a/tests/unit/test_tool_optimization.py
+++ b/tests/unit/test_tool_optimization.py
@@ -1,0 +1,359 @@
+from pyghidra_mcp.models import SearchMode
+from tests.benchmark_helpers import (
+    FakeCodeCollection,
+    FakeFunction,
+    FakeMcpTool,
+    FakeProgram,
+    FakeSymbol,
+    collect_internal_call_counts,
+    get_program_tools,
+    json_size,
+    make_runtime_program_info,
+    tool_surface_metrics,
+)
+
+
+def test_tool_surface_metrics_measure_description_and_schema_sizes():
+    tool = FakeMcpTool(
+        name="search_code",
+        description="Search binary code.",
+        input_schema={"type": "object", "properties": {"query": {"type": "string"}}},
+        output_schema={"type": "object", "properties": {"results": {"type": "array"}}},
+    )
+
+    metrics = tool_surface_metrics(tool)
+
+    assert metrics.description_length == len("Search binary code.")
+    assert metrics.input_schema_bytes == json_size(tool.model_dump()["inputSchema"])
+    assert metrics.output_schema_bytes == json_size(tool.model_dump()["outputSchema"])
+    assert metrics.total_json_bytes == json_size(tool.model_dump())
+
+
+def test_search_code_semantic_preserves_contract_and_avoids_literal_page_fetch():
+    code_collection = FakeCodeCollection(
+        documents=[
+            {
+                "id": "func1",
+                "document": "printf alpha branch with extra text",
+                "metadata": {"function_name": "func1"},
+            },
+            {
+                "id": "func2",
+                "document": "printf beta branch with extra text",
+                "metadata": {"function_name": "func2"},
+            },
+            {
+                "id": "func3",
+                "document": "gamma branch without literal match",
+                "metadata": {"function_name": "func3"},
+            },
+        ],
+        query_results=[
+            {
+                "id": "func1",
+                "document": "printf alpha branch with extra text",
+                "metadata": {"function_name": "func1"},
+                "distance": 0.0,
+            },
+            {
+                "id": "func2",
+                "document": "printf beta branch with extra text",
+                "metadata": {"function_name": "func2"},
+                "distance": 1.0,
+            },
+            {
+                "id": "func3",
+                "document": "gamma branch without literal match",
+                "metadata": {"function_name": "func3"},
+                "distance": 9.0,
+            },
+        ],
+    )
+    program_info = make_runtime_program_info(code_collection=code_collection)
+    tools = get_program_tools(program_info)
+
+    results = tools.search_code(
+        query="printf",
+        limit=2,
+        offset=1,
+        search_mode=SearchMode.SEMANTIC,
+        include_full_code=False,
+        preview_length=10,
+        similarity_threshold=0.4,
+    )
+    tools.search_code(query="printf", limit=1, offset=0, search_mode=SearchMode.SEMANTIC)
+
+    assert code_collection.count_calls == 1
+    assert len(code_collection.get_calls) == 2
+    assert all(call["include"] == [] for call in code_collection.get_calls)
+    assert all(call["limit"] is None for call in code_collection.get_calls)
+    assert all(call["offset"] is None for call in code_collection.get_calls)
+    assert len(code_collection.query_calls) == 2
+
+    assert results.query == "printf"
+    assert results.search_mode == SearchMode.SEMANTIC
+    assert results.offset == 1
+    assert results.limit == 2
+    assert results.literal_total == 2
+    assert results.semantic_total == 2
+    assert results.total_functions == 3
+    assert results.returned_count == 1
+    assert results.results[0].function_name == "func2"
+    assert results.results[0].preview == "printf bet..."
+    assert results.results[0].code == "printf bet..."
+    assert results.results[0].similarity == 0.5
+
+
+def test_search_code_literal_uses_paginated_fetch_and_preview_contract():
+    code_collection = FakeCodeCollection(
+        documents=[
+            {
+                "id": "func1",
+                "document": "printf alpha branch with extra text",
+                "metadata": {"function_name": "func1"},
+            },
+            {
+                "id": "func2",
+                "document": "printf beta branch with extra text",
+                "metadata": {"function_name": "func2"},
+            },
+            {
+                "id": "func3",
+                "document": "gamma branch without literal match",
+                "metadata": {"function_name": "func3"},
+            },
+        ]
+    )
+    program_info = make_runtime_program_info(code_collection=code_collection)
+    tools = get_program_tools(program_info)
+
+    results = tools.search_code(
+        query="printf",
+        limit=1,
+        offset=1,
+        search_mode=SearchMode.LITERAL,
+        include_full_code=False,
+        preview_length=6,
+    )
+
+    assert code_collection.count_calls == 1
+    assert len(code_collection.get_calls) == 2
+    assert code_collection.get_calls[0]["include"] == []
+    assert code_collection.get_calls[0]["limit"] is None
+    assert code_collection.get_calls[0]["offset"] is None
+    assert code_collection.get_calls[1]["include"] == ["metadatas", "documents"]
+    assert code_collection.get_calls[1]["limit"] == 1
+    assert code_collection.get_calls[1]["offset"] == 1
+    assert len(code_collection.query_calls) == 0
+
+    assert results.search_mode == SearchMode.LITERAL
+    assert results.offset == 1
+    assert results.limit == 1
+    assert results.literal_total == 2
+    assert results.semantic_total == 3
+    assert results.total_functions == 3
+    assert results.returned_count == 1
+    assert results.results[0].function_name == "func2"
+    assert results.results[0].preview == "printf..."
+    assert results.results[0].code == "printf..."
+    assert results.results[0].similarity == 1.0
+
+
+def test_search_symbols_by_name_paginates_before_refcounts():
+    symbols = [
+        FakeSymbol("match_one", "0x1"),
+        FakeSymbol("match_two", "0x2"),
+        FakeSymbol("match_three", "0x3"),
+        FakeSymbol("other", "0x4"),
+    ]
+    program = FakeProgram(
+        symbols=symbols,
+        references_by_address={
+            "0x1": [object(), object()],
+            "0x2": [object()],
+            "0x3": [object(), object(), object()],
+        },
+    )
+    program_info = make_runtime_program_info(program=program)
+    tools = get_program_tools(program_info)
+
+    second_page = tools.search_symbols_by_name("match", offset=1, limit=1)
+    first_page = tools.search_symbols_by_name("match", offset=0, limit=1)
+
+    assert program.symbol_table.all_symbols_calls == 1
+    assert program.reference_manager.calls == ["0x2", "0x1"]
+    assert [symbol.name for symbol in second_page] == ["match_two"]
+    assert [symbol.refcount for symbol in second_page] == [1]
+    assert [symbol.name for symbol in first_page] == ["match_one"]
+    assert [symbol.refcount for symbol in first_page] == [2]
+
+
+def test_search_functions_by_name_paginates_before_refcounts():
+    func_one = FakeFunction(FakeSymbol("func_one", "0x10"), "0x10")
+    func_two = FakeFunction(FakeSymbol("func_two", "0x20"), "0x20")
+    func_three = FakeFunction(FakeSymbol("func_three", "0x30"), "0x30")
+    program = FakeProgram(
+        functions=[func_one, func_two, func_three],
+        references_by_address={
+            "0x10": [object()],
+            "0x20": [object(), object()],
+            "0x30": [object(), object(), object()],
+        },
+    )
+    program_info = make_runtime_program_info(program=program)
+    tools = get_program_tools(program_info)
+
+    second_page = tools.search_functions_by_name("func", offset=1, limit=1)
+    first_page = tools.search_functions_by_name("func", offset=0, limit=1)
+
+    assert program.function_manager.get_functions_calls == 1
+    assert program.reference_manager.calls == ["0x20", "0x10"]
+    assert [symbol.name for symbol in second_page] == ["func_two"]
+    assert [symbol.refcount for symbol in second_page] == [2]
+    assert [symbol.name for symbol in first_page] == ["func_one"]
+    assert [symbol.refcount for symbol in first_page] == [1]
+
+
+def test_list_exports_and_imports_reuse_cached_symbol_views():
+    export_one = FakeSymbol("shared_func_one", "0x1", external_entry=True)
+    helper = FakeSymbol("helper", "0x2")
+    export_two = FakeSymbol("shared_func_two", "0x3", external_entry=True)
+    import_one = FakeSymbol("printf", "0x4", external=True, namespace="libc")
+    import_two = FakeSymbol("malloc", "0x5", external=True, namespace="libc")
+    program = FakeProgram(
+        symbols=[export_one, helper, export_two],
+        external_symbols=[import_one, import_two],
+    )
+    program_info = make_runtime_program_info(program=program)
+    tools = get_program_tools(program_info)
+
+    first_export_page = tools.list_exports(query="shared", offset=0, limit=1)
+    second_export_page = tools.list_exports(query="shared", offset=1, limit=1)
+    printf_import = tools.list_imports(query="printf", offset=0, limit=1)
+    malloc_import = tools.list_imports(query="malloc", offset=0, limit=1)
+
+    assert program.symbol_table.all_symbols_calls == 1
+    assert program.symbol_table.external_symbols_calls == 1
+    assert [item.name for item in first_export_page] == ["shared_func_one"]
+    assert [item.name for item in second_export_page] == ["shared_func_two"]
+    assert [item.name for item in printf_import] == ["printf"]
+    assert [item.name for item in malloc_import] == ["malloc"]
+
+
+def test_program_info_invalidation_clears_shared_tool_caches():
+    func_one = FakeFunction(FakeSymbol("func_one", "0x10"), "0x10")
+    func_two = FakeFunction(FakeSymbol("func_two", "0x20"), "0x20")
+    symbols = [FakeSymbol("match_one", "0x1"), FakeSymbol("match_two", "0x2")]
+    code_collection = FakeCodeCollection(
+        documents=[
+            {
+                "id": "func1",
+                "document": "printf alpha branch with extra text",
+                "metadata": {"function_name": "func1"},
+            },
+            {
+                "id": "func2",
+                "document": "printf beta branch with extra text",
+                "metadata": {"function_name": "func2"},
+            },
+        ],
+        query_results=[
+            {
+                "id": "func1",
+                "document": "printf alpha branch with extra text",
+                "metadata": {"function_name": "func1"},
+                "distance": 0.0,
+            }
+        ],
+    )
+    program = FakeProgram(
+        symbols=symbols,
+        functions=[func_one, func_two],
+        references_by_address={"0x1": [object()], "0x10": [object()]},
+    )
+    program_info = make_runtime_program_info(program=program, code_collection=code_collection)
+    tools = get_program_tools(program_info)
+
+    tools.search_symbols_by_name("match", limit=1)
+    tools.search_functions_by_name("func", limit=1)
+    tools.search_code(query="printf", limit=1, search_mode=SearchMode.SEMANTIC)
+
+    assert program_info.get_tools() is tools
+    assert program.symbol_table.all_symbols_calls == 1
+    assert program.function_manager.get_functions_calls == 1
+    assert code_collection.count_calls == 1
+
+    program_info.invalidate_derived_caches()
+
+    tools.search_symbols_by_name("match", limit=1)
+    tools.search_functions_by_name("func", limit=1)
+    tools.search_code(query="printf", limit=1, search_mode=SearchMode.SEMANTIC)
+
+    assert program_info.derived_cache_version == 1
+    assert program.symbol_table.all_symbols_calls == 2
+    assert program.function_manager.get_functions_calls == 2
+    assert code_collection.count_calls == 2
+
+
+def test_large_scale_internal_call_counts_remain_bounded():
+    counts = collect_internal_call_counts()
+
+    assert counts["search_code_semantic"].chroma_count_calls == 1
+    assert counts["search_code_semantic"].chroma_get_calls == 2
+    assert counts["search_code_semantic"].chroma_query_calls == 2
+
+    assert counts["search_code_literal"].chroma_count_calls == 1
+    assert counts["search_code_literal"].chroma_get_calls == 2
+    assert counts["search_code_literal"].chroma_query_calls == 0
+
+    assert counts["search_symbols_by_name"].symbol_table_all_symbols_calls == 1
+    assert counts["search_symbols_by_name"].reference_lookup_calls == 50
+
+    assert counts["search_functions_by_name"].function_manager_get_functions_calls == 1
+    assert counts["search_functions_by_name"].reference_lookup_calls == 50
+
+    assert counts["list_exports"].symbol_table_all_symbols_calls == 1
+    assert counts["list_imports"].symbol_table_external_symbols_calls == 1
+
+
+def test_search_strings_combines_literal_hits_with_semantic_fill():
+    strings_collection = FakeCodeCollection(
+        documents=[
+            {
+                "id": "str1",
+                "document": "sentinel alpha string",
+                "metadata": {"address": "0x1"},
+            },
+            {
+                "id": "str2",
+                "document": "sentinel beta string",
+                "metadata": {"address": "0x2"},
+            },
+        ],
+        query_results=[
+            {
+                "id": "str3",
+                "document": "semantic gamma string",
+                "metadata": {"address": "0x3"},
+                "distance": 0.1,
+            },
+            {
+                "id": "str4",
+                "document": "semantic delta string",
+                "metadata": {"address": "0x4"},
+                "distance": 0.2,
+            },
+        ],
+    )
+    program_info = make_runtime_program_info(strings_collection=strings_collection)
+    tools = get_program_tools(program_info)
+
+    results = tools.search_strings("sentinel", limit=4)
+
+    assert len(strings_collection.get_calls) == 1
+    assert len(strings_collection.query_calls) == 1
+    assert len(results) == 4
+    assert [result.address for result in results[:2]] == ["0x1", "0x2"]
+    assert results[0].similarity == 1
+    assert results[2].address == "0x3"
+    assert results[3].address == "0x4"


### PR DESCRIPTION
This is the initial PR to improve efficiency (the MCP descriptions, and execution/cache of ghidra access)

This PR is based on https://github.com/clearbluejar/pyghidra-mcp/pull/53 and only the last commit is additional code.

- Shrink MCP tool descriptions and schemas to reduce list_tools payload size.                                                                                                                                     
- Cache shared GhidraTools state and invalidate derived lookups on program changes.
- Paginate symbol, function, export, and import searches before refcount work.                                                                                                                                    
- Add literal-mode code search paging, previews, and richer result counters.                                                                                                                                      
- Add tests for payload budgets, cache reuse, exact-match lookups, and call timing.