### PR TITLE
reduce MCP tool manifest token bloat

### DIFF
--- a/src/pyghidra_mcp/mcp_tools.py
+++ b/src/pyghidra_mcp/mcp_tools.py
@@ -6,6 +6,7 @@ This module contains all MCP tool implementations with centralized error handlin
 
 import functools
 import logging
+from typing import Literal
 
 from mcp.server.fastmcp import Context
 from mcp.shared.exceptions import McpError
@@ -86,12 +87,7 @@ def mcp_error_handler(func):
 async def decompile_function(
     binary_name: str, name_or_address: str, ctx: Context
 ) -> DecompiledFunction:
-    """Decompiles a function in a specified binary and returns its pseudo-C code.
-
-    Args:
-        binary_name: The name of the binary containing the function.
-        name_or_address: The name or address of the function to decompile.
-    """
+    """Decompile a function to pseudo-C by name or address."""
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
@@ -102,17 +98,9 @@ async def decompile_function(
 def search_symbols_by_name(
     binary_name: str, query: str, ctx: Context, offset: int = 0, limit: int = 25
 ) -> SymbolSearchResults:
-    """Searches for symbols, including functions, within a binary by name.
+    """Search symbols by case-insensitive substring.
 
-    This tool searches for symbols by a case-insensitive substring. Symbols include
-    Functions, Labels, Classes, Namespaces, Externals, Dynamics, Libraries,
-    Global Variables, Parameters, and Local Variables.
-
-    Args:
-        binary_name: The name of the binary to search within.
-        query: The substring to search for in symbol names (case-insensitive).
-        offset: The number of results to skip.
-        limit: The maximum number of results to return.
+    Includes functions, labels, classes, namespaces, and variables.
     """
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
@@ -125,18 +113,7 @@ def search_symbols_by_name(
 def search_functions_by_name(
     binary_name: str, query: str, ctx: Context, offset: int = 0, limit: int = 25
 ) -> SymbolSearchResults:
-    """Searches for functions, excluding non-function symbols, within a binary by name.
-
-    This tool searches for functions by a case-insensitive substring. Unlike
-    `search_symbols_by_name`, it does not return labels, namespaces, variables,
-    or other non-function symbol types.
-
-    Args:
-        binary_name: The name of the binary to search within.
-        query: The substring to search for in function names (case-insensitive).
-        offset: The number of results to skip.
-        limit: The maximum number of results to return.
-    """
+    """Search functions only by case-insensitive substring (no labels/variables)."""
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
@@ -151,34 +128,15 @@ def search_code(
     ctx: Context,
     limit: int = 5,
     offset: int = 0,
-    search_mode: SearchMode = SearchMode.SEMANTIC,
+    search_mode: Literal["semantic", "literal"] = "semantic",
     include_full_code: bool = True,
     preview_length: int = 500,
     similarity_threshold: float = 0.0,
 ) -> CodeSearchResults:
-    """
-    Perform a code search over a binary's decompiled pseudo C output.
+    """Search decompiled pseudo-C code.
 
-    Supports two search modes:
-    - **semantic**: Vector similarity search for meaning-based matching (default)
-    - **literal**: Exact string matching using $contains for precise text matches
-
-    Results always include counts to help
-    decide if switching modes would yield better results
-
-    For best results provide a short distinctive query such as a function
-    signature or key logic snippet to minimize irrelevant matches.
-
-    Args:
-        binary_name: Name of the binary to search within.
-        query: Code snippet, signature, or exact text to search for.
-        limit: Maximum number of results to return (default: 5).
-        offset: Number of results to skip for pagination (default: 0).
-        search_mode: Search mode - 'semantic' or 'literal' (default: semantic).
-        include_full_code: If True, return full function code. If False, return truncated preview.
-        preview_length: Length of preview in characters when include_full_code=False (default: 500).
-        similarity_threshold: Minimum similarity score (0.0-1.0) for semantic results
-            (default: 0.0).
+    Modes: semantic (vector similarity, default) or literal (exact match).
+    Results include both mode counts.
     """
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
@@ -187,7 +145,7 @@ def search_code(
         query=query,
         limit=limit,
         offset=offset,
-        search_mode=search_mode,
+        search_mode=SearchMode(search_mode),
         include_full_code=include_full_code,
         preview_length=preview_length,
         similarity_threshold=similarity_threshold,
@@ -196,20 +154,7 @@ def search_code(
 
 @mcp_error_handler
 def list_project_binaries(ctx: Context) -> ProgramInfos:
-    """
-    Retrieve binary name, path, and analysis status for every program (binary) currently
-    loaded in the active project.
-
-    Returns a structured list of program entries, each containing:
-    - name: The display name of the program
-    - file_path: Absolute path to the binary file on disk (if available)
-    - load_time: Timestamp when the program was loaded into the project
-    - analysis_complete: Boolean indicating if automated analysis has finished
-
-    Use this to inspect the full set of binaries in the project, monitor analysis
-    progress, or drive follow up actions such as listing imports/exports or running
-    code searches on specific programs.
-    """
+    """List all binaries in the project with their status."""
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     program_infos = []
     for name, pi in pyghidra_context.programs.items():
@@ -229,15 +174,7 @@ def list_project_binaries(ctx: Context) -> ProgramInfos:
 
 @mcp_error_handler
 def list_project_binary_metadata(binary_name: str, ctx: Context) -> dict:
-    """
-    Retrieve detailed metadata for a specified binary.
-
-    Returns a dictionary containing properties such as architecture, compiler,
-    endianness, file hashes, and analysis counts (functions, symbols, etc.).
-
-    Args:
-        binary_name: The name of the binary to retrieve metadata for.
-    """
+    """Get binary metadata: architecture, compiler, endianness, hashes, analysis counts."""
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     return program_info.metadata
@@ -245,11 +182,7 @@ def list_project_binary_metadata(binary_name: str, ctx: Context) -> dict:
 
 @mcp_error_handler
 async def delete_project_binary(binary_name: str, ctx: Context) -> str:
-    """Deletes a binary (program) from the project.
-
-    Args:
-        binary_name: The name of the binary to delete.
-    """
+    """Delete a binary from the project."""
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     if pyghidra_context.delete_program(binary_name):
         return f"Successfully deleted binary: {binary_name}"
@@ -270,23 +203,7 @@ def list_exports(
     offset: int = 0,
     limit: int = 25,
 ) -> ExportInfos:
-    """
-    Retrieve exported functions and symbols from a given binary,
-    with optional regex filtering to focus on only the most relevant items.
-
-    For large binaries, using the `query` parameter is strongly recommended
-    to reduce noise and improve downstream reasoning. Specify a substring
-    or regex to match export names. For example: `query="init"`
-    to list only initialization-related exports.
-
-    Args:
-        binary_name: Name of the binary to inspect.
-        query: Strongly recommended. Regex pattern to match specific
-               export names. Use to limit irrelevant results and narrow
-               context for analysis.
-        offset: Number of matching results to skip (for pagination).
-        limit: Maximum number of results to return.
-    """
+    """List exported symbols, optionally filtered by regex query."""
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
@@ -302,23 +219,7 @@ def list_imports(
     offset: int = 0,
     limit: int = 25,
 ) -> ImportInfos:
-    """
-    Retrieve imported functions and symbols from a given binary,
-    with optional filtering to return only the most relevant matches.
-
-    This tool is most effective when you use the `query` parameter to
-    focus results — especially for large binaries — by specifying a
-    substring or regex that matches the desired import names.
-    For example: `query="socket"` to only see socket-related imports.
-
-    Args:
-        binary_name: Name of the binary to inspect.
-        query: Strongly recommended. Regex pattern to match specific
-               import names. Use to reduce irrelevant results and narrow
-               context for downstream reasoning.
-        offset: Number of matching results to skip (for pagination).
-        limit: Maximum number of results to return.
-    """
+    """List imported symbols, optionally filtered by regex query."""
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
@@ -330,15 +231,9 @@ def list_imports(
 def list_cross_references(
     binary_name: str, name_or_address: str, ctx: Context
 ) -> CrossReferenceInfos:
-    """Finds and lists all cross-references (x-refs) to a given function, symbol, or address within
-    a binary. This is crucial for understanding how code and data are used and related.
-    If an exact match for a function or symbol is not found,
-    the error message will suggest other symbols that are close matches.
+    """List cross-references to a function, symbol, or address.
 
-    Args:
-        binary_name: The name of the binary to search for cross-references in.
-        name_or_address: The name of the function, symbol, or a specific address (e.g., '0x1004010')
-        to find cross-references to.
+    Suggests close matches on no exact hit.
     """
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
@@ -354,14 +249,7 @@ def search_strings(
     query: str,
     limit: int = 100,
 ) -> StringSearchResults:
-    """Searches for strings within a binary by name.
-    This can be very useful to gain general understanding of behaviors.
-
-    Args:
-        binary_name: The name of the binary to search within.
-        query: A query to filter strings by.
-        limit: The maximum number of results to return.
-    """
+    """Search for strings within a binary."""
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
@@ -371,13 +259,7 @@ def search_strings(
 
 @mcp_error_handler
 def read_bytes(binary_name: str, ctx: Context, address: str, size: int = 32) -> BytesReadResult:
-    """Reads raw bytes from memory at a specified address.
-
-    Args:
-        binary_name: The name of the binary to read bytes from.
-        address: The memory address to read from (supports hex format with or without 0x prefix).
-        size: The number of bytes to read (default: 32, max: 8192).
-    """
+    """Read raw bytes at an address. Hex format supported (0x prefix optional)."""
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
@@ -389,37 +271,21 @@ def gen_callgraph(
     binary_name: str,
     function_name: str,
     ctx: Context,
-    direction: CallGraphDirection = CallGraphDirection.CALLING,
-    display_type: CallGraphDisplayType = CallGraphDisplayType.FLOW,
+    direction: Literal["calling", "called"] = "calling",
+    display_type: Literal["flow", "flow_ends"] = "flow",
     condense_threshold: int = 50,
     top_layers: int = 3,
     bottom_layers: int = 3,
     max_run_time: int = 120,
 ) -> CallGraphResult:
-    """Generates a mermaidjs function call graph for a specified function.
-
-    Typically the 'calling' callgraph is most useful.
-    The resulting graph string is mermaidjs format. This output is critical for correct rendering.
-    The graph details function calls originating from (calling) or terminating at (called)
-    the target function.
-
-    Args:
-        binary_name: The name of the binary containing the function.
-        function_name: The name of the function to generate the call graph for.
-        direction: Direction of the call graph (calling or called).
-        display_type: Format of the graph (flow, flow_ends).
-        condense_threshold: Maximum number of edges before graph condensation is triggered.
-        top_layers: Number of top layers to show in a condensed graph.
-        bottom_layers: Number of bottom layers to show in a condensed graph.
-        max_run_time: Maximum run time in seconds (default: 120).
-    """
+    """Generate a MermaidJS call graph for a function."""
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
     return tools.gen_callgraph(
         function_name_or_address=function_name,
-        cg_direction=direction,
-        cg_display_type=display_type,
+        cg_direction=CallGraphDirection(direction),
+        cg_display_type=CallGraphDisplayType(display_type),
         include_refs=True,
         max_depth=None,
         max_run_time=max_run_time,
@@ -431,11 +297,7 @@ def gen_callgraph(
 
 @mcp_error_handler
 def import_binary(binary_path: str, ctx: Context) -> str:
-    """Imports a binary from a designated path into the current Ghidra project.
-
-    Args:
-        binary_path: The path to the binary file to import.
-    """
+    """Import a binary into the project from a file path."""
     # We would like to do context progress updates, but until that is more
     # widely supported by clients, we will resort to this
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context

--- a/src/pyghidra_mcp/models.py
+++ b/src/pyghidra_mcp/models.py
@@ -4,115 +4,75 @@ from pydantic import BaseModel, Field
 
 
 class DecompiledFunction(BaseModel):
-    """Represents a single function decompiled by Ghidra."""
-
-    name: str = Field(..., description="The name of the function.")
-    code: str = Field(..., description="The decompiled pseudo-C code of the function.")
-    signature: str | None = Field(None, description="The signature of the function.")
+    name: str
+    code: str
+    signature: str | None = None
 
 
 class ProgramBasicInfo(BaseModel):
-    """Basic information about a program: name and analysis status"""
-
-    name: str = Field(..., description="The name of the program.")
-    analysis_complete: bool = Field(..., description="Indicates if program is ready to be used.")
+    name: str
+    analysis_complete: bool
 
 
 class ProgramBasicInfos(BaseModel):
-    """A container for a list of basic program information objects."""
-
-    programs: list[ProgramBasicInfo] = Field(
-        ..., description="A list of basic program information."
-    )
+    programs: list[ProgramBasicInfo]
 
 
 class ProgramInfo(BaseModel):
-    """Detailed information about a program (binary) loaded in Ghidra."""
-
-    name: str = Field(..., description="The name of the program in Ghidra.")
-    file_path: str | None = Field(None, description="The file path of the program on disk.")
-    load_time: float | None = Field(
-        None, description="The time it took to load the program in seconds."
-    )
-    analysis_complete: bool = Field(
-        ..., description="Indicates if Ghidra's analysis of the program has completed."
-    )
-    metadata: dict = Field(..., description="A dictionary of metadata associated with the program.")
-    code_collection: bool = Field(..., description="True if the chromadb code collection is ready")
-    strings_collection: bool = Field(..., description="True if strings have been indexed")
+    name: str
+    file_path: str | None = None
+    load_time: float | None = None
+    analysis_complete: bool
+    metadata: dict
+    code_collection: bool
+    strings_collection: bool
 
 
 class ProgramInfos(BaseModel):
-    """A container for a list of program information objects."""
-
-    programs: list[ProgramInfo] = Field(..., description="A list of program information objects.")
+    programs: list[ProgramInfo]
 
 
 class ExportInfo(BaseModel):
-    """Represents a single exported function or symbol from a binary."""
-
-    name: str = Field(..., description="The name of the export.")
-    address: str = Field(..., description="The address of the export.")
+    name: str
+    address: str
 
 
 class ExportInfos(BaseModel):
-    """A container for a list of exports from a binary."""
-
-    exports: list[ExportInfo] = Field(..., description="A list of exports.")
+    exports: list[ExportInfo]
 
 
 class ImportInfo(BaseModel):
-    """Represents a single imported function or symbol."""
-
-    name: str = Field(..., description="The name of the import.")
-    library: str = Field(
-        ..., description="The name of the library from which the symbol is imported."
-    )
+    name: str
+    library: str
 
 
 class ImportInfos(BaseModel):
-    """A container for a list of imports."""
-
-    imports: list[ImportInfo] = Field(..., description="A list of imports.")
+    imports: list[ImportInfo]
 
 
 class CrossReferenceInfo(BaseModel):
-    """Represents a cross-reference to a specific address in the binary."""
-
-    function_name: str | None = Field(
-        None, description="The name of the function containing the cross-reference."
-    )
-    from_address: str = Field(..., description="The address where the cross-reference originates.")
-    to_address: str = Field(..., description="The address that is being referenced.")
-    type: str = Field(..., description="The type of the cross-reference.")
+    function_name: str | None = None
+    from_address: str
+    to_address: str
+    type: str
 
 
 class CrossReferenceInfos(BaseModel):
-    """A container for a list of cross-references."""
-
-    cross_references: list[CrossReferenceInfo] = Field(
-        ..., description="A list of cross-references."
-    )
+    cross_references: list[CrossReferenceInfo]
 
 
 class SymbolInfo(BaseModel):
-    """Represents a symbol within the binary."""
-
-    name: str = Field(..., description="The name of the symbol.")
-    address: str = Field(..., description="The address of the symbol.")
-    type: str = Field(..., description="The type of the symbol.")
-    namespace: str = Field(..., description="The namespace of the symbol.")
-    source: str = Field(..., description="The source of the symbol.")
-    refcount: int = Field(..., description="The reference count of the symbol.")
-    external: bool = Field(..., description="Is symbol external.")
+    name: str
+    address: str
+    type: str
+    namespace: str
+    source: str
+    refcount: int
+    external: bool
 
 
 class SymbolSearchResults(BaseModel):
-    """A container for a list of symbols found during a search."""
-
-    symbols: list[SymbolInfo] = Field(
-        ..., description="A list of symbols that match the search criteria."
-    )
+    symbols: list[SymbolInfo]
 
 
 class SearchMode(str, Enum):
@@ -123,60 +83,42 @@ class SearchMode(str, Enum):
 
 
 class CodeSearchResult(BaseModel):
-    """Represents a single search result from the codebase."""
-
-    function_name: str = Field(
-        ..., description="The name of the function where the code was found."
-    )
-    code: str = Field(..., description="The psuedo-c code snippet")
-    similarity: float = Field(..., description="The similarity score of the search result.")
-    search_mode: SearchMode = Field(..., description="The search mode used for this result.")
-    preview: str | None = Field(None, description="Truncated preview when include_full_code=False.")
+    function_name: str
+    code: str
+    similarity: float
+    search_mode: SearchMode
+    preview: str | None = None
 
 
 class CodeSearchResults(BaseModel):
-    """A container for a list of code search results"""
-
-    results: list[CodeSearchResult] = Field(..., description="A list of code search results.")
-    query: str = Field(..., description="The query used for the search.")
-    search_mode: SearchMode = Field(..., description="The search mode used.")
-    # Pagination
-    returned_count: int = Field(..., description="Number of results returned in this response.")
-    offset: int = Field(..., description="Offset used for pagination.")
-    limit: int = Field(..., description="Limit used for pagination.")
-    # Dual-mode counts - ALWAYS populated to help LLM decide on mode switching
-    literal_total: int = Field(
-        ..., description="Total functions containing literal match. 0 if none found."
-    )
-    semantic_total: int = Field(..., description="Estimated total for semantic search.")
-    total_functions: int = Field(..., description="Total number of functions in the binary.")
+    results: list[CodeSearchResult]
+    query: str
+    search_mode: SearchMode
+    returned_count: int
+    offset: int
+    limit: int
+    literal_total: int = Field(..., description="total literal matches")
+    semantic_total: int = Field(..., description="estimated semantic matches")
+    total_functions: int
 
 
 class StringInfo(BaseModel):
-    """Represents a string found within the binary."""
-
-    value: str = Field(..., description="The value of the string.")
-    address: str = Field(..., description="The address of the string.")
+    value: str
+    address: str
 
 
 class StringSearchResult(StringInfo):
-    """Represents a string search result found within the binary."""
-
-    similarity: float = Field(..., description="The similarity score of the search result.")
+    similarity: float
 
 
 class StringSearchResults(BaseModel):
-    """A container for a list of string search results."""
-
-    strings: list[StringSearchResult] = Field(..., description="A list of string search results.")
+    strings: list[StringSearchResult]
 
 
 class BytesReadResult(BaseModel):
-    """Represents the result of reading raw bytes from memory."""
-
-    address: str = Field(..., description="The normalized address where bytes were read from.")
-    size: int = Field(..., description="The actual number of bytes read.")
-    data: str = Field(..., description="The raw bytes as a hexadecimal string.")
+    address: str
+    size: int
+    data: str = Field(..., description="hex string")
 
 
 class CallGraphDirection(str, Enum):
@@ -195,16 +137,8 @@ class CallGraphDisplayType(str, Enum):
 
 
 class CallGraphResult(BaseModel):
-    """Represents the result of a mermaidjs call graph generation."""
-
-    function_name: str = Field(
-        ..., description="The name of the function for which the call graph was generated."
-    )
-    direction: CallGraphDirection = Field(
-        ..., description="The direction of the call graph (calling or called)."
-    )
-    display_type: CallGraphDisplayType = Field(
-        ..., description="The type of the call graph visualization."
-    )
-    graph: str = Field(..., description="The MermaidJS markdown string for the call graph.")
-    mermaid_url: str = Field(..., description="The MermaidJS image url")
+    function_name: str
+    direction: CallGraphDirection
+    display_type: CallGraphDisplayType
+    graph: str = Field(..., description="MermaidJS graph string")
+    mermaid_url: str


### PR DESCRIPTION
## Summary
- Strip `Field(description=...)` from self-explanatory Pydantic model fields, replace with bare type annotations
- Remove class-level docstrings from all response models (they become `description` in JSON schema)
- Trim all 14 tool docstrings to 1-2 sentences, drop all `Args:` sections
- Convert enum params (`SearchMode`, `CallGraphDirection`, `CallGraphDisplayType`) to `Literal` types at MCP boundary, keeping enums internal to `tools.py`

~12,850 chars (~3,670 tokens) removed from per-session tool manifest. **66% reduction.**

## Test plan
- [x] `make test-unit` -- 21/21 pass
- [x] `make lint` -- ruff clean
- [x] `uv run pyright src/` -- 0 errors
- [ ] `make test-integration` -- field names/types unchanged, should pass

