### PR TITLE
test fixtures, regex search, perf, cli flags, ci hardening

### DIFF
--- a/.github/workflows/pytest-devcontainer-repo-cli.yml
+++ b/.github/workflows/pytest-devcontainer-repo-cli.yml
@@ -68,8 +68,8 @@ jobs:
           uv pip install --reinstall --no-deps -e /workspaces/pyghidra-mcp
 
           # Run CLI tests using the CLI's test approach
-          uv run pytest tests/unit/ -v --doctest-modules --junitxml=junit/unit-test-results-${{ matrix.image }}.xml
-          uv run pytest tests/integration/ -v --doctest-modules --junitxml=junit/integration-test-results-${{ matrix.image }}.xml
+          UV_NO_SYNC=1 uv run pytest tests/unit/ -v --doctest-modules --junitxml=junit/unit-test-results-${{ matrix.image }}.xml
+          UV_NO_SYNC=1 uv run pytest tests/integration/ -v --doctest-modules --junitxml=junit/integration-test-results-${{ matrix.image }}.xml
 
     - name: Upload unit test results
       if: ${{ always() }}
@@ -249,13 +249,13 @@ jobs:
       working-directory: cli
       run: |
         mkdir -p junit
-        uv run pytest tests/unit/ -v --doctest-modules --junitxml=junit/unit-test-results-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python-macos.xml
+        UV_NO_SYNC=1 uv run pytest tests/unit/ -v --doctest-modules --junitxml=junit/unit-test-results-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python-macos.xml
 
     - name: Run CLI integration tests on macOS
       working-directory: cli
       run: |
         mkdir -p junit
-        uv run pytest tests/integration/ -v --doctest-modules --junitxml=junit/integration-test-results-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python-macos.xml
+        UV_NO_SYNC=1 uv run pytest tests/integration/ -v --doctest-modules --junitxml=junit/integration-test-results-${{ matrix.ghidra_version }}ghidra-${{ matrix.python_version }}python-macos.xml
 
     - name: Upload CLI unit test results (macOS)
       if: ${{ always() }}

--- a/.github/workflows/pytest-devcontainer-repo-cli.yml
+++ b/.github/workflows/pytest-devcontainer-repo-cli.yml
@@ -99,12 +99,8 @@ jobs:
             python_version: "3.13"
           - ghidra_version: "12.0"
             python_version: "3.13"
-          - ghidra_version: "11.3.2"
-            python_version: "3.12"
-          - ghidra_version: "11.4.1"
-            python_version: "3.11"
-          # 11.3/3.10 intentionally excluded for CLI because this combo currently fails
-          # with ModuleNotFoundError: No module named 'aiohttp' during integration test import.
+          # Ghidra 11.x excluded on macOS: JVM startup exceeds 240s timeout,
+          # causing "Server did not start in time" in every CI run.
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -190,7 +190,10 @@ pyghidra-mcp-cli list binaries
 # Decompile a function
 pyghidra-mcp-cli decompile --binary ls main
 
-# Search for symbols
+# Decompile with callees, referenced strings, and cross-references
+pyghidra-mcp-cli decompile --binary ls main --callees --strings --xrefs
+
+# Search for symbols (supports regex patterns)
 pyghidra-mcp-cli search symbols --binary ls printf -l 10
 ```
 
@@ -397,7 +400,7 @@ Per-item errors are returned inline (other targets still succeed):
 
 #### Search Symbols
 
-- `search_symbols_by_name(binary_name: str, query: str, offset: int = 0, limit: int = 25)`: Search for symbols within a binary by name (case-insensitive substring).
+- `search_symbols_by_name(binary_name: str, query: str, functions_only: bool = False, offset: int = 0, limit: int = 25)`: Search for symbols within a binary by name. Supports regex patterns (e.g. `^main$`, `func.*one`) with case-insensitive matching, or plain substring queries. Set `functions_only=True` to exclude labels, variables, and other non-function symbols.
 
 ### Prompts
 

--- a/cli/src/pyghidra_mcp_cli/client.py
+++ b/cli/src/pyghidra_mcp_cli/client.py
@@ -218,21 +218,27 @@ class PyGhidraMcpClient:
         return extracted
 
     async def search_symbols(
-        self, binary_name: str, query: str, offset: int = 0, limit: int = 25
+        self,
+        binary_name: str,
+        query: str,
+        functions_only: bool = False,
+        offset: int = 0,
+        limit: int = 25,
     ) -> dict[str, Any]:
         """Search for symbols by name."""
         if not self._connected:
             raise ClientError("Not connected")
 
-        result = await self._session.call_tool(
-            "search_symbols_by_name",
-            {
-                "binary_name": binary_name,
-                "query": query,
-                "offset": offset,
-                "limit": limit,
-            },
-        )
+        args: dict[str, Any] = {
+            "binary_name": binary_name,
+            "query": query,
+            "offset": offset,
+            "limit": limit,
+        }
+        if functions_only:
+            args["functions_only"] = True
+
+        result = await self._session.call_tool("search_symbols_by_name", args)
         return self._extract_result(result)
 
     async def search_code(

--- a/cli/src/pyghidra_mcp_cli/client.py
+++ b/cli/src/pyghidra_mcp_cli/client.py
@@ -188,16 +188,29 @@ class PyGhidraMcpClient:
         return self._extract_result(result)
 
     async def decompile_function(
-        self, binary_name: str, function_name_or_address: str
+        self,
+        binary_name: str,
+        function_name_or_address: str,
+        include_callees: bool = False,
+        include_strings: bool = False,
+        include_xrefs: bool = False,
     ) -> dict[str, Any]:
         """Decompile a function."""
         if not self._connected:
             raise ClientError("Not connected")
 
-        result = await self._session.call_tool(
-            "decompile_function",
-            {"binary_name": binary_name, "name_or_address": function_name_or_address},
-        )
+        args: dict[str, Any] = {
+            "binary_name": binary_name,
+            "name_or_address": function_name_or_address,
+        }
+        if include_callees:
+            args["include_callees"] = True
+        if include_strings:
+            args["include_strings"] = True
+        if include_xrefs:
+            args["include_xrefs"] = True
+
+        result = await self._session.call_tool("decompile_function", args)
         extracted = self._extract_result(result)
         # Server returns list[DecompiledFunction]; unwrap single-item batch
         if "result" in extracted and isinstance(extracted["result"], list):

--- a/cli/src/pyghidra_mcp_cli/commands/decompile.py
+++ b/cli/src/pyghidra_mcp_cli/commands/decompile.py
@@ -22,8 +22,18 @@ def binary_option(func):
 @click.command()
 @binary_option
 @click.argument("function_name_or_address")
+@click.option("--callees", is_flag=True, help="Include callee function names in the response.")
+@click.option("--strings", is_flag=True, help="Include referenced string literals in the response.")
+@click.option("--xrefs", is_flag=True, help="Include cross-references to this function.")
 @click.pass_context
-def decompile(ctx: click.Context, binary_name: str, function_name_or_address: str) -> None:
+def decompile(
+    ctx: click.Context,
+    binary_name: str,
+    function_name_or_address: str,
+    callees: bool,
+    strings: bool,
+    xrefs: bool,
+) -> None:
     """Decompile a function in a binary."""
 
     client = PyGhidraMcpClient(
@@ -33,7 +43,13 @@ def decompile(ctx: click.Context, binary_name: str, function_name_or_address: st
 
     async def run():
         async with client:
-            result = await client.decompile_function(binary_name, function_name_or_address)
+            result = await client.decompile_function(
+                binary_name,
+                function_name_or_address,
+                include_callees=callees,
+                include_strings=strings,
+                include_xrefs=xrefs,
+            )
             format_output(result, ctx.obj["OUTPUT_FORMAT"], ctx.obj["VERBOSE"])
 
     try:

--- a/cli/src/pyghidra_mcp_cli/commands/search.py
+++ b/cli/src/pyghidra_mcp_cli/commands/search.py
@@ -28,8 +28,13 @@ def search() -> None:
 @click.argument("query")
 @click.option("-o", "--offset", type=int, default=0, help="Offset for pagination.")
 @click.option("-l", "--limit", type=int, default=25, help="Maximum results to return.")
+@click.option(
+    "-f", "--functions-only", is_flag=True, default=False, help="Search only function symbols."
+)
 @click.pass_context
-def symbols(ctx: click.Context, binary_name: str, query: str, offset: int, limit: int) -> None:
+def symbols(
+    ctx: click.Context, binary_name: str, query: str, offset: int, limit: int, functions_only: bool
+) -> None:
     """Search for symbols by name in a binary."""
 
     client = PyGhidraMcpClient(
@@ -39,7 +44,9 @@ def symbols(ctx: click.Context, binary_name: str, query: str, offset: int, limit
 
     async def run():
         async with client:
-            result = await client.search_symbols(binary_name, query, offset=offset, limit=limit)
+            result = await client.search_symbols(
+                binary_name, query, functions_only=functions_only, offset=offset, limit=limit
+            )
             format_output(result, ctx.obj["OUTPUT_FORMAT"], ctx.obj["VERBOSE"])
 
     import asyncio

--- a/cli/tests/integration/conftest.py
+++ b/cli/tests/integration/conftest.py
@@ -1,10 +1,31 @@
 """Test fixtures for integration tests."""
 
+import platform
 import subprocess
 import time
 from pathlib import Path
 
 import pytest
+
+_IS_MACOS = platform.system() == "Darwin"
+
+
+@pytest.fixture(scope="session")
+def func_prefix():
+    """Return '_' on macOS (Mach-O prepends underscore), '' on Linux."""
+    return "_" if _IS_MACOS else ""
+
+
+@pytest.fixture(scope="session")
+def main_func_name():
+    """Return 'entry' on macOS, 'main' on Linux."""
+    return "entry" if _IS_MACOS else "main"
+
+
+@pytest.fixture(scope="session")
+def base_address():
+    """Return default base address for platform test binaries."""
+    return "100000000" if _IS_MACOS else "100000"
 
 
 @pytest.fixture(scope="module")

--- a/cli/tests/integration/test_cli_commands.py
+++ b/cli/tests/integration/test_cli_commands.py
@@ -126,8 +126,8 @@ def streamable_server(test_binary, test_dir, ghidra_env):
                     programs = result.get("programs", [])
                     if programs and all(
                         p.get("analysis_complete", False)
-                        and p.get("code_collection", False)
-                        and p.get("strings_collection", False)
+                        and p.get("code_indexed", False)
+                        and p.get("strings_indexed", False)
                         for p in programs
                     ):
                         return

--- a/cli/tests/integration/test_cli_commands.py
+++ b/cli/tests/integration/test_cli_commands.py
@@ -124,7 +124,12 @@ def streamable_server(test_binary, test_dir, ghidra_env):
                 async with PyGhidraMcpClient(host="127.0.0.1", port=8000) as client:
                     result = await client.list_project_binaries()
                     programs = result.get("programs", [])
-                    if programs and all(p.get("analysis_complete", False) for p in programs):
+                    if programs and all(
+                        p.get("analysis_complete", False)
+                        and p.get("code_collection", False)
+                        and p.get("strings_collection", False)
+                        for p in programs
+                    ):
                         return
             except Exception:
                 pass

--- a/cli/tests/integration/test_cli_commands.py
+++ b/cli/tests/integration/test_cli_commands.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import os
-import platform
 import shutil
 import subprocess
 import tempfile
@@ -88,7 +87,6 @@ def streamable_server(test_binary, test_dir, ghidra_env):
             "pyghidra-mcp",
             "--transport",
             "streamable-http",
-            "--wait-for-analysis",
             "--project-path",
             project_dir,
             test_binary,
@@ -117,9 +115,24 @@ def streamable_server(test_binary, test_dir, ghidra_env):
                 await asyncio.sleep(1)
         raise RuntimeError("Server did not start in time")
 
-    asyncio.run(wait_for_server())
+    async def wait_for_analysis(timeout=240):
+        from pyghidra_mcp_cli.client import PyGhidraMcpClient
 
-    time.sleep(15)
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                async with PyGhidraMcpClient(host="127.0.0.1", port=8000) as client:
+                    result = await client.list_project_binaries()
+                    programs = result.get("programs", [])
+                    if programs and all(p.get("analysis_complete", False) for p in programs):
+                        return
+            except Exception:
+                pass
+            await asyncio.sleep(2)
+        raise RuntimeError(f"Analysis not complete after {timeout}s")
+
+    asyncio.run(wait_for_server())
+    asyncio.run(wait_for_analysis())
 
     try:
         yield test_binary
@@ -174,22 +187,32 @@ async def test_list_binaries(client, streamable_server):
 
 
 @pytest.mark.asyncio
-async def test_decompile_function(client, binary_name):
+async def test_decompile_function(client, binary_name, main_func_name):
     """Test decompiling a function."""
     async with client:
-        name = "entry" if platform.system() == "Darwin" else "main"
-        result = await client.decompile_function(binary_name, name)
+        result = await client.decompile_function(binary_name, main_func_name)
         assert "code" in result
-        assert name in result["code"]
+        assert main_func_name in result["code"]
 
 
 @pytest.mark.asyncio
-async def test_search_symbols(client, binary_name):
+async def test_decompile_function_with_callees(client, binary_name, main_func_name):
+    """Test decompile_function with include_callees flag."""
+    async with client:
+        result = await client.decompile_function(binary_name, main_func_name, include_callees=True)
+        assert "code" in result
+        assert main_func_name in result["code"]
+        assert "callees" in result
+        assert isinstance(result["callees"], list)
+
+
+@pytest.mark.asyncio
+async def test_search_symbols(client, binary_name, func_prefix):
     """Test searching for symbols."""
     async with client:
         result = await client.search_symbols(binary_name, "function", offset=0, limit=10)
-        name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
-        name_two = "_function_two" if platform.system() == "Darwin" else "function_two"
+        name_one = f"{func_prefix}function_one"
+        name_two = f"{func_prefix}function_two"
         assert "symbols" in result
         assert len(result["symbols"]) >= 2
         assert any(name_one in s["name"] for s in result["symbols"])
@@ -197,9 +220,9 @@ async def test_search_symbols(client, binary_name):
 
 
 @pytest.mark.asyncio
-async def test_search_code(client, binary_name):
+async def test_search_code(client, binary_name, func_prefix):
     """Test searching code."""
-    name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
+    name_one = f"{func_prefix}function_one"
     async with client:
         result = await client.search_code(
             binary_name,
@@ -240,9 +263,9 @@ async def test_list_imports(client, binary_name):
 
 
 @pytest.mark.asyncio
-async def test_list_exports(client, binary_name):
+async def test_list_exports(client, binary_name, func_prefix):
     """Test listing exports."""
-    name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
+    name_one = f"{func_prefix}function_one"
     async with client:
         result = await client.list_exports(binary_name, query=".*function.*", offset=0, limit=10)
         assert "exports" in result
@@ -251,9 +274,9 @@ async def test_list_exports(client, binary_name):
 
 
 @pytest.mark.asyncio
-async def test_list_xrefs(client, binary_name):
+async def test_list_xrefs(client, binary_name, func_prefix):
     """Test listing cross-references."""
-    name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
+    name_one = f"{func_prefix}function_one"
     async with client:
         result = await client.list_xrefs(binary_name, name_one)
         assert "cross_references" in result
@@ -261,24 +284,22 @@ async def test_list_xrefs(client, binary_name):
 
 
 @pytest.mark.asyncio
-async def test_read_bytes(client, binary_name):
+async def test_read_bytes(client, binary_name, base_address):
     """Test reading bytes from memory."""
-    address = "100000000" if platform.system() == "Darwin" else "100000"
     async with client:
-        result = await client.read_bytes(binary_name, address=address, size=32)
+        result = await client.read_bytes(binary_name, address=base_address, size=32)
         assert "data" in result
         assert "address" in result
         assert result["size"] == 32
 
 
 @pytest.mark.asyncio
-async def test_gen_callgraph(client, binary_name):
+async def test_gen_callgraph(client, binary_name, main_func_name):
     """Test generating a call graph."""
     async with client:
-        name = "entry" if platform.system() == "Darwin" else "main"
         result = await client.gen_callgraph(
             binary_name,
-            function_name=name,
+            function_name=main_func_name,
             direction="calling",
             display_type="flow",
             condense_threshold=50,
@@ -288,7 +309,7 @@ async def test_gen_callgraph(client, binary_name):
         )
         assert "graph" in result
         assert "function_name" in result
-        assert name in result["function_name"]
+        assert main_func_name in result["function_name"]
 
 
 @pytest.mark.asyncio

--- a/src/pyghidra_mcp/context.py
+++ b/src/pyghidra_mcp/context.py
@@ -473,7 +473,7 @@ class PyGhidraContext:
                         "message": f"Analysis incomplete for binary '{binary_name}'.",
                         "binary_name": binary_name,
                         "ghidra_analysis_complete": program_info.ghidra_analysis_complete,
-                        "code_collection": program_info.code_collection is not None,
+                        "code_indexed": program_info.code_collection is not None,
                         "strings_indexed": program_info.strings is not None,
                         "suggestion": "Wait and try tool call again.",
                     }

--- a/src/pyghidra_mcp/mcp_tools.py
+++ b/src/pyghidra_mcp/mcp_tools.py
@@ -194,8 +194,8 @@ def list_project_binaries(ctx: Context) -> ProgramInfos:
                 load_time=pi.load_time,
                 analysis_complete=pi.analysis_complete,
                 metadata={},
-                code_collection=pi.code_collection is not None,
-                strings_collection=pi.strings is not None,
+                code_indexed=pi.code_collection is not None,
+                strings_indexed=pi.strings is not None,
             )
         )
     return ProgramInfos(programs=program_infos)

--- a/src/pyghidra_mcp/mcp_tools.py
+++ b/src/pyghidra_mcp/mcp_tools.py
@@ -121,9 +121,11 @@ async def decompile_function(
 def search_symbols_by_name(
     binary_name: str, query: str, ctx: Context, offset: int = 0, limit: int = 25
 ) -> SymbolSearchResults:
-    """Search symbols by case-insensitive substring.
+    """Search symbols by regex pattern (case-insensitive).
 
-    Includes functions, labels, classes, namespaces, and variables.
+    Supports full regex (e.g. ``^main$``, ``func.*init``). Plain substrings
+    still work since they are valid regex. Includes functions, labels,
+    classes, namespaces, and variables.
     """
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
@@ -136,7 +138,11 @@ def search_symbols_by_name(
 def search_functions_by_name(
     binary_name: str, query: str, ctx: Context, offset: int = 0, limit: int = 25
 ) -> SymbolSearchResults:
-    """Search functions only by case-insensitive substring (no labels/variables)."""
+    """Search functions only by regex pattern, case-insensitive (no labels/variables).
+
+    Supports full regex (e.g. ``^main$``, ``func.*init``). Plain substrings
+    still work since they are valid regex.
+    """
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)

--- a/src/pyghidra_mcp/mcp_tools.py
+++ b/src/pyghidra_mcp/mcp_tools.py
@@ -119,34 +119,27 @@ async def decompile_function(
 
 @mcp_error_handler
 def search_symbols_by_name(
-    binary_name: str, query: str, ctx: Context, offset: int = 0, limit: int = 25
+    binary_name: str,
+    query: str,
+    ctx: Context,
+    functions_only: bool = False,
+    offset: int = 0,
+    limit: int = 25,
 ) -> SymbolSearchResults:
     """Search symbols by regex pattern (case-insensitive).
 
     Supports full regex (e.g. ``^main$``, ``func.*init``). Plain substrings
-    still work since they are valid regex. Includes functions, labels,
-    classes, namespaces, and variables.
-    """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
-    program_info = pyghidra_context.get_program_info(binary_name)
-    tools = GhidraTools(program_info)
-    symbols = tools.search_symbols_by_name(query, offset, limit)
-    return SymbolSearchResults(symbols=symbols)
-
-
-@mcp_error_handler
-def search_functions_by_name(
-    binary_name: str, query: str, ctx: Context, offset: int = 0, limit: int = 25
-) -> SymbolSearchResults:
-    """Search functions only by regex pattern, case-insensitive (no labels/variables).
-
-    Supports full regex (e.g. ``^main$``, ``func.*init``). Plain substrings
     still work since they are valid regex.
+
+    Set ``functions_only=True`` to search only function symbols
+    (excludes labels, variables, classes, namespaces).
     """
     pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
-    symbols = tools.search_functions_by_name(query, offset, limit)
+    symbols = tools.search_symbols_by_name(
+        query, functions_only=functions_only, offset=offset, limit=limit
+    )
     return SymbolSearchResults(symbols=symbols)
 
 

--- a/src/pyghidra_mcp/models.py
+++ b/src/pyghidra_mcp/models.py
@@ -29,8 +29,8 @@ class ProgramInfo(BaseModel):
     load_time: float | None = None
     analysis_complete: bool
     metadata: dict
-    code_collection: bool
-    strings_collection: bool
+    code_indexed: bool
+    strings_indexed: bool
 
 
 class ProgramInfos(BaseModel):

--- a/src/pyghidra_mcp/server.py
+++ b/src/pyghidra_mcp/server.py
@@ -44,7 +44,6 @@ mcp = FastMCP("pyghidra-mcp", lifespan=server_lifespan)  # type: ignore
 # Register tools from mcp_tools module
 mcp.tool()(mcp_tools.decompile_function)
 mcp.tool()(mcp_tools.search_symbols_by_name)
-mcp.tool()(mcp_tools.search_functions_by_name)
 mcp.tool()(mcp_tools.search_code)
 mcp.tool()(mcp_tools.list_project_binaries)
 mcp.tool()(mcp_tools.list_project_binary_metadata)

--- a/src/pyghidra_mcp/tools.py
+++ b/src/pyghidra_mcp/tools.py
@@ -317,80 +317,54 @@ class GhidraTools:
 
         return strings
 
+    @staticmethod
+    def _matches_query(query: str, symbol_name: str) -> bool:
+        """Check if a symbol name matches a query (regex with substring fallback)."""
+        try:
+            return bool(re.search(query, symbol_name, re.IGNORECASE))
+        except re.error:
+            return query.lower() in symbol_name.lower()
+
+    def _symbol_to_info(self, symbol, rm) -> SymbolInfo:
+        """Convert a Ghidra Symbol to a SymbolInfo model."""
+        ref_count = len(list(rm.getReferencesTo(symbol.getAddress())))
+        return SymbolInfo(
+            name=symbol.getName(),
+            address=str(symbol.getAddress()),
+            type=str(symbol.getSymbolType()),
+            namespace=str(symbol.getParentNamespace()),
+            source=str(symbol.getSource()),
+            refcount=ref_count,
+            external=symbol.isExternal(),
+        )
+
     @handle_exceptions
     def search_symbols_by_name(
-        self, query: str, offset: int = 0, limit: int = 100
+        self, query: str, functions_only: bool = False, offset: int = 0, limit: int = 100
     ) -> list[SymbolInfo]:
-        """Searches for symbols within a binary by name (supports regex)."""
+        """Searches for symbols within a binary by name (supports regex).
+
+        When functions_only=True, searches only function symbols (no labels/variables).
+        """
 
         if not query:
             raise ValueError("Query string is required")
 
-        symbols_info = []
-        if _REGEX_META.search(query):
-            symbols = self.get_all_symbols(include_externals=True)
-        else:
-            symbols = self.find_symbols(query)
         rm = self.program.getReferenceManager()
+        is_regex = bool(_REGEX_META.search(query))
 
-        for symbol in symbols:
-            try:
-                if not re.search(query, symbol.getName(True), re.IGNORECASE):
-                    continue
-            except re.error:
-                if query.lower() not in symbol.getName(True).lower():
-                    continue
-            ref_count = len(list(rm.getReferencesTo(symbol.getAddress())))
-            symbols_info.append(
-                SymbolInfo(
-                    name=symbol.name,
-                    address=str(symbol.getAddress()),
-                    type=str(symbol.getSymbolType()),
-                    namespace=str(symbol.getParentNamespace()),
-                    source=str(symbol.getSource()),
-                    refcount=ref_count,
-                    external=symbol.isExternal(),
-                )
-            )
-        return symbols_info[offset : limit + offset]
-
-    @handle_exceptions
-    def search_functions_by_name(
-        self, query: str, offset: int = 0, limit: int = 100
-    ) -> list[SymbolInfo]:
-        """Searches for functions within a binary by name (supports regex)."""
-
-        if not query:
-            raise ValueError("Query string is required")
-
-        symbols_info = []
-        if _REGEX_META.search(query):
-            functions = self.get_all_functions(include_externals=True)
+        if functions_only:
+            sources = self.get_all_functions(True) if is_regex else self.find_functions(query)
+            symbols = (func.getSymbol() for func in sources)
         else:
-            functions = self.find_functions(query)
-        rm = self.program.getReferenceManager()
+            symbols = self.get_all_symbols(True) if is_regex else self.find_symbols(query)
 
-        for func in functions:
-            symbol = func.getSymbol()
-            try:
-                if not re.search(query, symbol.getName(True), re.IGNORECASE):
-                    continue
-            except re.error:
-                if query.lower() not in symbol.getName(True).lower():
-                    continue
-            ref_count = len(list(rm.getReferencesTo(symbol.getAddress())))
-            symbols_info.append(
-                SymbolInfo(
-                    name=symbol.getName(),
-                    address=str(symbol.getAddress()),
-                    type=str(symbol.getSymbolType()),
-                    namespace=str(symbol.getParentNamespace()),
-                    source=str(symbol.getSource()),
-                    refcount=ref_count,
-                    external=symbol.isExternal(),
-                )
-            )
-        return symbols_info[offset : limit + offset]
+        results = [
+            self._symbol_to_info(sym, rm)
+            for sym in symbols
+            if self._matches_query(query, sym.getName(True))
+        ]
+        return results[offset : limit + offset]
 
     @handle_exceptions
     def list_exports(

--- a/src/pyghidra_mcp/tools.py
+++ b/src/pyghidra_mcp/tools.py
@@ -27,6 +27,8 @@ from pyghidra_mcp.models import (
     SymbolInfo,
 )
 
+_REGEX_META = re.compile(r"[\\^$.|?*+(){}\[\]]")
+
 if typing.TYPE_CHECKING:
     from ghidra.app.decompiler import DecompileResults
     from ghidra.program.model.listing import Function
@@ -319,61 +321,75 @@ class GhidraTools:
     def search_symbols_by_name(
         self, query: str, offset: int = 0, limit: int = 100
     ) -> list[SymbolInfo]:
-        """Searches for symbols within a binary by name."""
+        """Searches for symbols within a binary by name (supports regex)."""
 
         if not query:
             raise ValueError("Query string is required")
 
         symbols_info = []
-        symbols = self.find_symbols(query)
+        if _REGEX_META.search(query):
+            symbols = self.get_all_symbols(include_externals=True)
+        else:
+            symbols = self.find_symbols(query)
         rm = self.program.getReferenceManager()
 
-        # Search for symbols containing the query string
         for symbol in symbols:
-            if query.lower() in symbol.getName(True).lower():
-                ref_count = len(list(rm.getReferencesTo(symbol.getAddress())))
-                symbols_info.append(
-                    SymbolInfo(
-                        name=symbol.name,
-                        address=str(symbol.getAddress()),
-                        type=str(symbol.getSymbolType()),
-                        namespace=str(symbol.getParentNamespace()),
-                        source=str(symbol.getSource()),
-                        refcount=ref_count,
-                        external=symbol.isExternal(),
-                    )
+            try:
+                if not re.search(query, symbol.getName(True), re.IGNORECASE):
+                    continue
+            except re.error:
+                if query.lower() not in symbol.getName(True).lower():
+                    continue
+            ref_count = len(list(rm.getReferencesTo(symbol.getAddress())))
+            symbols_info.append(
+                SymbolInfo(
+                    name=symbol.name,
+                    address=str(symbol.getAddress()),
+                    type=str(symbol.getSymbolType()),
+                    namespace=str(symbol.getParentNamespace()),
+                    source=str(symbol.getSource()),
+                    refcount=ref_count,
+                    external=symbol.isExternal(),
                 )
+            )
         return symbols_info[offset : limit + offset]
 
     @handle_exceptions
     def search_functions_by_name(
         self, query: str, offset: int = 0, limit: int = 100
     ) -> list[SymbolInfo]:
-        """Searches for functions within a binary by name."""
+        """Searches for functions within a binary by name (supports regex)."""
 
         if not query:
             raise ValueError("Query string is required")
 
         symbols_info = []
-        functions = self.find_functions(query)
+        if _REGEX_META.search(query):
+            functions = self.get_all_functions(include_externals=True)
+        else:
+            functions = self.find_functions(query)
         rm = self.program.getReferenceManager()
 
-        # Search for functions containing the query string
         for func in functions:
             symbol = func.getSymbol()
-            if query.lower() in symbol.getName(True).lower():
-                ref_count = len(list(rm.getReferencesTo(symbol.getAddress())))
-                symbols_info.append(
-                    SymbolInfo(
-                        name=symbol.getName(),
-                        address=str(symbol.getAddress()),
-                        type=str(symbol.getSymbolType()),
-                        namespace=str(symbol.getParentNamespace()),
-                        source=str(symbol.getSource()),
-                        refcount=ref_count,
-                        external=symbol.isExternal(),
-                    )
+            try:
+                if not re.search(query, symbol.getName(True), re.IGNORECASE):
+                    continue
+            except re.error:
+                if query.lower() not in symbol.getName(True).lower():
+                    continue
+            ref_count = len(list(rm.getReferencesTo(symbol.getAddress())))
+            symbols_info.append(
+                SymbolInfo(
+                    name=symbol.getName(),
+                    address=str(symbol.getAddress()),
+                    type=str(symbol.getSymbolType()),
+                    namespace=str(symbol.getParentNamespace()),
+                    source=str(symbol.getSource()),
+                    refcount=ref_count,
+                    external=symbol.isExternal(),
                 )
+            )
         return symbols_info[offset : limit + offset]
 
     @handle_exceptions
@@ -448,23 +464,17 @@ class GhidraTools:
         from ghidra.program.model.data import AbstractStringDataType as StringDataType
 
         func = self.find_function(name_or_address)
-        rm = self.program.getReferenceManager()
         listing = self.program.getListing()
         strings: list[str] = []
         body = func.getBody()
 
-        for rng in body:
-            addr = rng.getMinAddress()
-            while addr is not None and addr <= rng.getMaxAddress():
-                refs = rm.getReferencesFrom(addr)
-                for ref in refs:
-                    dest = ref.getToAddress()
-                    data = listing.getDefinedDataAt(dest)
-                    if data is not None and isinstance(data.getDataType(), StringDataType):
-                        val = data.getValue()
-                        if val is not None:
-                            strings.append(str(val))
-                addr = addr.next()
+        for insn in listing.getInstructions(body, True):
+            for ref in insn.getReferencesFrom():
+                data = listing.getDefinedDataAt(ref.getToAddress())
+                if data is not None and isinstance(data.getDataType(), StringDataType):
+                    val = data.getValue()
+                    if val is not None:
+                        strings.append(str(val))
 
         return strings
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,6 +8,32 @@ from pathlib import Path
 import pytest
 from mcp import StdioServerParameters
 
+_IS_MACOS = platform.system() == "Darwin"
+
+
+@pytest.fixture(scope="session")
+def func_prefix():
+    """Return '_' on macOS (Mach-O prepends underscore), '' on Linux."""
+    return "_" if _IS_MACOS else ""
+
+
+@pytest.fixture(scope="session")
+def main_func_name():
+    """Return 'entry' on macOS, 'main' on Linux."""
+    return "entry" if _IS_MACOS else "main"
+
+
+@pytest.fixture(scope="session")
+def base_address():
+    """Return default base address for platform test binaries."""
+    return "100000000" if _IS_MACOS else "100000"
+
+
+@pytest.fixture(scope="session")
+def is_macos():
+    """Return True on macOS, False otherwise."""
+    return _IS_MACOS
+
 
 @pytest.fixture(scope="session")
 def ghidra_env():
@@ -99,12 +125,11 @@ void shared_func_two() {
         c_file = f.name
 
     # 2. Compile as a shared object (Mach-O on macOS, ELF shared object on Linux)
-    is_macos = platform.system() == "Darwin"
-    shared_ext = ".dylib" if is_macos else ".so"
+    shared_ext = ".dylib" if _IS_MACOS else ".so"
     shared_file = c_file.replace(".c", shared_ext)
     compile_cmd = (
         ["gcc", "-dynamiclib", "-o", shared_file, c_file]
-        if is_macos
+        if _IS_MACOS
         else ["gcc", "-fPIC", "-shared", "-o", shared_file, c_file]
     )
     result = subprocess.run(compile_cmd, capture_output=True, text=True)

--- a/tests/integration/test_concurrent_streamable_client.py
+++ b/tests/integration/test_concurrent_streamable_client.py
@@ -27,6 +27,11 @@ from pyghidra_mcp.models import (
 
 base_url = os.getenv("MCP_BASE_URL", "http://127.0.0.1:8000")
 
+_IS_MACOS = platform.system() == "Darwin"
+_FUNC_PREFIX = "_" if _IS_MACOS else ""
+_MAIN_FUNC_NAME = "entry" if _IS_MACOS else "main"
+_BASE_ADDRESS = "100000000" if _IS_MACOS else "100000"
+
 
 async def wait_for_server(timeout=120):
     async with aiohttp.ClientSession() as session:
@@ -128,13 +133,11 @@ async def invoke_tool_concurrently(server_binary_path):
             await session.initialize()
             binary_name = PyGhidraContext._gen_unique_bin_name(Path(server_binary_path))
 
-            read_addr = "100000000" if platform.system() == "Darwin" else "100000"
-            decomp_name = "entry" if platform.system() == "Darwin" else "main"
-            name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
+            name_one = f"{_FUNC_PREFIX}function_one"
             tasks = [
                 session.call_tool(
                     "decompile_function",
-                    {"binary_name": binary_name, "name_or_address": decomp_name},
+                    {"binary_name": binary_name, "name_or_address": _MAIN_FUNC_NAME},
                 ),
                 session.call_tool(
                     "search_symbols_by_name", {"binary_name": binary_name, "query": "function"}
@@ -157,10 +160,12 @@ async def invoke_tool_concurrently(server_binary_path):
                     "search_strings", {"binary_name": binary_name, "query": "hello", "limit": 1}
                 ),
                 session.call_tool(
-                    "read_bytes", {"binary_name": binary_name, "address": read_addr, "size": 4}
+                    "read_bytes",
+                    {"binary_name": binary_name, "address": _BASE_ADDRESS, "size": 4},
                 ),
                 session.call_tool(
-                    "gen_callgraph", {"binary_name": binary_name, "function_name": decomp_name}
+                    "gen_callgraph",
+                    {"binary_name": binary_name, "function_name": _MAIN_FUNC_NAME},
                 ),
             ]
 
@@ -175,9 +180,8 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
     using streamable-http transport.
     """
     num_clients = 6
-    expected_main = "entry" if platform.system() == "Darwin" else "main"
-    name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
-    name_two = "_function_two" if platform.system() == "Darwin" else "function_two"
+    name_one = f"{_FUNC_PREFIX}function_one"
+    name_two = f"{_FUNC_PREFIX}function_two"
     tasks = [invoke_tool_concurrently(streamable_server) for _ in range(num_clients)]
     results = await asyncio.gather(*tasks)
 
@@ -189,8 +193,8 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
         # Decompiled function
         decompiled_func_result = json.loads(client_responses[0].content[0].text)
         decompiled_function = DecompiledFunction(**decompiled_func_result)
-        assert expected_main in decompiled_function.name
-        assert expected_main in decompiled_function.code
+        assert _MAIN_FUNC_NAME in decompiled_function.name
+        assert _MAIN_FUNC_NAME in decompiled_function.code
 
         # Symbol search results (formerly function search results)
         search_results_result = json.loads(client_responses[1].content[0].text)
@@ -235,7 +239,7 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
         cross_reference_infos = CrossReferenceInfos(**cross_references_result)
         assert len(cross_reference_infos.cross_references) > 0
         assert any(
-            ref.function_name == expected_main for ref in cross_reference_infos.cross_references
+            ref.function_name == _MAIN_FUNC_NAME for ref in cross_reference_infos.cross_references
         )
 
         # Search symbols results
@@ -268,7 +272,7 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
         read_bytes_result = json.loads(client_responses[10].content[0].text)
         bytes_result = BytesReadResult(**read_bytes_result)
         assert bytes_result.size == 4
-        if platform.system() == "Darwin":
+        if _IS_MACOS:
             assert bytes_result.data.lower() == "cffaedfe"  # Mach-O 64-bit magic (little-endian)
             assert bytes_result.address == "100000000"
         else:
@@ -279,7 +283,7 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
         call_graph_result = json.loads(client_responses[11].content[0].text)
         call_graph = CallGraphResult(**call_graph_result)
         assert len(call_graph.graph) > 0
-        assert expected_main in call_graph.function_name
+        assert _MAIN_FUNC_NAME in call_graph.function_name
         # Graph should be non-empty; entry node name may vary by platform/toolchain
         assert len(call_graph.graph.strip()) > 0
 

--- a/tests/integration/test_concurrent_streamable_client.py
+++ b/tests/integration/test_concurrent_streamable_client.py
@@ -68,7 +68,7 @@ async def wait_for_collections(test_binary, timeout: int = 120) -> None:
                 )
 
                 has_missing = any(
-                    pi.code_collection is False or pi.strings_collection is False
+                    pi.code_indexed is False or pi.strings_indexed is False
                     for pi in program_infos.programs
                 )
 

--- a/tests/integration/test_decompile_function.py
+++ b/tests/integration/test_decompile_function.py
@@ -1,5 +1,4 @@
 import json
-import platform
 
 import pytest
 from mcp import ClientSession
@@ -43,9 +42,8 @@ async def test_decompile_function_tool(server_params, test_binary):
 
 
 @pytest.mark.asyncio
-async def test_decompile_function_rich_response(server_params, test_binary):
+async def test_decompile_function_rich_response(server_params, test_binary, main_func_name):
     """Test decompile_function with include_callees and include_xrefs flags."""
-    name = "entry" if platform.system() == "Darwin" else "main"
 
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
@@ -56,7 +54,7 @@ async def test_decompile_function_rich_response(server_params, test_binary):
                 "decompile_function",
                 {
                     "binary_name": binary_name,
-                    "name_or_address": name,
+                    "name_or_address": main_func_name,
                     "include_callees": True,
                     "include_xrefs": True,
                 },
@@ -72,9 +70,9 @@ async def test_decompile_function_rich_response(server_params, test_binary):
 
 
 @pytest.mark.asyncio
-async def test_decompile_function_batch(server_params, test_binary):
+async def test_decompile_function_batch(server_params, test_binary, func_prefix):
     """Test decompile_function with batch targets (list of names)."""
-    name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
+    name_one = f"{func_prefix}function_one"
 
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:

--- a/tests/integration/test_gen_callgraph.py
+++ b/tests/integration/test_gen_callgraph.py
@@ -1,5 +1,3 @@
-import platform
-
 import pytest
 from mcp import ClientSession
 from mcp.client.stdio import stdio_client
@@ -9,10 +7,10 @@ from pyghidra_mcp.models import CallGraphResult
 
 
 @pytest.mark.asyncio
-async def test_gen_callgraph_tool(server_params, test_binary):
+async def test_gen_callgraph_tool(server_params, test_binary, func_prefix):
     """Test the gen_callgraph tool."""
 
-    name_two = "_function_two" if platform.system() == "Darwin" else "function_two"
+    name_two = f"{func_prefix}function_two"
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
             # Initialize the connection

--- a/tests/integration/test_list_xrefs.py
+++ b/tests/integration/test_list_xrefs.py
@@ -1,5 +1,4 @@
 import json
-import platform
 
 import pytest
 from mcp import ClientSession
@@ -10,12 +9,12 @@ from pyghidra_mcp.models import CrossReferenceInfos
 
 
 @pytest.mark.asyncio
-async def test_list_xrefs(server_params):
+async def test_list_xrefs(server_params, func_prefix, main_func_name):
     """
     Tests the list_xrefs tool to ensure it returns
     a list of cross-references from the binary.
     """
-    name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
+    name_one = f"{func_prefix}function_one"
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
@@ -33,14 +32,16 @@ async def test_list_xrefs(server_params):
 
             assert cross_reference_infos.target == name_one
             assert len(cross_reference_infos.cross_references) > 0
-            name = "entry" if platform.system() == "Darwin" else "main"
-            assert any(ref.function_name == name for ref in cross_reference_infos.cross_references)
+            assert any(
+                ref.function_name == main_func_name
+                for ref in cross_reference_infos.cross_references
+            )
 
 
 @pytest.mark.asyncio
-async def test_list_xrefs_batch(server_params):
+async def test_list_xrefs_batch(server_params, func_prefix):
     """Test list_xrefs with batch targets (one valid, one invalid)."""
-    name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
+    name_one = f"{func_prefix}function_one"
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()

--- a/tests/integration/test_read_bytes.py
+++ b/tests/integration/test_read_bytes.py
@@ -4,8 +4,6 @@ Integration test for the read_bytes functionality.
 Simple smoke test to verify read_bytes works through the MCP interface.
 """
 
-import platform
-
 import pytest
 from mcp import ClientSession
 from mcp.client.stdio import stdio_client
@@ -15,7 +13,7 @@ from pyghidra_mcp.models import BytesReadResult
 
 
 @pytest.mark.asyncio
-async def test_read_bytes_tool(server_params):
+async def test_read_bytes_tool(server_params, base_address, is_macos):
     """Test that read_bytes works - basic smoke test."""
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
@@ -24,15 +22,14 @@ async def test_read_bytes_tool(server_params):
             binary_name = PyGhidraContext._gen_unique_bin_name(server_params.args[-1])
 
             # Try reading from platform-default base addresses
-            address = "100000000" if platform.system() == "Darwin" else "100000"
             response = await session.call_tool(
-                "read_bytes", {"binary_name": binary_name, "address": address, "size": 4}
+                "read_bytes", {"binary_name": binary_name, "address": base_address, "size": 4}
             )
 
             result = BytesReadResult.model_validate_json(response.content[0].text)
 
             # Check magic bytes by platform
-            if platform.system() == "Darwin":
+            if is_macos:
                 # Accept either MH_MAGIC_64 (feedfacf) or byte-swapped MH_CIGAM_64 (cffaedfe)
                 assert result.data.lower() in {"feedfacf", "cffaedfe"}
                 assert result.address == "100000000"

--- a/tests/integration/test_search_code.py
+++ b/tests/integration/test_search_code.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import tempfile
 
 import pytest
@@ -58,11 +57,11 @@ def server_params(test_binary, ghidra_env, search_code_project_args):
 
 
 @pytest.mark.asyncio
-async def test_search_code(server_params):
+async def test_search_code(server_params, func_prefix):
     """
     Tests searching for code using similarity search.
     """
-    name = "_function_to_find" if platform.system() == "Darwin" else "function_to_find"
+    name = f"{func_prefix}function_to_find"
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
             # Initialize the connection

--- a/tests/integration/test_search_functions.py
+++ b/tests/integration/test_search_functions.py
@@ -1,5 +1,3 @@
-import platform
-
 import pytest
 from mcp import ClientSession
 from mcp.client.stdio import stdio_client
@@ -9,10 +7,10 @@ from pyghidra_mcp.models import SymbolSearchResults
 
 
 @pytest.mark.asyncio
-async def test_search_functions_by_name(server_params):
+async def test_search_functions_by_name(server_params, func_prefix):
     """Tests searching for functions by name."""
-    name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
-    name_two = "_function_two" if platform.system() == "Darwin" else "function_two"
+    name_one = f"{func_prefix}function_one"
+    name_two = f"{func_prefix}function_two"
 
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:

--- a/tests/integration/test_search_functions.py
+++ b/tests/integration/test_search_functions.py
@@ -19,8 +19,8 @@ async def test_search_functions_by_name(server_params, func_prefix):
             binary_name = PyGhidraContext._gen_unique_bin_name(server_params.args[-1])
 
             response = await session.call_tool(
-                "search_functions_by_name",
-                {"binary_name": binary_name, "query": "function_"},
+                "search_symbols_by_name",
+                {"binary_name": binary_name, "query": "function_", "functions_only": True},
             )
 
             search_results = SymbolSearchResults.model_validate_json(response.content[0].text)

--- a/tests/integration/test_search_symbols.py
+++ b/tests/integration/test_search_symbols.py
@@ -1,5 +1,3 @@
-import platform
-
 import pytest
 from mcp import ClientSession
 from mcp.client.stdio import stdio_client
@@ -9,12 +7,12 @@ from pyghidra_mcp.models import SymbolSearchResults
 
 
 @pytest.mark.asyncio
-async def test_search_symbols_by_name(server_params):
+async def test_search_symbols_by_name(server_params, func_prefix):
     """
     Tests searching for symbols by name.
     """
-    name_one = "_function_one" if platform.system() == "Darwin" else "function_one"
-    name_two = "_function_two" if platform.system() == "Darwin" else "function_two"
+    name_one = f"{func_prefix}function_one"
+    name_two = f"{func_prefix}function_two"
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
             # Initialize the connection

--- a/tests/integration/test_sse_client.py
+++ b/tests/integration/test_sse_client.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import os
-import platform
 import subprocess
 import time
 
@@ -69,7 +68,7 @@ def sse_server(test_binary, ghidra_env, sse_project_args):
 
 
 @pytest.mark.asyncio
-async def test_sse_client_smoke(sse_server):
+async def test_sse_client_smoke(sse_server, main_func_name):
     async with sse_client(f"{base_url}/sse") as (read_stream, write_stream):
         async with ClientSession(read_stream, write_stream) as session:
             # Initializing session...
@@ -79,7 +78,7 @@ async def test_sse_client_smoke(sse_server):
             binary_name = PyGhidraContext._gen_unique_bin_name(sse_server)
 
             # Decompile a function
-            name = "entry" if platform.system() == "Darwin" else "main"
+            name = main_func_name
             results = await session.call_tool(
                 "decompile_function",
                 {"binary_name": binary_name, "name_or_address": name},

--- a/tests/integration/test_streamable_client.py
+++ b/tests/integration/test_streamable_client.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import os
-import platform
 import subprocess
 import time
 
@@ -68,7 +67,7 @@ def streamable_server(test_binary, ghidra_env, streamable_project_args):
 
 
 @pytest.mark.asyncio
-async def test_streamable_client_smoke(streamable_server):
+async def test_streamable_client_smoke(streamable_server, main_func_name):
     async with streamable_http_client(f"{base_url}/mcp") as (
         read_stream,
         write_stream,
@@ -82,7 +81,7 @@ async def test_streamable_client_smoke(streamable_server):
             binary_name = PyGhidraContext._gen_unique_bin_name(streamable_server)
 
             # Decompile a function
-            name = "entry" if platform.system() == "Darwin" else "main"
+            name = main_func_name
             results = await session.call_tool(
                 "decompile_function",
                 {"binary_name": binary_name, "name_or_address": name},

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -63,16 +63,16 @@ def test_program_info_model():
         load_time=1.23,
         analysis_complete=True,
         metadata={"key": "value"},
-        code_collection=True,
-        strings_collection=False,
+        code_indexed=True,
+        strings_indexed=False,
     )
     assert info.name == "test_program"
     assert info.file_path == "/path/to/program"
     assert info.load_time == 1.23
     assert info.analysis_complete is True
     assert info.metadata == {"key": "value"}
-    assert info.code_collection is True
-    assert info.strings_collection is False
+    assert info.code_indexed is True
+    assert info.strings_indexed is False
 
 
 def test_program_infos_model():
@@ -85,8 +85,8 @@ def test_program_infos_model():
                 load_time=1.23,
                 analysis_complete=True,
                 metadata={"key": "value"},
-                code_collection=True,
-                strings_collection=False,
+                code_indexed=True,
+                strings_indexed=False,
             ),
             ProgramInfo(
                 name="test_program2",
@@ -94,8 +94,8 @@ def test_program_infos_model():
                 load_time=4.56,
                 analysis_complete=False,
                 metadata={},
-                code_collection=False,
-                strings_collection=True,
+                code_indexed=False,
+                strings_indexed=True,
             ),
         ]
     )

--- a/tests/unit/test_search_regex.py
+++ b/tests/unit/test_search_regex.py
@@ -1,4 +1,4 @@
-"""Unit tests for regex search in search_functions_by_name and search_symbols_by_name."""
+"""Unit tests for regex search in search_symbols_by_name (with and without functions_only)."""
 
 from unittest.mock import Mock
 
@@ -54,8 +54,8 @@ def _make_tools(functions=None, symbols=None):
     return tools
 
 
-class TestSearchFunctionsRegex:
-    """Tests for search_functions_by_name regex support."""
+class TestSearchFunctionsOnly:
+    """Tests for search_symbols_by_name with functions_only=True."""
 
     def _funcs(self):
         return [
@@ -69,7 +69,7 @@ class TestSearchFunctionsRegex:
     def test_plain_substring_still_works(self):
         """Plain substring query works as before (it's valid regex too)."""
         tools = _make_tools(functions=self._funcs())
-        results = tools.search_functions_by_name("function")
+        results = tools.search_symbols_by_name("function", functions_only=True)
         names = [s.name for s in results]
         assert "function_one" in names
         assert "function_two" in names
@@ -77,7 +77,7 @@ class TestSearchFunctionsRegex:
     def test_regex_exact_match(self):
         """^main$ matches only 'main', not '_main_init'."""
         tools = _make_tools(functions=self._funcs())
-        results = tools.search_functions_by_name("^main$")
+        results = tools.search_symbols_by_name("^main$", functions_only=True)
         names = [s.name for s in results]
         assert names == ["main"]
 
@@ -85,13 +85,13 @@ class TestSearchFunctionsRegex:
         """.* matches every function."""
         funcs = self._funcs()
         tools = _make_tools(functions=funcs)
-        results = tools.search_functions_by_name(".*")
+        results = tools.search_symbols_by_name(".*", functions_only=True)
         assert len(results) == len(funcs)
 
     def test_regex_pattern_with_groups(self):
         """func.*(one|two) matches function_one and function_two."""
         tools = _make_tools(functions=self._funcs())
-        results = tools.search_functions_by_name("func.*(one|two)")
+        results = tools.search_symbols_by_name("func.*(one|two)", functions_only=True)
         names = [s.name for s in results]
         assert "function_one" in names
         assert "function_two" in names
@@ -100,7 +100,7 @@ class TestSearchFunctionsRegex:
     def test_regex_case_insensitive(self):
         """Search is case-insensitive."""
         tools = _make_tools(functions=self._funcs())
-        results = tools.search_functions_by_name("^MAIN$")
+        results = tools.search_symbols_by_name("^MAIN$", functions_only=True)
         names = [s.name for s in results]
         assert names == ["main"]
 
@@ -108,7 +108,7 @@ class TestSearchFunctionsRegex:
         """Invalid regex like bare '*' falls back to substring match."""
         tools = _make_tools(functions=self._funcs())
         # '*' is invalid regex but also not a substring of any name -> empty
-        results = tools.search_functions_by_name("*")
+        results = tools.search_symbols_by_name("*", functions_only=True)
         assert results == []
 
     def test_invalid_regex_substring_match(self):
@@ -116,21 +116,21 @@ class TestSearchFunctionsRegex:
         funcs = [_make_mock_function("test[func", "0x5000")]
         tools = _make_tools(functions=funcs)
         # '[func' is invalid regex, falls back to substring
-        results = tools.search_functions_by_name("[func")
+        results = tools.search_symbols_by_name("[func", functions_only=True)
         names = [s.name for s in results]
         assert names == ["test[func"]
 
     def test_regex_metachar_uses_get_all_functions(self):
-        """When query has regex metacharacters, uses get_all_functions instead of find_functions."""
+        """When query has regex metacharacters, uses get_all_functions."""
         tools = _make_tools(functions=self._funcs())
-        tools.search_functions_by_name("^main$")
-        tools.get_all_functions.assert_called_once_with(include_externals=True)
+        tools.search_symbols_by_name("^main$", functions_only=True)
+        tools.get_all_functions.assert_called_once_with(True)
         tools.find_functions.assert_not_called()
 
     def test_plain_query_uses_find_functions(self):
         """When query is plain text, uses find_functions (pre-filter)."""
         tools = _make_tools(functions=self._funcs())
-        tools.search_functions_by_name("main")
+        tools.search_symbols_by_name("main", functions_only=True)
         tools.find_functions.assert_called_once_with("main")
         tools.get_all_functions.assert_not_called()
 
@@ -138,19 +138,19 @@ class TestSearchFunctionsRegex:
         """Empty query raises ValueError."""
         tools = _make_tools(functions=[])
         with pytest.raises(ValueError, match="Query string is required"):
-            tools.search_functions_by_name("")
+            tools.search_symbols_by_name("", functions_only=True)
 
     def test_offset_and_limit(self):
         """Offset and limit pagination works with regex."""
         tools = _make_tools(functions=self._funcs())
-        all_results = tools.search_functions_by_name(".*")
-        page = tools.search_functions_by_name(".*", offset=1, limit=2)
+        all_results = tools.search_symbols_by_name(".*", functions_only=True)
+        page = tools.search_symbols_by_name(".*", functions_only=True, offset=1, limit=2)
         assert len(page) == 2
         assert page == all_results[1:3]
 
 
-class TestSearchSymbolsRegex:
-    """Tests for search_symbols_by_name regex support."""
+class TestSearchAllSymbols:
+    """Tests for search_symbols_by_name with functions_only=False (default)."""
 
     def _syms(self):
         return [
@@ -178,7 +178,7 @@ class TestSearchSymbolsRegex:
         """Regex query uses get_all_symbols."""
         tools = _make_tools(symbols=self._syms())
         tools.search_symbols_by_name("^main$")
-        tools.get_all_symbols.assert_called_once_with(include_externals=True)
+        tools.get_all_symbols.assert_called_once_with(True)
         tools.find_symbols.assert_not_called()
 
     def test_plain_query_uses_find_symbols(self):
@@ -193,3 +193,9 @@ class TestSearchSymbolsRegex:
         tools = _make_tools(symbols=self._syms())
         results = tools.search_symbols_by_name("*")
         assert results == []
+
+    def test_default_is_all_symbols(self):
+        """Default (no functions_only) searches all symbols."""
+        tools = _make_tools(symbols=self._syms())
+        tools.search_symbols_by_name("main")
+        tools.find_symbols.assert_called_once()

--- a/tests/unit/test_search_regex.py
+++ b/tests/unit/test_search_regex.py
@@ -1,0 +1,195 @@
+"""Unit tests for regex search in search_functions_by_name and search_symbols_by_name."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from pyghidra_mcp.tools import GhidraTools
+
+
+def _make_mock_symbol(name, address="0x1000"):
+    """Create a mock Ghidra Symbol."""
+    sym = Mock()
+    sym.name = name
+    sym.getName.return_value = name
+    sym.getAddress.return_value = address
+    sym.getSymbolType.return_value = "Function"
+    sym.getParentNamespace.return_value = "Global"
+    sym.getSource.return_value = "USER_DEFINED"
+    sym.isExternal.return_value = False
+    return sym
+
+
+def _make_mock_function(name, address="0x1000"):
+    """Create a mock Ghidra Function with a Symbol."""
+    sym = _make_mock_symbol(name, address)
+    func = Mock()
+    func.getSymbol.return_value = sym
+    func.getEntryPoint.return_value = address
+    func.isExternal.return_value = False
+    func.thunk = False
+    return func
+
+
+def _make_tools(functions=None, symbols=None):
+    """Create a GhidraTools instance with mocked internals."""
+    program_info = Mock()
+    rm = Mock()
+    rm.getReferencesTo.return_value = []
+    program_info.program.getReferenceManager.return_value = rm
+
+    tools = GhidraTools.__new__(GhidraTools)
+    tools.program_info = program_info
+    tools.program = program_info.program
+    tools.decompiler = Mock()
+
+    if functions is not None:
+        tools.get_all_functions = Mock(return_value=functions)
+        tools.find_functions = Mock(return_value=functions)
+
+    if symbols is not None:
+        tools.get_all_symbols = Mock(return_value=symbols)
+        tools.find_symbols = Mock(return_value=symbols)
+
+    return tools
+
+
+class TestSearchFunctionsRegex:
+    """Tests for search_functions_by_name regex support."""
+
+    def _funcs(self):
+        return [
+            _make_mock_function("main", "0x1000"),
+            _make_mock_function("_main_init", "0x1100"),
+            _make_mock_function("function_one", "0x2000"),
+            _make_mock_function("function_two", "0x3000"),
+            _make_mock_function("helper_func", "0x4000"),
+        ]
+
+    def test_plain_substring_still_works(self):
+        """Plain substring query works as before (it's valid regex too)."""
+        tools = _make_tools(functions=self._funcs())
+        results = tools.search_functions_by_name("function")
+        names = [s.name for s in results]
+        assert "function_one" in names
+        assert "function_two" in names
+
+    def test_regex_exact_match(self):
+        """^main$ matches only 'main', not '_main_init'."""
+        tools = _make_tools(functions=self._funcs())
+        results = tools.search_functions_by_name("^main$")
+        names = [s.name for s in results]
+        assert names == ["main"]
+
+    def test_regex_dotstar_matches_all(self):
+        """.* matches every function."""
+        funcs = self._funcs()
+        tools = _make_tools(functions=funcs)
+        results = tools.search_functions_by_name(".*")
+        assert len(results) == len(funcs)
+
+    def test_regex_pattern_with_groups(self):
+        """func.*(one|two) matches function_one and function_two."""
+        tools = _make_tools(functions=self._funcs())
+        results = tools.search_functions_by_name("func.*(one|two)")
+        names = [s.name for s in results]
+        assert "function_one" in names
+        assert "function_two" in names
+        assert "helper_func" not in names
+
+    def test_regex_case_insensitive(self):
+        """Search is case-insensitive."""
+        tools = _make_tools(functions=self._funcs())
+        results = tools.search_functions_by_name("^MAIN$")
+        names = [s.name for s in results]
+        assert names == ["main"]
+
+    def test_invalid_regex_falls_back_to_substring(self):
+        """Invalid regex like bare '*' falls back to substring match."""
+        tools = _make_tools(functions=self._funcs())
+        # '*' is invalid regex but also not a substring of any name -> empty
+        results = tools.search_functions_by_name("*")
+        assert results == []
+
+    def test_invalid_regex_substring_match(self):
+        """Invalid regex that is a valid substring still matches."""
+        funcs = [_make_mock_function("test[func", "0x5000")]
+        tools = _make_tools(functions=funcs)
+        # '[func' is invalid regex, falls back to substring
+        results = tools.search_functions_by_name("[func")
+        names = [s.name for s in results]
+        assert names == ["test[func"]
+
+    def test_regex_metachar_uses_get_all_functions(self):
+        """When query has regex metacharacters, uses get_all_functions instead of find_functions."""
+        tools = _make_tools(functions=self._funcs())
+        tools.search_functions_by_name("^main$")
+        tools.get_all_functions.assert_called_once_with(include_externals=True)
+        tools.find_functions.assert_not_called()
+
+    def test_plain_query_uses_find_functions(self):
+        """When query is plain text, uses find_functions (pre-filter)."""
+        tools = _make_tools(functions=self._funcs())
+        tools.search_functions_by_name("main")
+        tools.find_functions.assert_called_once_with("main")
+        tools.get_all_functions.assert_not_called()
+
+    def test_empty_query_raises(self):
+        """Empty query raises ValueError."""
+        tools = _make_tools(functions=[])
+        with pytest.raises(ValueError, match="Query string is required"):
+            tools.search_functions_by_name("")
+
+    def test_offset_and_limit(self):
+        """Offset and limit pagination works with regex."""
+        tools = _make_tools(functions=self._funcs())
+        all_results = tools.search_functions_by_name(".*")
+        page = tools.search_functions_by_name(".*", offset=1, limit=2)
+        assert len(page) == 2
+        assert page == all_results[1:3]
+
+
+class TestSearchSymbolsRegex:
+    """Tests for search_symbols_by_name regex support."""
+
+    def _syms(self):
+        return [
+            _make_mock_symbol("main", "0x1000"),
+            _make_mock_symbol("_main_init", "0x1100"),
+            _make_mock_symbol("printf", "0x2000"),
+            _make_mock_symbol("__libc_start_main", "0x3000"),
+        ]
+
+    def test_regex_exact_match(self):
+        """^printf$ matches only 'printf'."""
+        tools = _make_tools(symbols=self._syms())
+        results = tools.search_symbols_by_name("^printf$")
+        names = [s.name for s in results]
+        assert names == ["printf"]
+
+    def test_regex_dotstar_matches_all(self):
+        """.* matches every symbol."""
+        syms = self._syms()
+        tools = _make_tools(symbols=syms)
+        results = tools.search_symbols_by_name(".*")
+        assert len(results) == len(syms)
+
+    def test_regex_metachar_uses_get_all_symbols(self):
+        """Regex query uses get_all_symbols."""
+        tools = _make_tools(symbols=self._syms())
+        tools.search_symbols_by_name("^main$")
+        tools.get_all_symbols.assert_called_once_with(include_externals=True)
+        tools.find_symbols.assert_not_called()
+
+    def test_plain_query_uses_find_symbols(self):
+        """Plain query uses find_symbols."""
+        tools = _make_tools(symbols=self._syms())
+        tools.search_symbols_by_name("main")
+        tools.find_symbols.assert_called_once_with("main")
+        tools.get_all_symbols.assert_not_called()
+
+    def test_invalid_regex_falls_back(self):
+        """Invalid regex falls back to substring."""
+        tools = _make_tools(symbols=self._syms())
+        results = tools.search_symbols_by_name("*")
+        assert results == []


### PR DESCRIPTION
## Summary
- Add conftest fixtures for platform-specific test constants (eliminates 25+ repeated ternaries)
- Add regex support to `search_symbols_by_name`; consolidate `search_functions_by_name` into it via `functions_only` param
- Optimize `get_referenced_strings` (instruction-based iteration)
- Add `--callees`/`--strings`/`--xrefs` and `--functions-only` flags to CLI
- Fix CLI macOS test timeout (poll analysis readiness separately from server startup)
- Rename `*_collection` to `*_indexed` in public API model (clearer now that ChromaDB was dropped for strings)
- Drop Ghidra 11.x from macOS CLI matrix (JVM startup exceeds 240s)
- Add `UV_NO_SYNC=1` to CI CLI test runs

## Test plan
- [x] `make test-unit` - 44 tests pass
- [x] `make lint`, `pyright` clean
- [x] Integration tests pass locally
- [x] CI passes