### PR TITLE
Fix Windows existing-project reopen path handling

### DIFF
--- a/src/pyghidra_mcp/context.py
+++ b/src/pyghidra_mcp/context.py
@@ -189,14 +189,12 @@ class PyGhidraContext:
         """
         from ghidra.program.model.listing import Program
 
-        all_binary_paths = self.list_binaries()
-        for binary_path_s in all_binary_paths:
-            binary_path = Path(binary_path_s)
-            program: Program = self.project.openProgram(
-                str(binary_path.parent), binary_path.name, False
-            )
+        for domain_file in self.list_binary_domain_files():
+            parent = domain_file.getParent()
+            parent_path = parent.pathname if parent else "/"
+            program: Program = self.project.openProgram(parent_path, domain_file.getName(), False)
             program_info = self._init_program_info(program)
-            self.programs[binary_path_s] = program_info
+            self.programs[domain_file.pathname] = program_info
 
     def list_binaries(self) -> list[str]:
         """List all the binaries within the Ghidra project."""

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,0 +1,58 @@
+import sys
+import types
+from unittest.mock import Mock, call
+
+from pyghidra_mcp.context import PyGhidraContext
+
+
+def test_init_project_programs_uses_domain_file_paths(monkeypatch):
+    """Existing project programs should reopen via Ghidra domain paths, not pathlib."""
+    ghidra_module = types.ModuleType("ghidra")
+    program_module = types.ModuleType("ghidra.program")
+    model_module = types.ModuleType("ghidra.program.model")
+    listing_module = types.ModuleType("ghidra.program.model.listing")
+    listing_module.Program = object
+
+    monkeypatch.setitem(sys.modules, "ghidra", ghidra_module)
+    monkeypatch.setitem(sys.modules, "ghidra.program", program_module)
+    monkeypatch.setitem(sys.modules, "ghidra.program.model", model_module)
+    monkeypatch.setitem(sys.modules, "ghidra.program.model.listing", listing_module)
+
+    context = PyGhidraContext.__new__(PyGhidraContext)
+    context.project = Mock()
+    context.programs = {}
+
+    root_parent = Mock()
+    root_parent.pathname = "/"
+
+    nested_parent = Mock()
+    nested_parent.pathname = "/bin/tools"
+
+    root_domain_file = Mock()
+    root_domain_file.pathname = "/ls-aa11bb"
+    root_domain_file.getName.return_value = "ls-aa11bb"
+    root_domain_file.getParent.return_value = root_parent
+
+    nested_domain_file = Mock()
+    nested_domain_file.pathname = "/bin/tools/libfoo-cc22dd"
+    nested_domain_file.getName.return_value = "libfoo-cc22dd"
+    nested_domain_file.getParent.return_value = nested_parent
+
+    context.list_binary_domain_files = Mock(
+        return_value=[root_domain_file, nested_domain_file]
+    )
+    context.project.openProgram.side_effect = ["root-program", "nested-program"]
+    context._init_program_info = Mock(side_effect=["root-info", "nested-info"])
+
+    context._init_project_programs()
+
+    context.project.openProgram.assert_has_calls(
+        [
+            call("/", "ls-aa11bb", False),
+            call("/bin/tools", "libfoo-cc22dd", False),
+        ]
+    )
+    assert context.programs == {
+        "/ls-aa11bb": "root-info",
+        "/bin/tools/libfoo-cc22dd": "nested-info",
+    }


### PR DESCRIPTION
## Summary
- fix existing-project startup on Windows by reopening programs from Ghidra `DomainFile` paths instead of coercing them through `pathlib.Path`
- keep program registry keys aligned with `DomainFile.pathname`
- add a unit regression test covering root and nested project paths

## Reproduction
1. Start `pyghidra-mcp` once so it creates `pyghidra_mcp_projects/my_project`.
2. Start `pyghidra-mcp` again on Windows.
3. Current `main` crashes while reopening existing programs with `java.lang.IllegalArgumentException: Absolute path must begin with '/'`.

## Root Cause
`_init_project_programs()` was taking Ghidra project domain paths like `/binary-name` and converting them with `pathlib.Path`. On Windows that produces backslash-rooted filesystem paths, which are invalid for `GhidraProject.openProgram(...)`.

## Verification
- `uv run pytest tests/unit/test_context.py tests/unit/test_version.py tests/unit/test_models.py`
- manually reproduced the crash from `C:\Users\Q\code\eloquence`, then verified the patched build reopens the existing project and analyzes binaries normally
