### PR TITLE
Add phase 1 GUI-backed shared-program mode

### DIFF
--- a/src/pyghidra_mcp/context.py
+++ b/src/pyghidra_mcp/context.py
@@ -723,14 +723,13 @@ class PyGhidraContext:
         verbose_analysis: bool = False,
     ):
         # Import symbol utilities from ghidrecomp
-        from ghidrecomp.utility import get_pdb, set_pdb, set_remote_pdbs, setup_symbol_server
-
         from ghidra.app.script import GhidraScriptUtil
         from ghidra.framework.model import DomainFile
         from ghidra.program.flatapi import FlatProgramAPI
         from ghidra.program.model.listing import Program
         from ghidra.program.util import GhidraProgramUtilities
         from ghidra.util.task import ConsoleTaskMonitor
+        from ghidrecomp.utility import get_pdb, set_pdb, set_remote_pdbs, setup_symbol_server
 
         df = df_or_prog
         if not isinstance(df_or_prog, DomainFile):
@@ -954,13 +953,12 @@ class PyGhidraContext:
         """
         Apply GDT to program
         """
-        from java.io import File  # type: ignore
-        from java.util import List  # type: ignore
-
         from ghidra.app.cmd.function import ApplyFunctionDataTypesCmd
         from ghidra.program.model.data import FileDataTypeManager
         from ghidra.program.model.symbol import SourceType
         from ghidra.util.task import ConsoleTaskMonitor
+        from java.io import File  # type: ignore
+        from java.util import List  # type: ignore
 
         gdt_path = Path(gdt_path)
 

--- a/src/pyghidra_mcp/context.py
+++ b/src/pyghidra_mcp/context.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Union
 import chromadb
 from chromadb.config import Settings
 
+from pyghidra_mcp.models import ProgramInfo as ProgramInfoModel
 from pyghidra_mcp.tools import GhidraTools
 
 if TYPE_CHECKING:
@@ -208,6 +209,27 @@ class PyGhidraContext:
             return names
 
         return list_folder_contents(self.project.getRootFolder())
+
+    def list_program_infos(self) -> list[ProgramInfo]:
+        """Return loaded program infos for MCP project listing."""
+        return list(self.programs.values())
+
+    def list_project_binary_infos(self) -> list[ProgramInfoModel]:
+        """Return MCP response models for project binaries."""
+        program_infos = []
+        for name, pi in self.programs.items():
+            program_infos.append(
+                ProgramInfoModel(
+                    name=name,
+                    file_path=str(pi.file_path) if pi.file_path else None,
+                    load_time=pi.load_time,
+                    analysis_complete=pi.analysis_complete,
+                    metadata={},
+                    code_indexed=pi.code_collection is not None,
+                    strings_indexed=pi.strings is not None,
+                )
+            )
+        return program_infos
 
     def list_binary_domain_files(self) -> list["DomainFile"]:
         """Return a list of DomainFile objects for all binaries in the project.
@@ -700,15 +722,15 @@ class PyGhidraContext:
         force_analysis: bool = False,
         verbose_analysis: bool = False,
     ):
+        # Import symbol utilities from ghidrecomp
+        from ghidrecomp.utility import get_pdb, set_pdb, set_remote_pdbs, setup_symbol_server
+
         from ghidra.app.script import GhidraScriptUtil
         from ghidra.framework.model import DomainFile
         from ghidra.program.flatapi import FlatProgramAPI
         from ghidra.program.model.listing import Program
         from ghidra.program.util import GhidraProgramUtilities
         from ghidra.util.task import ConsoleTaskMonitor
-
-        # Import symbol utilities from ghidrecomp
-        from ghidrecomp.utility import get_pdb, set_pdb, set_remote_pdbs, setup_symbol_server
 
         df = df_or_prog
         if not isinstance(df_or_prog, DomainFile):
@@ -932,12 +954,13 @@ class PyGhidraContext:
         """
         Apply GDT to program
         """
+        from java.io import File  # type: ignore
+        from java.util import List  # type: ignore
+
         from ghidra.app.cmd.function import ApplyFunctionDataTypesCmd
         from ghidra.program.model.data import FileDataTypeManager
         from ghidra.program.model.symbol import SourceType
         from ghidra.util.task import ConsoleTaskMonitor
-        from java.io import File  # type: ignore
-        from java.util import List  # type: ignore
 
         gdt_path = Path(gdt_path)
 

--- a/src/pyghidra_mcp/context_protocol.py
+++ b/src/pyghidra_mcp/context_protocol.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from .context import ProgramInfo
+    from .models import ProgramInfo as ProgramInfoModel
+
+
+class MCPContext(Protocol):
+    """Tool-facing context contract shared by headless and GUI modes."""
+
+    programs: dict[str, "ProgramInfo"]
+
+    def get_program_info(self, binary_name: str) -> "ProgramInfo": ...
+
+    def list_binaries(self) -> list[str]: ...
+
+    def list_binary_domain_files(self) -> list[Any]: ...
+
+    def list_program_infos(self) -> list["ProgramInfo"]: ...
+
+    def list_project_binary_infos(self) -> list["ProgramInfoModel"]: ...
+
+    def delete_program(self, program_name: str) -> bool: ...
+
+    def import_binary_backgrounded(self, binary_path: str | Path) -> None: ...
+
+    def close(self, save: bool = True) -> None: ...

--- a/src/pyghidra_mcp/gui_context.py
+++ b/src/pyghidra_mcp/gui_context.py
@@ -1,0 +1,544 @@
+import concurrent.futures
+import json
+import logging
+import threading
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from pyghidra_mcp.context import ProgramInfo
+from pyghidra_mcp.models import ProgramInfo as ProgramInfoModel
+from pyghidra_mcp.project_spec import ProjectSpec
+
+logger = logging.getLogger(__name__)
+
+
+class GuiPyGhidraContext:
+    """MCP context backed by the active in-process Ghidra GUI project.
+
+    The GUI owns the project and Program lifecycle. This context owns only MCP-side
+    helpers such as DecompInterface instances and Python references.
+    """
+
+    def __init__(
+        self,
+        project_spec: ProjectSpec,
+        *,
+        pyghidra_mcp_dir: Path | None = None,
+        readiness_timeout: float = 30.0,
+        readiness_interval: float = 0.2,
+    ):
+        self.project_spec = project_spec
+        self.project_name = project_spec.project_name
+        self.project_path = project_spec.project_directory
+        self.pyghidra_mcp_dir = pyghidra_mcp_dir or project_spec.pyghidra_mcp_dir
+        self.programs: dict[str, ProgramInfo] = {}
+        self._programs_lock = threading.RLock()
+        self.import_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+
+        self.project = self.wait_for_gui_ready(
+            timeout=readiness_timeout,
+            interval=readiness_interval,
+        )
+        self.refresh_programs()
+
+    @staticmethod
+    def wait_for_gui_ready(timeout: float = 30.0, interval: float = 0.2):
+        """Wait until Ghidra has an active project."""
+        from ghidra.framework.main import AppInfo
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            project = AppInfo.getActiveProject()
+            if project is not None:
+                return project
+            time.sleep(interval)
+
+        raise RuntimeError("Timed out waiting for Ghidra GUI active project.")
+
+    def refresh_programs(self) -> None:
+        active: dict[str, Any] = {}
+        for program_manager in self._get_program_managers():
+            for program in program_manager.getAllOpenPrograms():
+                domain_file = program.getDomainFile()
+                key = domain_file.getPathname() if domain_file else program.getName()
+                active[str(key)] = program
+
+        with self._programs_lock:
+            stale_keys = set(self.programs) - set(active)
+            for key in stale_keys:
+                self._dispose_decompiler(self.programs[key])
+                del self.programs[key]
+
+            for key, program in active.items():
+                if key not in self.programs:
+                    self.programs[key] = self._init_program_info(program)
+                    continue
+
+                program_info = self.programs[key]
+                if program_info.program != program:
+                    self._dispose_decompiler(program_info)
+                    self.programs[key] = self._init_program_info(program)
+                    continue
+
+                self._sync_program_info(program_info, program)
+
+    def list_binaries(self) -> list[str]:
+        return [df.getPathname() for df in self.list_binary_domain_files()]
+
+    def list_binary_domain_files(self) -> list[Any]:
+        return self._list_folder_domain_files(self.project.getProjectData().getRootFolder())
+
+    def list_open_programs(self) -> list[dict[str, Any]]:
+        self.refresh_programs()
+        program_manager = self._get_primary_program_manager(required=False)
+        current_program = program_manager.getCurrentProgram() if program_manager else None
+
+        with self._programs_lock:
+            results = []
+            for path, program_info in self.programs.items():
+                results.append(
+                    {
+                        "name": program_info.name,
+                        "path": path,
+                        "current": program_info.program == current_program,
+                        "analysis_complete": program_info.analysis_complete,
+                    }
+                )
+            return results
+
+    def open_program_in_gui(self, binary_name: str, *, current: bool = False) -> dict[str, Any]:
+        from ghidra.app.services import ProgramManager
+        from ghidra.framework.model import DomainFile
+
+        domain_file = self._find_domain_file(binary_name)
+        program_manager = self._get_primary_program_manager(required=False)
+        if program_manager is None:
+            from java.util import List  # type: ignore
+
+            tool = self.project.getToolServices().launchDefaultTool(List.of(domain_file))
+            if tool is None:
+                raise RuntimeError(f"Failed to launch a Ghidra tool for {binary_name}")
+            program_manager = self._get_primary_program_manager()
+
+        assert program_manager is not None
+        state = ProgramManager.OPEN_CURRENT if current else ProgramManager.OPEN_VISIBLE
+        program_manager.openProgram(domain_file, DomainFile.DEFAULT_VERSION, state)
+
+        expected_path = str(domain_file.getPathname())
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            self.refresh_programs()
+            with self._programs_lock:
+                program_info = self.programs.get(expected_path)
+                if program_info is not None:
+                    return {
+                        "name": program_info.name,
+                        "path": expected_path,
+                        "current": current
+                        or program_info.program == program_manager.getCurrentProgram(),
+                        "analysis_complete": program_info.analysis_complete,
+                    }
+            time.sleep(0.1)
+
+        raise RuntimeError(f"Timed out waiting for GUI to open program {expected_path}")
+
+    def set_current_program(self, binary_name: str) -> dict[str, Any]:
+        return self.open_program_in_gui(binary_name, current=True)
+
+    def run_on_swing(self, fn, *args, **kwargs):
+        import jpype
+        from java.lang import Runnable  # type: ignore
+
+        from ghidra.util import Swing
+
+        result_box: list[Any] = [None]
+        exc_box: list[BaseException | None] = [None]
+
+        def runnable():
+            try:
+                result_box[0] = fn(*args, **kwargs)
+            except BaseException as e:
+                exc_box[0] = e
+
+        Swing.runNow(jpype.JProxy(Runnable, dict={"run": runnable}))
+        if exc_box[0] is not None:
+            raise exc_box[0]
+        return result_box[0]
+
+    def goto(self, binary_name: str, target: str, target_type: str) -> dict[str, Any]:
+        normalized_type = target_type.lower()
+        program_info = self._resolve_program_info(binary_name)
+
+        if normalized_type == "function":
+            from pyghidra_mcp.tools import GhidraTools
+
+            function = GhidraTools(program_info).find_function(target)
+            address_obj = function.getEntryPoint()
+        elif normalized_type == "address":
+            address_obj = self._parse_address(program_info.program, target)
+        else:
+            raise ValueError(
+                f"Invalid target_type '{target_type}'. Expected one of: ['address', 'function']"
+            )
+
+        tool = self._find_tool_for_program(program_info.program)
+
+        from ghidra.app.services import GoToService
+
+        service = tool.getService(GoToService)
+        if service is None:
+            raise RuntimeError("No GoToService is available in the active Ghidra tool.")
+
+        def do_goto():
+            return bool(service.goTo(address_obj, program_info.program))
+
+        success = bool(self.run_on_swing(do_goto))
+        return {
+            "binary_name": binary_name,
+            "address": str(address_obj),
+            "success": success,
+        }
+
+    def _get_program_managers(self) -> list[Any]:
+        from ghidra.app.services import ProgramManager
+
+        program_managers = []
+        for tool in self.project.getToolServices().getRunningTools():
+            program_manager = tool.getService(ProgramManager)
+            if program_manager is not None:
+                program_managers.append(program_manager)
+        return program_managers
+
+    def _get_primary_program_manager(self, *, required: bool = True):
+        program_managers = self._get_program_managers()
+        if program_managers:
+            return program_managers[0]
+        if required:
+            raise RuntimeError("No Ghidra tool with ProgramManager is available.")
+        return None
+
+    def _find_tool_for_program(self, program):
+        from ghidra.app.services import ProgramManager
+
+        fallback_tool = None
+        for tool in self.project.getToolServices().getRunningTools():
+            program_manager = tool.getService(ProgramManager)
+            if program_manager is None:
+                continue
+            fallback_tool = fallback_tool or tool
+            if program in list(program_manager.getAllOpenPrograms()):
+                return tool
+        if fallback_tool is not None:
+            return fallback_tool
+        raise RuntimeError("No Ghidra tool with ProgramManager is available.")
+
+    def _find_domain_file(self, binary_name: str):
+        matches = []
+        for domain_file in self.list_binary_domain_files():
+            path = str(domain_file.getPathname())
+            name = str(domain_file.getName())
+            if binary_name in {path, name, Path(path).name}:
+                matches.append(domain_file)
+
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            paths = [str(domain_file.getPathname()) for domain_file in matches]
+            raise ValueError(
+                f"Binary name '{binary_name}' is ambiguous. Use one of these paths: {paths}"
+            )
+        raise ValueError(f"Binary {binary_name} not found in project.")
+
+    @staticmethod
+    def _parse_address(program, address: str):
+        addr_str = address[2:] if address.lower().startswith("0x") else address
+        addr = program.getAddressFactory().getAddress(addr_str)
+        if addr is None:
+            raise ValueError(f"Invalid address: {address}")
+        return addr
+
+    @staticmethod
+    def _list_folder_domain_files(folder) -> list[Any]:
+        def list_folder_domain_files(folder) -> list[Any]:
+            files: list[Any] = []
+            for subfolder in folder.getFolders():
+                files.extend(list_folder_domain_files(subfolder))
+            files.extend([f for f in folder.getFiles() if f.getContentType() == "Program"])
+            return files
+
+        return list_folder_domain_files(folder)
+
+    def list_program_infos(self) -> list[ProgramInfo]:
+        self.refresh_programs()
+        with self._programs_lock:
+            return list(self.programs.values())
+
+    def list_project_binary_infos(self) -> list[ProgramInfoModel]:
+        self.refresh_programs()
+        with self._programs_lock:
+            live_programs = dict(self.programs)
+
+        program_infos = []
+        for domain_file in self.list_binary_domain_files():
+            path = str(domain_file.getPathname())
+            live_info = live_programs.get(path)
+            if live_info is not None:
+                program_infos.append(
+                    ProgramInfoModel(
+                        name=path,
+                        file_path=str(live_info.file_path) if live_info.file_path else None,
+                        load_time=live_info.load_time,
+                        analysis_complete=live_info.analysis_complete,
+                        metadata=live_info.metadata,
+                        code_indexed=live_info.code_collection is not None,
+                        strings_indexed=live_info.strings is not None,
+                    )
+                )
+                continue
+
+            metadata = dict(domain_file.getMetadata() or {})
+            executable_location = metadata.get("Executable Location")
+            analyzed_value = str(metadata.get("Analyzed", "")).lower()
+            program_infos.append(
+                ProgramInfoModel(
+                    name=path,
+                    file_path=executable_location,
+                    load_time=None,
+                    analysis_complete=analyzed_value == "true",
+                    metadata=metadata,
+                    code_indexed=False,
+                    strings_indexed=False,
+                )
+            )
+        return program_infos
+
+    def get_program_info(self, binary_name: str) -> ProgramInfo:
+        program_info = self._resolve_program_info(binary_name)
+
+        if not program_info.analysis_complete:
+            raise RuntimeError(
+                json.dumps(
+                    {
+                        "message": f"Analysis incomplete for binary '{binary_name}'.",
+                        "binary_name": binary_name,
+                        "ghidra_analysis_complete": program_info.ghidra_analysis_complete,
+                        "code_indexed": program_info.code_collection is not None,
+                        "strings_indexed": program_info.strings is not None,
+                        "suggestion": "Wait and try tool call again.",
+                    }
+                )
+            )
+        return program_info
+
+    def _resolve_program_info(self, binary_name: str) -> ProgramInfo:
+        self.refresh_programs()
+        with self._programs_lock:
+            program_info = self.programs.get(binary_name)
+            if program_info is None:
+                program_info = self._get_unique_short_name_match(binary_name)
+
+            if program_info is None:
+                available_progs = list(self.programs.keys())
+                try:
+                    opened_info = self.open_program_in_gui(binary_name)
+                except ValueError:
+                    raise ValueError(
+                        f"Binary {binary_name} not found. Available binaries: {available_progs}"
+                    ) from None
+                program_info = self.programs.get(opened_info["path"])
+                if program_info is None:
+                    raise ValueError(
+                        f"Binary {binary_name} could not be opened. Available binaries: "
+                        f"{available_progs}"
+                    )
+        return program_info
+
+    def delete_program(self, program_name: str) -> bool:
+        try:
+            program_info = self._resolve_program_info(program_name)
+            program = program_info.program
+            domain_file = program.getDomainFile()
+        except ValueError:
+            program_info = None
+            program = None
+            domain_file = self._find_domain_file(program_name)
+
+        for program_manager in self._get_program_managers():
+            if program is not None and program in list(program_manager.getAllOpenPrograms()):
+                if not bool(program_manager.closeProgram(program, False)):
+                    return False
+
+        if program_info is not None:
+            self._dispose_decompiler(program_info)
+
+        domain_file.delete()
+        self.refresh_programs()
+        return True
+
+    def import_binaries(self, binary_paths: Sequence[str | Path]) -> None:
+        resolved_paths: list[Path] = [Path(p) for p in binary_paths]
+
+        files_to_import: list[tuple[Path, Path | None]] = []
+        for path in resolved_paths:
+            if path.is_dir():
+                for candidate in path.rglob("*"):
+                    if candidate.is_file() and self._is_binary_file(candidate):
+                        files_to_import.append((candidate, candidate.relative_to(path).parent))
+            elif path.is_file() and self._is_binary_file(path):
+                files_to_import.append((path, None))
+
+        for binary_path, relative_path in files_to_import:
+            self.import_binary(binary_path, relative_path=relative_path)
+
+    def import_binary(self, binary_path: str | Path, relative_path: Path | None = None) -> None:
+        from java.io import File  # type: ignore
+
+        from ghidra.app.util.importer import ProgramLoader
+        from ghidra.util.task import TaskMonitor
+        from pyghidra_mcp.context import PyGhidraContext
+
+        binary_path = Path(binary_path)
+        if binary_path.is_dir():
+            return self.import_binaries([binary_path])
+
+        program_name = PyGhidraContext._gen_unique_bin_name(binary_path)
+        folder_path = (
+            "/" if relative_path is None or str(relative_path) == "." else f"/{relative_path}"
+        )
+        expected_path = str(Path(folder_path) / program_name)
+
+        try:
+            self.open_program_in_gui(expected_path)
+            return
+        except ValueError:
+            pass
+
+        load_results = None
+        try:
+            load_results = (
+                ProgramLoader.builder()
+                .source(File(str(binary_path.absolute())))
+                .project(self.project)
+                .projectFolderPath(folder_path)
+                .name(program_name)
+                .monitor(TaskMonitor.DUMMY)
+                .load()
+            )
+            domain_file = load_results.getPrimary().save(TaskMonitor.DUMMY)
+        finally:
+            if load_results is not None:
+                load_results.close()
+
+        self.open_program_in_gui(str(domain_file.getPathname()))
+
+    def import_binary_backgrounded(self, binary_path: str | Path) -> None:
+        binary_path = Path(binary_path)
+        if not binary_path.exists():
+            raise FileNotFoundError(f"The file {binary_path} cannot be found")
+
+        future = self.import_executor.submit(self.import_binary, binary_path)
+        future.add_done_callback(self._import_done_callback)
+
+    def close(self, save: bool = True) -> None:
+        """Release MCP-owned resources. Does not close the GUI project or programs."""
+        self.import_executor.shutdown(wait=True)
+        with self._programs_lock:
+            for program_info in self.programs.values():
+                self._dispose_decompiler(program_info)
+            self.programs.clear()
+
+    @staticmethod
+    def _is_binary_file(path: Path) -> bool:
+        return True
+
+    @staticmethod
+    def _import_done_callback(future: concurrent.futures.Future) -> None:
+        try:
+            future.result()
+            logger.info("GUI background import completed successfully.")
+        except Exception:
+            logger.error("GUI background import failed.", exc_info=True)
+
+    def _get_unique_short_name_match(self, binary_name: str) -> ProgramInfo | None:
+        matches: list[tuple[str, ProgramInfo]] = []
+        for full_path, program_info in self.programs.items():
+            domain_file = program_info.program.getDomainFile()
+            names = {Path(full_path).name, program_info.name}
+            if domain_file is not None:
+                names.add(str(domain_file.getName()))
+            if binary_name in names:
+                matches.append((full_path, program_info))
+
+        if len(matches) == 1:
+            return matches[0][1]
+        if len(matches) > 1:
+            paths = [path for path, _program_info in matches]
+            raise ValueError(
+                f"Binary name '{binary_name}' is ambiguous. Use one of these paths: {paths}"
+            )
+        return None
+
+    def _init_program_info(self, program) -> ProgramInfo:
+        from ghidra.program.flatapi import FlatProgramAPI
+
+        program_info = ProgramInfo(
+            name=program.getName(),
+            program=program,
+            flat_api=FlatProgramAPI(program),
+            decompiler=self._setup_decompiler(program),
+            metadata={},
+            ghidra_analysis_complete=False,
+            file_path=None,
+            load_time=time.time(),
+            code_collection=None,
+            strings=None,
+        )
+        self._sync_program_info(program_info, program)
+        return program_info
+
+    def _sync_program_info(self, program_info: ProgramInfo, program) -> None:
+        metadata = dict(program.getMetadata())
+        executable_location = metadata.get("Executable Location")
+
+        program_info.name = program.getName()
+        program_info.program = program
+        program_info.metadata = metadata
+        program_info.file_path = Path(executable_location) if executable_location else None
+        program_info.ghidra_analysis_complete = self._is_program_analysis_complete(program)
+
+    @staticmethod
+    def _is_program_analysis_complete(program) -> bool:
+        from ghidra.program.util import GhidraProgramUtilities
+
+        try:
+            return not bool(GhidraProgramUtilities.shouldAskToAnalyze(program))
+        except Exception:
+            logger.debug("Could not determine GUI program analysis state", exc_info=True)
+            return False
+
+    @staticmethod
+    def _setup_decompiler(program):
+        from ghidra.app.decompiler import DecompileOptions, DecompInterface
+
+        options = DecompileOptions()
+        options.grabFromProgram(program)
+        options.setMaxPayloadMBytes(100)
+
+        decompiler = DecompInterface()
+        decompiler.setOptions(options)
+        decompiler.openProgram(program)
+        return decompiler
+
+    @staticmethod
+    def _dispose_decompiler(program_info: ProgramInfo) -> None:
+        decompiler = program_info.decompiler
+        for method_name in ("dispose", "closeProgram"):
+            method = getattr(decompiler, method_name, None)
+            if method is not None:
+                try:
+                    method()
+                except Exception:
+                    logger.debug("Failed to dispose decompiler with %s", method_name, exc_info=True)
+                return

--- a/src/pyghidra_mcp/gui_context.py
+++ b/src/pyghidra_mcp/gui_context.py
@@ -149,9 +149,8 @@ class GuiPyGhidraContext:
 
     def run_on_swing(self, fn, *args, **kwargs):
         import jpype
-        from java.lang import Runnable  # type: ignore
-
         from ghidra.util import Swing
+        from java.lang import Runnable  # type: ignore
 
         result_box: list[Any] = [None]
         exc_box: list[BaseException | None] = [None]
@@ -393,10 +392,10 @@ class GuiPyGhidraContext:
             self.import_binary(binary_path, relative_path=relative_path)
 
     def import_binary(self, binary_path: str | Path, relative_path: Path | None = None) -> None:
-        from java.io import File  # type: ignore
-
         from ghidra.app.util.importer import ProgramLoader
         from ghidra.util.task import TaskMonitor
+        from java.io import File  # type: ignore
+
         from pyghidra_mcp.context import PyGhidraContext
 
         binary_path = Path(binary_path)

--- a/src/pyghidra_mcp/gui_launcher.py
+++ b/src/pyghidra_mcp/gui_launcher.py
@@ -1,0 +1,88 @@
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+from pyghidra.launcher import DeferredPyGhidraLauncher
+
+REEXEC_ENV = "PYGHIDRA_MCP_REEXEC"
+
+
+def _framework_python_path() -> Path:
+    return Path(sys.base_exec_prefix) / "Resources/Python.app/Contents/MacOS/Python"
+
+
+def ensure_macos_framework_python() -> None:
+    """Re-exec into framework Python before JVM startup when GUI mode needs it."""
+    if sys.platform != "darwin":
+        return
+
+    if os.environ.get(REEXEC_ENV):
+        # Python.app may preserve the venv's sys.executable after re-exec, so
+        # sys.executable is not a reliable framework-Python check here.
+        return
+
+    framework_python = _framework_python_path()
+    if not framework_python.exists():
+        return
+
+    if Path(sys.executable).resolve() == framework_python.resolve():
+        return
+
+    env = os.environ.copy()
+    env[REEXEC_ENV] = "1"
+    os.execve(
+        str(framework_python),
+        [sys.executable, "-m", "pyghidra_mcp", *sys.argv[1:]],
+        env,
+    )
+
+
+class GuiPyGhidraMcpLauncher(DeferredPyGhidraLauncher):
+    """Deferred PyGhidra launcher that runs Ghidra GUI as the blocking foreground app."""
+
+    def __init__(self, project_gpr_path: Path, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.args = [str(project_gpr_path.absolute())]
+        self._is_exiting = threading.Event()
+        self._shutdown_requested = False
+
+    def run_gui_event_loop(self) -> None:
+        """Initialize the Ghidra GUI and block until the JVM is shutting down."""
+        from java.lang import Runtime, Thread  # type: ignore
+
+        Runtime.getRuntime().addShutdownHook(Thread(self._is_exiting.set))
+
+        self.initialize_ghidra(headless=False)
+
+        if sys.platform == "darwin":
+            from pyghidra.launcher import _run_mac_app
+
+            _run_mac_app()
+
+        self._is_exiting.wait()
+
+    def request_shutdown(self) -> None:
+        """Ask the running Ghidra front-end to close itself cleanly."""
+        if self._shutdown_requested or self._is_exiting.is_set():
+            return
+        self._shutdown_requested = True
+
+        from ghidra.framework.main import AppInfo
+        from ghidra.util import Swing
+
+        def do_close():
+            front_end_tool = AppInfo.getFrontEndTool()
+            if front_end_tool is not None:
+                front_end_tool.close()
+
+        Swing.runLater(do_close)
+
+    def wait_for_shutdown(self, timeout: float = 5.0) -> bool:
+        """Wait briefly for a clean GUI shutdown after requesting it."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self._is_exiting.wait(timeout=0.1):
+                return True
+        return self._is_exiting.is_set()

--- a/src/pyghidra_mcp/mcp_tools.py
+++ b/src/pyghidra_mcp/mcp_tools.py
@@ -6,25 +6,29 @@ This module contains all MCP tool implementations with centralized error handlin
 
 import functools
 import logging
-from typing import Literal
+from typing import Literal, cast
 
 from mcp.server.fastmcp import Context
 from mcp.shared.exceptions import McpError
 from mcp.types import INTERNAL_ERROR, INVALID_PARAMS, ErrorData
 
-from pyghidra_mcp.context import PyGhidraContext
+from pyghidra_mcp.context_protocol import MCPContext
 from pyghidra_mcp.models import (
     BytesReadResult,
     CallGraphDirection,
     CallGraphDisplayType,
     CallGraphResult,
     CodeSearchResults,
+    CommentResponse,
     CrossReferenceInfos,
     DecompiledFunction,
     ExportInfos,
+    GotoResponse,
     ImportInfos,
-    ProgramInfo,
+    OpenProgramInfo,
+    OpenProgramInfos,
     ProgramInfos,
+    RenameResponse,
     SearchMode,
     StringSearchResults,
     SymbolSearchResults,
@@ -32,6 +36,23 @@ from pyghidra_mcp.models import (
 from pyghidra_mcp.tools import GhidraTools
 
 logger = logging.getLogger(__name__)
+
+
+def _require_gui_context(ctx: Context):
+    from pyghidra_mcp.gui_context import GuiPyGhidraContext
+
+    pyghidra_context = ctx.request_context.lifespan_context
+    if not isinstance(pyghidra_context, GuiPyGhidraContext):
+        raise ValueError("This tool requires pyghidra-mcp to be running with --gui")
+    return pyghidra_context
+
+
+def _run_for_context(pyghidra_context: MCPContext, fn):
+    from pyghidra_mcp.gui_context import GuiPyGhidraContext
+
+    if isinstance(pyghidra_context, GuiPyGhidraContext):
+        return pyghidra_context.run_on_swing(fn)
+    return fn()
 
 
 def _get_action_name(func_name: str) -> str:
@@ -97,7 +118,7 @@ async def decompile_function(
     Accepts a single target or a list for batch decompilation.
     Rich response flags attach callees, strings, and/or xrefs to each result.
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
     targets = [name_or_address] if isinstance(name_or_address, str) else name_or_address
@@ -134,7 +155,7 @@ def search_symbols_by_name(
     Set ``functions_only=True`` to search only function symbols
     (excludes labels, variables, classes, namespaces).
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
     symbols = tools.search_symbols_by_name(
@@ -160,7 +181,7 @@ def search_code(
     Modes: semantic (vector similarity, default) or literal (exact match).
     Results include both mode counts.
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
     return tools.search_code(
@@ -177,35 +198,95 @@ def search_code(
 @mcp_error_handler
 def list_project_binaries(ctx: Context) -> ProgramInfos:
     """List all binaries in the project with their status."""
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
-    program_infos = []
-    for name, pi in pyghidra_context.programs.items():
-        program_infos.append(
-            ProgramInfo(
-                name=name,
-                file_path=str(pi.file_path) if pi.file_path else None,
-                load_time=pi.load_time,
-                analysis_complete=pi.analysis_complete,
-                metadata={},
-                code_indexed=pi.code_collection is not None,
-                strings_indexed=pi.strings is not None,
-            )
-        )
-    return ProgramInfos(programs=program_infos)
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
+    return ProgramInfos(programs=pyghidra_context.list_project_binary_infos())
 
 
 @mcp_error_handler
 def list_project_binary_metadata(binary_name: str, ctx: Context) -> dict:
     """Get binary metadata: architecture, compiler, endianness, hashes, analysis counts."""
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     return program_info.metadata
 
 
 @mcp_error_handler
+def list_open_programs(ctx: Context) -> OpenProgramInfos:
+    """List programs currently open in the Ghidra GUI."""
+    gui_context = _require_gui_context(ctx)
+    programs = [OpenProgramInfo(**info) for info in gui_context.list_open_programs()]
+    return OpenProgramInfos(programs=programs)
+
+
+@mcp_error_handler
+def open_program_in_gui(binary_name: str, ctx: Context) -> OpenProgramInfo:
+    """Open a project binary in the Ghidra GUI CodeBrowser."""
+    gui_context = _require_gui_context(ctx)
+    return OpenProgramInfo(**gui_context.open_program_in_gui(binary_name))
+
+
+@mcp_error_handler
+def set_current_program(binary_name: str, ctx: Context) -> OpenProgramInfo:
+    """Set the active/current program in the Ghidra GUI CodeBrowser."""
+    gui_context = _require_gui_context(ctx)
+    return OpenProgramInfo(**gui_context.set_current_program(binary_name))
+
+
+@mcp_error_handler
+def goto(
+    binary_name: str,
+    target: str,
+    target_type: Literal["address", "function"],
+    ctx: Context,
+) -> GotoResponse:
+    """Navigate the Ghidra GUI CodeBrowser to an address or function."""
+    gui_context = _require_gui_context(ctx)
+    return GotoResponse(**gui_context.goto(binary_name, target, target_type))
+
+
+@mcp_error_handler
+def rename_function(
+    binary_name: str,
+    name_or_address: str,
+    new_name: str,
+    ctx: Context,
+) -> RenameResponse:
+    """Rename a function using a Ghidra transaction."""
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
+    program_info = pyghidra_context.get_program_info(binary_name)
+    tools = GhidraTools(program_info)
+    result = _run_for_context(
+        pyghidra_context,
+        lambda: tools.rename_function(name_or_address, new_name),
+    )
+    result = cast(dict, result)
+    return RenameResponse(binary_name=binary_name, **result)
+
+
+@mcp_error_handler
+def set_comment(
+    binary_name: str,
+    target: str,
+    comment: str,
+    comment_type: Literal["decompiler", "plate", "pre", "eol", "post", "repeatable"],
+    ctx: Context,
+) -> CommentResponse:
+    """Set a comment in the decompiler or listing."""
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
+    program_info = pyghidra_context.get_program_info(binary_name)
+    tools = GhidraTools(program_info)
+    result = _run_for_context(
+        pyghidra_context,
+        lambda: tools.set_comment(target, comment, comment_type),
+    )
+    result = cast(dict, result)
+    return CommentResponse(binary_name=binary_name, **result)
+
+
+@mcp_error_handler
 async def delete_project_binary(binary_name: str, ctx: Context) -> str:
     """Delete a binary from the project."""
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     if pyghidra_context.delete_program(binary_name):
         return f"Successfully deleted binary: {binary_name}"
     else:
@@ -226,7 +307,7 @@ def list_exports(
     limit: int = 25,
 ) -> ExportInfos:
     """List exported symbols, optionally filtered by regex query."""
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
     exports = tools.list_exports(query=query, offset=offset, limit=limit)
@@ -242,7 +323,7 @@ def list_imports(
     limit: int = 25,
 ) -> ImportInfos:
     """List imported symbols, optionally filtered by regex query."""
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
     imports = tools.list_imports(query=query, offset=offset, limit=limit)
@@ -258,7 +339,7 @@ def list_xrefs(
     Accepts a single target or a list for batch lookup.
     Suggests close matches on no exact hit.
     """
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
     targets = [name_or_address] if isinstance(name_or_address, str) else name_or_address
@@ -280,7 +361,7 @@ def search_strings(
     limit: int = 100,
 ) -> StringSearchResults:
     """Search for strings within a binary."""
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
     strings = tools.search_strings(query=query, limit=limit)
@@ -290,7 +371,7 @@ def search_strings(
 @mcp_error_handler
 def read_bytes(binary_name: str, ctx: Context, address: str, size: int = 32) -> BytesReadResult:
     """Read raw bytes at an address. Hex format supported (0x prefix optional)."""
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
     return tools.read_bytes(address=address, size=size)
@@ -309,7 +390,7 @@ def gen_callgraph(
     max_run_time: int = 120,
 ) -> CallGraphResult:
     """Generate a MermaidJS call graph for a function."""
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
     return tools.gen_callgraph(
@@ -330,7 +411,7 @@ def import_binary(binary_path: str, ctx: Context) -> str:
     """Import a binary into the project from a file path."""
     # We would like to do context progress updates, but until that is more
     # widely supported by clients, we will resort to this
-    pyghidra_context: PyGhidraContext = ctx.request_context.lifespan_context
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     pyghidra_context.import_binary_backgrounded(binary_path)
     return (
         f"Importing {binary_path} in the background."

--- a/src/pyghidra_mcp/models.py
+++ b/src/pyghidra_mcp/models.py
@@ -37,6 +37,37 @@ class ProgramInfos(BaseModel):
     programs: list[ProgramInfo]
 
 
+class OpenProgramInfo(BaseModel):
+    name: str
+    path: str
+    current: bool
+    analysis_complete: bool
+
+
+class OpenProgramInfos(BaseModel):
+    programs: list[OpenProgramInfo]
+
+
+class GotoResponse(BaseModel):
+    binary_name: str
+    address: str
+    success: bool
+
+
+class RenameResponse(BaseModel):
+    binary_name: str
+    address: str
+    old_name: str
+    new_name: str
+
+
+class CommentResponse(BaseModel):
+    binary_name: str
+    address: str
+    comment: str
+    comment_type: str
+
+
 class ExportInfo(BaseModel):
     name: str
     address: str

--- a/src/pyghidra_mcp/project_spec.py
+++ b/src/pyghidra_mcp/project_spec.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_PROJECT_NAME = "my_project"
+
+
+@dataclass(frozen=True)
+class ProjectSpec:
+    """Normalized Ghidra project paths for headless and GUI launch modes."""
+
+    project_directory: Path
+    project_name: str
+    gpr_path: Path
+    pyghidra_mcp_dir: Path
+    was_gpr_path: bool
+
+    @classmethod
+    def from_cli(
+        cls,
+        project_path: Path,
+        project_name: str,
+        *,
+        default_project_name: str = DEFAULT_PROJECT_NAME,
+    ) -> "ProjectSpec":
+        """Normalize CLI project options without depending on click."""
+        project_path = Path(project_path)
+
+        if project_path.suffix.lower() == ".gpr":
+            if project_name != default_project_name:
+                raise ValueError("Cannot use --project-name when specifying a .gpr file")
+
+            resolved_project_name = project_path.stem
+            project_directory = project_path.parent
+            return cls(
+                project_directory=project_directory,
+                project_name=resolved_project_name,
+                gpr_path=project_path,
+                pyghidra_mcp_dir=project_directory / f"{resolved_project_name}-pyghidra-mcp",
+                was_gpr_path=True,
+            )
+
+        return cls(
+            project_directory=project_path,
+            project_name=project_name,
+            gpr_path=project_path / f"{project_name}.gpr",
+            pyghidra_mcp_dir=project_path / f"{project_name}-pyghidra-mcp",
+            was_gpr_path=False,
+        )

--- a/src/pyghidra_mcp/server.py
+++ b/src/pyghidra_mcp/server.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import sys
+import threading
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -15,6 +16,10 @@ from mcp.server.fastmcp import FastMCP
 
 from pyghidra_mcp import __version__, mcp_tools
 from pyghidra_mcp.context import PyGhidraContext
+from pyghidra_mcp.context_protocol import MCPContext
+from pyghidra_mcp.gui_context import GuiPyGhidraContext
+from pyghidra_mcp.gui_launcher import GuiPyGhidraMcpLauncher, ensure_macos_framework_python
+from pyghidra_mcp.project_spec import DEFAULT_PROJECT_NAME, ProjectSpec
 
 logging.basicConfig(
     level=logging.INFO,
@@ -27,7 +32,7 @@ logger = logging.getLogger(__name__)
 # Init Pyghidra
 # ---------------------------------------------------------------------------------
 @asynccontextmanager
-async def server_lifespan(server: Server) -> AsyncIterator[PyGhidraContext]:
+async def server_lifespan(server: Server) -> AsyncIterator[MCPContext]:
     """Manage server startup and shutdown lifecycle."""
     try:
         yield server._pyghidra_context  # type: ignore
@@ -39,22 +44,32 @@ async def server_lifespan(server: Server) -> AsyncIterator[PyGhidraContext]:
 mcp = FastMCP("pyghidra-mcp", lifespan=server_lifespan)  # type: ignore
 
 
-# MCP Tools
-# ---------------------------------------------------------------------------------
-# Register tools from mcp_tools module
-mcp.tool()(mcp_tools.decompile_function)
-mcp.tool()(mcp_tools.search_symbols_by_name)
-mcp.tool()(mcp_tools.search_code)
-mcp.tool()(mcp_tools.list_project_binaries)
-mcp.tool()(mcp_tools.list_project_binary_metadata)
-mcp.tool()(mcp_tools.delete_project_binary)
-mcp.tool()(mcp_tools.list_exports)
-mcp.tool()(mcp_tools.list_imports)
-mcp.tool()(mcp_tools.list_xrefs)
-mcp.tool()(mcp_tools.search_strings)
-mcp.tool()(mcp_tools.read_bytes)
-mcp.tool()(mcp_tools.gen_callgraph)
-mcp.tool()(mcp_tools.import_binary)
+def register_common_tools(server: FastMCP) -> None:
+    server.tool()(mcp_tools.decompile_function)
+    server.tool()(mcp_tools.search_symbols_by_name)
+    server.tool()(mcp_tools.search_code)
+    server.tool()(mcp_tools.list_project_binaries)
+    server.tool()(mcp_tools.list_project_binary_metadata)
+    server.tool()(mcp_tools.rename_function)
+    server.tool()(mcp_tools.set_comment)
+    server.tool()(mcp_tools.delete_project_binary)
+    server.tool()(mcp_tools.list_exports)
+    server.tool()(mcp_tools.list_imports)
+    server.tool()(mcp_tools.list_xrefs)
+    server.tool()(mcp_tools.search_strings)
+    server.tool()(mcp_tools.read_bytes)
+    server.tool()(mcp_tools.gen_callgraph)
+    server.tool()(mcp_tools.import_binary)
+
+
+def register_gui_tools(server: FastMCP) -> None:
+    server.tool()(mcp_tools.list_open_programs)
+    server.tool()(mcp_tools.open_program_in_gui)
+    server.tool()(mcp_tools.set_current_program)
+    server.tool()(mcp_tools.goto)
+
+
+register_common_tools(mcp)
 
 
 def init_pyghidra_context(
@@ -146,6 +161,41 @@ def init_pyghidra_context(
     return mcp
 
 
+def init_gui_context(
+    mcp: FastMCP,
+    *,
+    project_spec: ProjectSpec,
+    input_paths: list[Path],
+) -> FastMCP:
+    logger.info("Waiting for Ghidra GUI project...")
+    gui_context = GuiPyGhidraContext(project_spec=project_spec)
+    if input_paths:
+        logger.info("Importing/opening GUI binaries: %s", ", ".join(map(str, input_paths)))
+        gui_context.import_binaries(input_paths)
+    mcp._pyghidra_context = gui_context  # type: ignore
+    logger.info("GUI-backed server initialized")
+    return mcp
+
+
+def run_mcp_server(mcp: FastMCP, transport: str) -> None:
+    if transport == "stdio":
+        mcp.run(transport="stdio")
+    elif transport in ["streamable-http", "http"]:
+        mcp.run(transport="streamable-http")
+    elif transport == "sse":
+        import warnings
+
+        warnings.warn(
+            "SSE transport is deprecated per the MCP spec (June 2025). "
+            "Use --transport streamable-http instead.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+        mcp.run(transport="sse")
+    else:
+        raise ValueError(f"Invalid transport: {transport}")
+
+
 # MCP Server Entry Point
 # ---------------------------------------------------------------------------------
 
@@ -218,6 +268,15 @@ def init_pyghidra_context(
     default=False,
     show_default=True,
     help="Wait for initial project analysis to complete before starting the server.",
+)
+@optgroup.option(
+    "--gui/--no-gui",
+    default=False,
+    show_default=True,
+    help=(
+        "Launch Ghidra GUI in-process and serve MCP over HTTP against GUI-open programs. "
+        "Cannot attach to an already-running external Ghidra process."
+    ),
 )
 # --- Project Options ---
 @optgroup.group("Project Management")
@@ -297,6 +356,7 @@ def main(
     gzfs_path: str | None,
     max_workers: int,
     wait_for_analysis: bool,
+    gui: bool,
     list_project_binaries: bool,
     delete_project_binary: str | None,
     sym_file_path: str | None,
@@ -310,25 +370,57 @@ def main(
     For streamable-http and sse, it will start an HTTP server on the specified port (default 8000).
 
     """
-    # Handle both .gpr files and directory paths
-    if project_path.suffix.lower() == ".gpr":
-        # Check constraint: cannot use --project-name with .gpr files
-        if project_name != "my_project":  # project_name was explicitly provided (not default)
-            raise click.BadParameter("Cannot use --project-name when specifying a .gpr file")
+    try:
+        project_spec = ProjectSpec.from_cli(
+            project_path,
+            project_name,
+            default_project_name=DEFAULT_PROJECT_NAME,
+        )
+    except ValueError as e:
+        raise click.BadParameter(str(e)) from e
 
-        # Direct .gpr opening - create pyghidra-mcp alongside existing project
-        project_directory = str(project_path.parent)
-        project_name = project_path.stem
-        pyghidra_mcp_dir = project_path.parent / f"{project_name}-pyghidra-mcp"
-    else:
-        # Directory-based opening - create self-contained project
-        # Use provided project_name (defaults to my_project)
-        # This creates the structure:
-        # project_path/project_name.gpr, project_path/project_name-pyghidra-mcp/, etc.
-        project_directory = str(project_path)
-        pyghidra_mcp_dir = project_path / f"{project_name}-pyghidra-mcp"
+    project_directory = str(project_spec.project_directory)
+    project_name = project_spec.project_name
+    pyghidra_mcp_dir = project_spec.pyghidra_mcp_dir
     mcp.settings.port = port
     mcp.settings.host = host
+
+    if gui:
+        if transport == "stdio":
+            raise click.UsageError("--gui requires --transport streamable-http or --transport http")
+        if transport == "sse":
+            raise click.UsageError("--gui requires --transport streamable-http or --transport http")
+        if list_project_binaries or delete_project_binary:
+            raise click.UsageError("GUI mode does not support project-management CLI actions yet")
+        if not project_spec.gpr_path.exists():
+            raise click.UsageError(
+                f"GUI mode currently requires an existing Ghidra project: {project_spec.gpr_path}"
+            )
+
+        register_gui_tools(mcp)
+        ensure_macos_framework_python()
+        launcher = GuiPyGhidraMcpLauncher(project_spec.gpr_path)
+        launcher.start()
+
+        def gui_server_thread() -> None:
+            init_gui_context(mcp=mcp, project_spec=project_spec, input_paths=input_paths)
+            run_mcp_server(mcp, transport)
+
+        server_thread = threading.Thread(
+            target=gui_server_thread,
+            name="pyghidra-mcp-gui-server",
+            daemon=True,
+        )
+        server_thread.start()
+        try:
+            launcher.run_gui_event_loop()
+        finally:
+            launcher.request_shutdown()
+            launcher.wait_for_shutdown()
+            context = getattr(mcp, "_pyghidra_context", None)
+            if context is not None:
+                context.close()
+        return
 
     init_pyghidra_context(
         mcp=mcp,
@@ -352,22 +444,7 @@ def main(
     )
 
     try:
-        if transport == "stdio":
-            mcp.run(transport="stdio")
-        elif transport in ["streamable-http", "http"]:
-            mcp.run(transport="streamable-http")
-        elif transport == "sse":
-            import warnings
-
-            warnings.warn(
-                "SSE transport is deprecated per the MCP spec (June 2025). "
-                "Use --transport streamable-http instead.",
-                DeprecationWarning,
-                stacklevel=1,
-            )
-            mcp.run(transport="sse")
-        else:
-            raise ValueError(f"Invalid transport: {transport}")
+        run_mcp_server(mcp, transport)
     finally:
         mcp._pyghidra_context.close()  # type: ignore
 

--- a/src/pyghidra_mcp/tools.py
+++ b/src/pyghidra_mcp/tools.py
@@ -6,6 +6,7 @@ import functools
 import logging
 import re
 import typing
+from contextlib import contextmanager
 
 from ghidrecomp.callgraph import gen_callgraph
 from jpype import JByte
@@ -37,6 +38,17 @@ if typing.TYPE_CHECKING:
     from .context import ProgramInfo
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def ghidra_transaction(program, description: str):
+    tx_id = program.startTransaction(description)
+    committed = False
+    try:
+        yield
+        committed = True
+    finally:
+        program.endTransaction(tx_id, committed)
 
 
 def handle_exceptions(func):
@@ -325,6 +337,16 @@ class GhidraTools:
         except re.error:
             return query.lower() in symbol_name.lower()
 
+    @classmethod
+    def _symbol_matches_query(cls, query: str, symbol) -> bool:
+        """Match against both simple and namespace-qualified symbol names."""
+        names = {str(symbol.getName())}
+        try:
+            names.add(str(symbol.getName(True)))
+        except TypeError:
+            pass
+        return any(cls._matches_query(query, name) for name in names)
+
     def _symbol_to_info(self, symbol, rm) -> SymbolInfo:
         """Convert a Ghidra Symbol to a SymbolInfo model."""
         ref_count = len(list(rm.getReferencesTo(symbol.getAddress())))
@@ -362,7 +384,7 @@ class GhidraTools:
         results = [
             self._symbol_to_info(sym, rm)
             for sym in symbols
-            if self._matches_query(query, sym.getName(True))
+            if self._symbol_matches_query(query, sym)
         ]
         return results[offset : limit + offset]
 
@@ -772,3 +794,93 @@ class GhidraTools:
             graph=selected_graph_content,
             mermaid_url=mermaid_url,
         )
+
+    @handle_exceptions
+    def rename_function(self, name_or_address: str, new_name: str) -> dict:
+        from ghidra.program.model.symbol import SourceType
+
+        func = self.find_function(name_or_address)
+        old_name = str(func.getName())
+        address = str(func.getEntryPoint())
+
+        with ghidra_transaction(
+            self.program,
+            f"pyghidra-mcp: rename {old_name} -> {new_name}",
+        ):
+            func.setName(new_name, SourceType.USER_DEFINED)
+
+        self.invalidate_decompiler_cache()
+        return {
+            "address": address,
+            "old_name": old_name,
+            "new_name": new_name,
+        }
+
+    @handle_exceptions
+    def set_comment(self, target: str, comment: str, comment_type: str) -> dict:
+        from ghidra.program.model.listing import CommentType
+
+        normalized_type = comment_type.lower()
+        if normalized_type == "decompiler":
+            func = self.find_function(target)
+            addr = func.getEntryPoint()
+
+            with ghidra_transaction(
+                self.program,
+                f"pyghidra-mcp: set function comment @ {addr}",
+            ):
+                func.setComment(comment)
+
+            self.invalidate_decompiler_cache()
+            return {
+                "address": str(addr),
+                "comment": comment,
+                "comment_type": "decompiler",
+            }
+
+        listing_comment_types = {
+            "plate": CommentType.PLATE,
+            "pre": CommentType.PRE,
+            "eol": CommentType.EOL,
+            "post": CommentType.POST,
+            "repeatable": CommentType.REPEATABLE,
+        }
+        ghidra_comment_type = listing_comment_types.get(normalized_type)
+        if ghidra_comment_type is None:
+            allowed = ["decompiler", *listing_comment_types.keys()]
+            raise ValueError(f"Invalid comment_type '{comment_type}'. Expected one of: {allowed}")
+
+        addr = self._parse_address(target)
+        with ghidra_transaction(
+            self.program,
+            f"pyghidra-mcp: set {normalized_type} comment @ {addr}",
+        ):
+            self.program.getListing().setComment(addr, ghidra_comment_type, comment)
+
+        self.invalidate_decompiler_cache()
+        return {
+            "address": str(addr),
+            "comment": comment,
+            "comment_type": normalized_type,
+        }
+
+    def invalidate_decompiler_cache(self) -> None:
+        for method_name in ("flushCache", "resetDecompiler"):
+            method = getattr(self.decompiler, method_name, None)
+            if method is not None:
+                try:
+                    method()
+                except Exception:
+                    logger.debug(
+                        "Failed to invalidate decompiler cache with %s",
+                        method_name,
+                        exc_info=True,
+                    )
+                return
+
+    def _parse_address(self, address: str):
+        addr_str = address[2:] if address.lower().startswith("0x") else address
+        addr = self.program.getAddressFactory().getAddress(addr_str)
+        if addr is None:
+            raise ValueError(f"Invalid address: {address}")
+        return addr

--- a/tests/integration/test_gui_smoke.py
+++ b/tests/integration/test_gui_smoke.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import platform
 import signal
 import socket
@@ -36,6 +37,8 @@ async def _wait_for_http_server(base_url: str, timeout: int = 240) -> None:
 def _gui_env_or_skip(env: dict[str, str]) -> dict[str, str]:
     if platform.system() == "Linux" and not env.get("DISPLAY"):
         pytest.skip("GUI smoke test requires DISPLAY on Linux (e.g. Xvfb in CI).")
+    if platform.system() == "Darwin" and os.environ.get("GITHUB_ACTIONS") == "true":
+        pytest.skip("GUI smoke test is not supported on GitHub-hosted macOS runners.")
     return env
 
 

--- a/tests/integration/test_gui_smoke.py
+++ b/tests/integration/test_gui_smoke.py
@@ -1,0 +1,165 @@
+import asyncio
+import json
+import platform
+import signal
+import socket
+import subprocess
+
+import aiohttp
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamable_http_client
+
+from pyghidra_mcp.context import PyGhidraContext
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+async def _wait_for_http_server(base_url: str, timeout: int = 240) -> None:
+    async with aiohttp.ClientSession() as session:
+        for _ in range(timeout):
+            try:
+                async with session.get(f"{base_url}/mcp") as response:
+                    if response.status == 406:
+                        return
+            except aiohttp.ClientConnectorError:
+                pass
+            await asyncio.sleep(1)
+    raise RuntimeError("GUI server did not start in time")
+
+
+def _gui_env_or_skip(env: dict[str, str]) -> dict[str, str]:
+    if platform.system() == "Linux" and not env.get("DISPLAY"):
+        pytest.skip("GUI smoke test requires DISPLAY on Linux (e.g. Xvfb in CI).")
+    return env
+
+
+@pytest.mark.asyncio
+async def test_gui_smoke(
+    test_binary,
+    ghidra_env,
+    isolated_project_root,
+    main_func_name,
+    find_binary_in_list_response,
+):
+    gui_env = _gui_env_or_skip(dict(ghidra_env))
+    fixture_name = "gui_smoke"
+    project_dir = isolated_project_root / fixture_name
+    project_name = f"{fixture_name}_project"
+
+    headless_params = StdioServerParameters(
+        command="python",
+        args=[
+            "-m",
+            "pyghidra_mcp",
+            "--project-path",
+            str(project_dir),
+            "--project-name",
+            project_name,
+            "--wait-for-analysis",
+            test_binary,
+        ],
+        env=gui_env,
+    )
+
+    binary_name = PyGhidraContext._gen_unique_bin_name(test_binary)
+
+    async with stdio_client(headless_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            ready = False
+            for _ in range(240):
+                response = await session.call_tool("list_project_binaries", {})
+                program = find_binary_in_list_response(response, binary_name)
+                if program and program["analysis_complete"]:
+                    ready = True
+                    break
+                await asyncio.sleep(1)
+
+            assert ready
+
+    project_gpr = project_dir / f"{project_name}.gpr"
+    assert project_gpr.exists()
+
+    port = _find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    proc = subprocess.Popen(
+        [
+            "python",
+            "-m",
+            "pyghidra_mcp",
+            "--gui",
+            "--transport",
+            "streamable-http",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--project-path",
+            str(project_gpr),
+        ],
+        env=gui_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        await _wait_for_http_server(base_url)
+
+        async with streamable_http_client(f"{base_url}/mcp") as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+
+                binaries = await session.call_tool("list_project_binaries", {})
+                program = find_binary_in_list_response(binaries, binary_name)
+                assert program is not None
+                assert program["analysis_complete"] is True
+
+                opened = await session.call_tool(
+                    "open_program_in_gui",
+                    {"binary_name": binary_name, "current": True},
+                )
+                opened_payload = json.loads(opened.content[0].text)
+                assert opened_payload["current"] is True
+                assert opened_payload["analysis_complete"] is True
+
+                goto_result = await session.call_tool(
+                    "goto",
+                    {
+                        "binary_name": binary_name,
+                        "target": main_func_name,
+                        "target_type": "function",
+                    },
+                )
+                goto_payload = json.loads(goto_result.content[0].text)
+                assert goto_payload["success"] is True
+
+                comment_result = await session.call_tool(
+                    "set_comment",
+                    {
+                        "binary_name": binary_name,
+                        "target": main_func_name,
+                        "comment_type": "decompiler",
+                        "comment": "GUI smoke test comment.",
+                    },
+                )
+                comment_payload = json.loads(comment_result.content[0].text)
+                assert comment_payload["comment_type"] == "decompiler"
+                assert comment_payload["comment"] == "GUI smoke test comment."
+    finally:
+        proc.send_signal(signal.SIGINT)
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=10)
+
+        stderr = proc.stderr.read() if proc.stderr else ""
+        assert "AWT blocker activation interrupted" not in stderr

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -54,3 +54,13 @@ def test_init_project_programs_uses_domain_file_paths(monkeypatch):
         "/ls-aa11bb": "root-info",
         "/bin/tools/libfoo-cc22dd": "nested-info",
     }
+
+
+def test_list_program_infos_returns_loaded_programs():
+    context = PyGhidraContext.__new__(PyGhidraContext)
+    context.programs = {
+        "/one": "one-info",
+        "/two": "two-info",
+    }
+
+    assert context.list_program_infos() == ["one-info", "two-info"]

--- a/tests/unit/test_gui_context.py
+++ b/tests/unit/test_gui_context.py
@@ -1,0 +1,113 @@
+import threading
+from unittest.mock import Mock
+
+import pytest
+
+from pyghidra_mcp.context import ProgramInfo
+from pyghidra_mcp.gui_context import GuiPyGhidraContext
+
+
+def test_unique_short_name_match_returns_unambiguous_program():
+    context = GuiPyGhidraContext.__new__(GuiPyGhidraContext)
+
+    domain_file = Mock()
+    domain_file.getName.return_value = "sample"
+
+    program = Mock()
+    program.getDomainFile.return_value = domain_file
+
+    program_info = Mock()
+    program_info.name = "sample"
+    program_info.program = program
+
+    context.programs = {"/folder/sample": program_info}
+
+    assert context._get_unique_short_name_match("sample") is program_info
+
+
+def test_unique_short_name_match_rejects_ambiguous_programs():
+    context = GuiPyGhidraContext.__new__(GuiPyGhidraContext)
+
+    program_infos = []
+    for _ in range(2):
+        domain_file = Mock()
+        domain_file.getName.return_value = "sample"
+
+        program = Mock()
+        program.getDomainFile.return_value = domain_file
+
+        program_info = Mock()
+        program_info.name = "sample"
+        program_info.program = program
+        program_infos.append(program_info)
+
+    context.programs = {
+        "/one/sample": program_infos[0],
+        "/two/sample": program_infos[1],
+    }
+
+    with pytest.raises(ValueError, match="ambiguous"):
+        context._get_unique_short_name_match("sample")
+
+
+def test_list_project_binary_infos_includes_closed_domain_files():
+    context = GuiPyGhidraContext.__new__(GuiPyGhidraContext)
+    context.programs = {}
+    context._programs_lock = threading.RLock()
+    context.refresh_programs = Mock()
+
+    domain_file = Mock()
+    domain_file.getPathname.return_value = "/folder/sample"
+    domain_file.getMetadata.return_value = {
+        "Executable Location": "/bin/sample",
+        "Analyzed": "true",
+    }
+    context.list_binary_domain_files = Mock(return_value=[domain_file])
+
+    infos = context.list_project_binary_infos()
+
+    assert len(infos) == 1
+    assert infos[0].name == "/folder/sample"
+    assert infos[0].file_path == "/bin/sample"
+    assert infos[0].analysis_complete is True
+    assert infos[0].metadata["Analyzed"] == "true"
+    assert infos[0].code_indexed is False
+    assert infos[0].strings_indexed is False
+
+
+def test_refresh_programs_resyncs_existing_program_state():
+    context = GuiPyGhidraContext.__new__(GuiPyGhidraContext)
+    context._programs_lock = threading.RLock()
+
+    domain_file = Mock()
+    domain_file.getPathname.return_value = "/folder/sample"
+
+    program = Mock()
+    program.getDomainFile.return_value = domain_file
+
+    program_info = ProgramInfo(
+        name="sample",
+        program=program,
+        flat_api=None,
+        decompiler=Mock(),
+        metadata={},
+        ghidra_analysis_complete=False,
+    )
+    context.programs = {"/folder/sample": program_info}
+    context._dispose_decompiler = Mock()
+    context._init_program_info = Mock()
+    context._get_program_managers = Mock(
+        return_value=[Mock(getAllOpenPrograms=Mock(return_value=[program]))]
+    )
+
+    def sync(info, current_program):
+        assert info is program_info
+        assert current_program is program
+        info.ghidra_analysis_complete = True
+
+    context._sync_program_info = Mock(side_effect=sync)
+
+    context.refresh_programs()
+
+    assert context._sync_program_info.call_count == 1
+    assert context.programs["/folder/sample"].analysis_complete is True

--- a/tests/unit/test_gui_launcher.py
+++ b/tests/unit/test_gui_launcher.py
@@ -1,0 +1,54 @@
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock
+
+from pyghidra_mcp.gui_launcher import GuiPyGhidraMcpLauncher
+
+
+def test_request_shutdown_closes_frontend_tool(monkeypatch):
+    front_end_tool = Mock()
+
+    app_info_module = types.ModuleType("ghidra.framework.main")
+    app_info_module.AppInfo = types.SimpleNamespace(
+        getFrontEndTool=lambda: front_end_tool,
+    )
+
+    swing_calls = []
+
+    def run_later(callback):
+        swing_calls.append(callback)
+        callback()
+
+    util_module = types.ModuleType("ghidra.util")
+    util_module.Swing = types.SimpleNamespace(runLater=run_later)
+
+    monkeypatch.setitem(sys.modules, "ghidra.framework.main", app_info_module)
+    monkeypatch.setitem(sys.modules, "ghidra.util", util_module)
+
+    launcher = GuiPyGhidraMcpLauncher(Path("/tmp/project.gpr"))
+    launcher.request_shutdown()
+
+    assert len(swing_calls) == 1
+    front_end_tool.close.assert_called_once_with()
+
+
+def test_request_shutdown_is_idempotent(monkeypatch):
+    front_end_tool = Mock()
+
+    app_info_module = types.ModuleType("ghidra.framework.main")
+    app_info_module.AppInfo = types.SimpleNamespace(
+        getFrontEndTool=lambda: front_end_tool,
+    )
+
+    util_module = types.ModuleType("ghidra.util")
+    util_module.Swing = types.SimpleNamespace(runLater=lambda callback: callback())
+
+    monkeypatch.setitem(sys.modules, "ghidra.framework.main", app_info_module)
+    monkeypatch.setitem(sys.modules, "ghidra.util", util_module)
+
+    launcher = GuiPyGhidraMcpLauncher(Path("/tmp/project.gpr"))
+    launcher.request_shutdown()
+    launcher.request_shutdown()
+
+    front_end_tool.close.assert_called_once_with()

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -1,0 +1,84 @@
+from unittest.mock import Mock
+
+from pyghidra_mcp.gui_context import GuiPyGhidraContext
+from pyghidra_mcp.mcp_tools import goto, list_project_binaries, set_comment
+from pyghidra_mcp.models import ProgramInfo
+
+
+def test_list_project_binaries_uses_project_wide_context_listing():
+    program_info = ProgramInfo(
+        name="/folder/sample",
+        file_path=None,
+        load_time=None,
+        analysis_complete=False,
+        metadata={},
+        code_indexed=False,
+        strings_indexed=False,
+    )
+    pyghidra_context = Mock()
+    pyghidra_context.list_project_binary_infos.return_value = [program_info]
+    pyghidra_context.list_program_infos.side_effect = AssertionError(
+        "should not use open-program listing"
+    )
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = pyghidra_context
+
+    response = list_project_binaries(ctx)
+
+    assert response.programs == [program_info]
+
+
+def test_set_comment_uses_tool_path(monkeypatch):
+    pyghidra_context = Mock()
+    pyghidra_context.get_program_info.return_value = Mock()
+
+    fake_tools = Mock()
+    fake_tools.set_comment.return_value = {
+        "address": "1000042e3",
+        "comment": "function summary",
+        "comment_type": "decompiler",
+    }
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = pyghidra_context
+
+    monkeypatch.setattr("pyghidra_mcp.mcp_tools.GhidraTools", lambda _program_info: fake_tools)
+
+    response = set_comment(
+        binary_name="sample",
+        target="entry",
+        comment="function summary",
+        comment_type="decompiler",
+        ctx=ctx,
+    )
+
+    fake_tools.set_comment.assert_called_once_with("entry", "function summary", "decompiler")
+    assert response.binary_name == "sample"
+    assert response.address == "1000042e3"
+    assert response.comment_type == "decompiler"
+
+
+def test_goto_uses_gui_context():
+    gui_context = GuiPyGhidraContext.__new__(GuiPyGhidraContext)
+    gui_context.goto = Mock()
+    gui_context.goto.return_value = {
+        "binary_name": "sample",
+        "address": "1000042e3",
+        "success": True,
+    }
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = gui_context
+
+    response = goto(
+        binary_name="sample",
+        target="entry",
+        target_type="function",
+        ctx=ctx,
+    )
+
+    gui_context.goto.assert_called_once_with("sample", "entry", "function")
+    assert response.binary_name == "sample"
+    assert response.address == "1000042e3"
+    assert response.success is True

--- a/tests/unit/test_project_spec.py
+++ b/tests/unit/test_project_spec.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import pytest
+
+from pyghidra_mcp.project_spec import DEFAULT_PROJECT_NAME, ProjectSpec
+
+
+def test_project_spec_from_gpr_path():
+    spec = ProjectSpec.from_cli(Path("/tmp/projects/sample.gpr"), DEFAULT_PROJECT_NAME)
+
+    assert spec.was_gpr_path is True
+    assert spec.project_directory == Path("/tmp/projects")
+    assert spec.project_name == "sample"
+    assert spec.gpr_path == Path("/tmp/projects/sample.gpr")
+    assert spec.pyghidra_mcp_dir == Path("/tmp/projects/sample-pyghidra-mcp")
+
+
+def test_project_spec_rejects_project_name_with_gpr_path():
+    with pytest.raises(ValueError, match="Cannot use --project-name"):
+        ProjectSpec.from_cli(Path("/tmp/projects/sample.gpr"), "custom")
+
+
+def test_project_spec_from_directory_path():
+    spec = ProjectSpec.from_cli(Path("/tmp/projects"), "sample")
+
+    assert spec.was_gpr_path is False
+    assert spec.project_directory == Path("/tmp/projects")
+    assert spec.project_name == "sample"
+    assert spec.gpr_path == Path("/tmp/projects/sample.gpr")
+    assert spec.pyghidra_mcp_dir == Path("/tmp/projects/sample-pyghidra-mcp")
+
+
+def test_gui_stdio_rejected_before_ghidra_start():
+    import click.testing
+
+    from pyghidra_mcp.server import main
+
+    runner = click.testing.CliRunner()
+    result = runner.invoke(main, ["--gui", "--transport", "stdio"])
+
+    assert result.exit_code != 0
+    assert "--gui requires --transport streamable-http or --transport http" in result.output

--- a/tests/unit/test_search_regex.py
+++ b/tests/unit/test_search_regex.py
@@ -7,11 +7,14 @@ import pytest
 from pyghidra_mcp.tools import GhidraTools
 
 
-def _make_mock_symbol(name, address="0x1000"):
+def _make_mock_symbol(name, address="0x1000", qualified_name=None):
     """Create a mock Ghidra Symbol."""
     sym = Mock()
     sym.name = name
-    sym.getName.return_value = name
+    qualified = qualified_name or name
+    sym.getName.side_effect = lambda include_namespace=False: (
+        qualified if include_namespace else name
+    )
     sym.getAddress.return_value = address
     sym.getSymbolType.return_value = "Function"
     sym.getParentNamespace.return_value = "Global"
@@ -20,9 +23,9 @@ def _make_mock_symbol(name, address="0x1000"):
     return sym
 
 
-def _make_mock_function(name, address="0x1000"):
+def _make_mock_function(name, address="0x1000", qualified_name=None):
     """Create a mock Ghidra Function with a Symbol."""
-    sym = _make_mock_symbol(name, address)
+    sym = _make_mock_symbol(name, address, qualified_name=qualified_name)
     func = Mock()
     func.getSymbol.return_value = sym
     func.getEntryPoint.return_value = address
@@ -103,6 +106,14 @@ class TestSearchFunctionsOnly:
         results = tools.search_symbols_by_name("^MAIN$", functions_only=True)
         names = [s.name for s in results]
         assert names == ["main"]
+
+    def test_regex_exact_match_uses_simple_name_when_symbol_is_namespaced(self):
+        """Anchored matches should work against display names, not just qualified names."""
+        funcs = [_make_mock_function("entry", "0x1000", qualified_name="Global::entry")]
+        tools = _make_tools(functions=funcs)
+        results = tools.search_symbols_by_name("^entry$", functions_only=True)
+        names = [s.name for s in results]
+        assert names == ["entry"]
 
     def test_invalid_regex_falls_back_to_substring(self):
         """Invalid regex like bare '*' falls back to substring match."""

--- a/tests/unit/test_transactions.py
+++ b/tests/unit/test_transactions.py
@@ -1,0 +1,35 @@
+import pytest
+
+from pyghidra_mcp.tools import ghidra_transaction
+
+
+class FakeProgram:
+    def __init__(self):
+        self.ended = []
+
+    def startTransaction(self, description):  # noqa: N802
+        self.description = description
+        return 7
+
+    def endTransaction(self, tx_id, committed):  # noqa: N802
+        self.ended.append((tx_id, committed))
+
+
+def test_ghidra_transaction_commits_on_success():
+    program = FakeProgram()
+
+    with ghidra_transaction(program, "test transaction"):
+        pass
+
+    assert program.description == "test transaction"
+    assert program.ended == [(7, True)]
+
+
+def test_ghidra_transaction_rolls_back_on_exception():
+    program = FakeProgram()
+
+    with pytest.raises(RuntimeError):
+        with ghidra_transaction(program, "test transaction"):
+            raise RuntimeError("boom")
+
+    assert program.ended == [(7, False)]


### PR DESCRIPTION
## Summary
- add  mode that launches Ghidra in-process and shares live GUI-owned programs with pyghidra-mcp
- add GUI navigation plus transactional rename/comment support
- keep the phase-1 MCP surface compact with , , and 

## Notes
- does not attach to an already-running external Ghidra instance
- GUI mode currently requires launching Ghidra through 
- GUI-discovered binaries may still need MCP indexing for  / semantic 
