### PR TITLE
Add variable editing and decompiler pooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,75 +421,53 @@ Per-item errors are returned inline (other targets still succeed):
 ]
 ```
 
-#### Code Search
+#### Read / Analysis Tools
 
 - `search_code(binary_name: str, query: str, limit: int = 5)`: Search for code within a binary by similarity using vector embeddings.
 
-#### Cross-References
-
 - `list_xrefs(binary_name: str, name_or_address: str | list[str])`: List cross-references to function(s), symbol(s), or address(es). Accepts a single target or a list for batch lookup.
-
-#### Generate Call Graph
 
 - `gen_callgraph(binary_name: str, function_name_or_address: str, direction: str = "calling", display_type: str = "flow", include_refs: bool = True, max_depth: int | None = None, max_run_time: int = 60, condense_threshold: int = 50, top_layers: int = 5, bottom_layers: int = 5)`: Generates a MermaidJS call graph for a specified function. Supports both "calling" (functions called by the target) and "called" (functions that call the target) directions with multiple visualization types.
 
-#### Decompile Function
-
-- `decompile_function(binary_name: str, name_or_address: str | list[str], include_callees: bool = False, include_strings: bool = False, include_xrefs: bool = False)`: Decompile function(s) by name or address. Accepts a single target or a list for batch decompilation. Rich response flags attach callees, strings, and/or xrefs to each result.
-
-#### Import Binary
-
-- `import_binary(binary_path: str)`: Imports a binary from a designated path into the current Ghidra project. If the path is a directory, it will recursively scan and import all supported binary files, preserving the directory structure within the Ghidra project.
-
-#### List Exports
+- `decompile_function(binary_name: str, name_or_address: str | list[str], include_callees: bool = False, include_strings: bool = False, include_xrefs: bool = False, timeout_sec: int = 30)`: Decompile function(s) by name or address. Accepts a single target or a list for batch decompilation. Rich response flags attach callees, strings, and/or xrefs to each result. `timeout_sec` applies per target and bounds each decompilation attempt independently.
 
 - `list_exports(binary_name: str, query: str = ".*", offset: int = 0, limit: int = 25)`: Lists all exported functions and symbols from a specified binary (regex supported for query).
 
-#### List Imports
-
 - `list_imports(binary_name: str, query: str = ".*", offset: int = 0, limit: int = 25)`: Lists all imported functions and symbols for a specified binary (regex supported for query).
-
-#### List Project Binaries
-
-- `list_project_binaries()`: Lists binaries in the current Ghidra project. In GUI mode this includes project binaries that exist on disk even if they are not currently open in CodeBrowser.
-
-#### List Project Binary Metadata
-
-- `list_project_binary_metadata(binary_name: str)`: Retrieves detailed metadata for a specific binary, including architecture, compiler, executable format, analysis metrics, and file hashes.
-
-#### Delete Project Binary
-
-- `delete_project_binary(binary_name: str)`: Deletes a binary (program) from the Ghidra project.
-
-#### Read Bytes
 
 - `read_bytes(binary_name: str, address: str, size: int = 32)`: Reads raw bytes from memory at a specified address. Returns raw hex data. Useful for inspecting memory contents, data structures, or confirming analysis findings.
 
-
-
-#### Search Strings
-
 - `search_strings(binary_name: str, query: str, limit: int = 100)`: Searches for strings within a binary by name.
-
-#### Search Symbols
 
 - `search_symbols_by_name(binary_name: str, query: str, functions_only: bool = False, offset: int = 0, limit: int = 25)`: Search for symbols within a binary by name. Supports regex patterns (e.g. `^main$`, `func.*one`) with case-insensitive matching, or plain substring queries. Set `functions_only=True` to exclude labels, variables, and other non-function symbols.
 
-#### Rename Function
+#### Project Operations
+
+- `import_binary(binary_path: str)`: Imports a binary from a designated path into the current Ghidra project. If the path is a directory, it will recursively scan and import all supported binary files, preserving the directory structure within the Ghidra project.
+
+- `list_project_binaries()`: Lists binaries in the current Ghidra project. In GUI mode this includes project binaries that exist on disk even if they are not currently open in CodeBrowser.
+
+- `list_project_binary_metadata(binary_name: str)`: Retrieves detailed metadata for a specific binary, including architecture, compiler, executable format, analysis metrics, and file hashes.
+
+- `delete_project_binary(binary_name: str)`: Deletes a binary (program) from the Ghidra project.
+
+#### Edit / Mutation Tools
 
 - `rename_function(binary_name: str, name_or_address: str, new_name: str)`: Rename a function by name or address. In GUI mode this runs as a live Ghidra transaction and updates the open program.
 
-#### Set Comment
+- `rename_variable(binary_name: str, function_name_or_address: str, variable_name: str, new_name: str)`: Rename a function parameter or local variable by exact name within a specific function. If the name is missing or ambiguous within that function, the tool returns an error instead of guessing. In GUI mode this runs as a live Ghidra transaction and updates the open program.
+
+- `set_variable_type(binary_name: str, function_name_or_address: str, variable_name: str, type_name: str)`: Set the data type for a function parameter or local variable by exact name within a specific function. If the name is missing or ambiguous within that function, the tool returns an error instead of guessing. `type_name` is parsed using Ghidra's datatype parser against the program datatype manager.
 
 - `set_comment(binary_name: str, target: str, comment: str, comment_type: str)`: Set a function/decompiler comment or listing comment. Supported `comment_type` values are `decompiler`, `plate`, `pre`, `eol`, `post`, and `repeatable`.
 
-#### GUI-only Tools
+#### GUI Control Tools (`--gui` only)
 
-These tools are only available when `pyghidra-mcp` is started with `--gui`:
+These tools are only available when `pyghidra-mcp` is started with `--gui` and control what the GUI is showing rather than mutating project data directly:
 
 - `list_open_programs()`: List programs currently open in the Ghidra GUI.
 - `open_program_in_gui(binary_name: str)`: Open a project binary in CodeBrowser.
-- `set_current_program(binary_name: str)`: Make an open program the active GUI program.
+- `set_current_program(binary_name: str)`: Make an open program the active/current program in the primary GUI tool context.
 - `goto(binary_name: str, target: str, target_type: str)`: Navigate the Ghidra GUI to an address or function. `target_type` must be `address` or `function`.
 
 ### Prompts

--- a/src/pyghidra_mcp/context.py
+++ b/src/pyghidra_mcp/context.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Union
 
 import chromadb
 
+from pyghidra_mcp.decompiler_pool import DecompilerPool
 from pyghidra_mcp.import_detection import is_ghidra_importable
 from pyghidra_mcp.import_planning import ImportCandidate, build_import_plan
 from pyghidra_mcp.indexing_mixin import IndexingMixin
@@ -20,7 +21,6 @@ from pyghidra_mcp.models import (
 )
 
 if TYPE_CHECKING:
-    from ghidra.app.decompiler import DecompInterface
     from ghidra.base.project import GhidraProject
     from ghidra.framework.model import DomainFile
     from ghidra.program.flatapi import FlatProgramAPI
@@ -38,7 +38,7 @@ class ProgramInfo:
     name: str
     program: "Program"
     flat_api: "FlatProgramAPI | None"
-    decompiler: "DecompInterface"
+    decompiler_pool: DecompilerPool
     metadata: dict  # Ghidra program metadata
     ghidra_analysis_complete: bool
     file_path: Path | None = None
@@ -98,9 +98,6 @@ class PyGhidraContext(IndexingMixin):
         self.project_path = Path(project_path)
         self.project: GhidraProject = self._get_or_create_project()
 
-        self.programs: dict[str, ProgramInfo] = {}
-        self._init_project_programs()
-
         # Use provided pyghidra-mcp directory or create default
         if pyghidra_mcp_dir:
             self.pyghidra_mcp_dir = pyghidra_mcp_dir
@@ -142,6 +139,9 @@ class PyGhidraContext(IndexingMixin):
         )
         self.wait_for_analysis = wait_for_analysis
 
+        self.programs: dict[str, ProgramInfo] = {}
+        self._init_project_programs()
+
     def close(self, save: bool = True):
         """
         Saves changes to all open programs and closes the project.
@@ -155,6 +155,7 @@ class PyGhidraContext(IndexingMixin):
             self.import_executor.shutdown(wait=True)
 
         for _program_name, program_info in self.programs.items():
+            self._dispose_decompiler(program_info)
             program = program_info.program
             self.project.close(program)
 
@@ -273,6 +274,7 @@ class PyGhidraContext(IndexingMixin):
             try:
                 program_to_delete: Program = program_info.program
                 program_to_delete_df: DomainFile = program_to_delete.getDomainFile()
+                self._dispose_decompiler(program_info)
                 self.project.close(program_to_delete)
                 program_to_delete_df.delete()
                 # clean up program reference
@@ -519,7 +521,7 @@ class PyGhidraContext(IndexingMixin):
             name=program.name,
             program=program,
             flat_api=FlatProgramAPI(program),
-            decompiler=self.setup_decompiler(program),
+            decompiler_pool=self._create_decompiler_pool(program),
             metadata=metadata,
             ghidra_analysis_complete=False,
             file_path=metadata["Executable Location"],
@@ -640,13 +642,14 @@ class PyGhidraContext(IndexingMixin):
         verbose_analysis: bool = False,
     ):
         # Import symbol utilities from ghidrecomp
+        from ghidrecomp.utility import get_pdb, set_pdb, set_remote_pdbs, setup_symbol_server
+
         from ghidra.app.script import GhidraScriptUtil
         from ghidra.framework.model import DomainFile
         from ghidra.program.flatapi import FlatProgramAPI
         from ghidra.program.model.listing import Program
         from ghidra.program.util import GhidraProgramUtilities
         from ghidra.util.task import ConsoleTaskMonitor
-        from ghidrecomp.utility import get_pdb, set_pdb, set_remote_pdbs, setup_symbol_server
 
         df = df_or_prog
         if not isinstance(df_or_prog, DomainFile):
@@ -870,12 +873,13 @@ class PyGhidraContext(IndexingMixin):
         """
         Apply GDT to program
         """
+        from java.io import File  # type: ignore
+        from java.util import List  # type: ignore
+
         from ghidra.app.cmd.function import ApplyFunctionDataTypesCmd
         from ghidra.program.model.data import FileDataTypeManager
         from ghidra.program.model.symbol import SourceType
         from ghidra.util.task import ConsoleTaskMonitor
-        from java.io import File  # type: ignore
-        from java.util import List  # type: ignore
 
         gdt_path = Path(gdt_path)
 
@@ -904,7 +908,7 @@ class PyGhidraContext(IndexingMixin):
         meta = prog.getMetadata()
         return dict(meta)
 
-    def setup_decompiler(self, program: "Program") -> "DecompInterface":
+    def setup_decompiler(self, program: "Program"):
         from ghidra.app.decompiler import DecompileOptions, DecompInterface
 
         prog_options = DecompileOptions()
@@ -921,3 +925,14 @@ class PyGhidraContext(IndexingMixin):
         decomp.openProgram(program)
 
         return decomp
+
+    def _create_decompiler_pool(self, program: "Program") -> DecompilerPool:
+        pool_size = 2 if self.threaded else 1
+        return DecompilerPool(lambda: self.setup_decompiler(program), size=pool_size)
+
+    @staticmethod
+    def _dispose_decompiler(program_info: ProgramInfo) -> None:
+        try:
+            program_info.decompiler_pool.dispose()
+        except Exception:
+            logger.debug("Failed to dispose decompiler pool", exc_info=True)

--- a/src/pyghidra_mcp/context.py
+++ b/src/pyghidra_mcp/context.py
@@ -642,14 +642,13 @@ class PyGhidraContext(IndexingMixin):
         verbose_analysis: bool = False,
     ):
         # Import symbol utilities from ghidrecomp
-        from ghidrecomp.utility import get_pdb, set_pdb, set_remote_pdbs, setup_symbol_server
-
         from ghidra.app.script import GhidraScriptUtil
         from ghidra.framework.model import DomainFile
         from ghidra.program.flatapi import FlatProgramAPI
         from ghidra.program.model.listing import Program
         from ghidra.program.util import GhidraProgramUtilities
         from ghidra.util.task import ConsoleTaskMonitor
+        from ghidrecomp.utility import get_pdb, set_pdb, set_remote_pdbs, setup_symbol_server
 
         df = df_or_prog
         if not isinstance(df_or_prog, DomainFile):
@@ -873,13 +872,12 @@ class PyGhidraContext(IndexingMixin):
         """
         Apply GDT to program
         """
-        from java.io import File  # type: ignore
-        from java.util import List  # type: ignore
-
         from ghidra.app.cmd.function import ApplyFunctionDataTypesCmd
         from ghidra.program.model.data import FileDataTypeManager
         from ghidra.program.model.symbol import SourceType
         from ghidra.util.task import ConsoleTaskMonitor
+        from java.io import File  # type: ignore
+        from java.util import List  # type: ignore
 
         gdt_path = Path(gdt_path)
 

--- a/src/pyghidra_mcp/decompiler_pool.py
+++ b/src/pyghidra_mcp/decompiler_pool.py
@@ -1,0 +1,76 @@
+import queue
+import threading
+from collections.abc import Callable
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ghidra.app.decompiler import DecompInterface
+
+
+class DecompilerPool:
+    def __init__(
+        self,
+        factory: Callable[[], "DecompInterface"],
+        *,
+        size: int = 1,
+    ) -> None:
+        self._factory = factory
+        self._size = max(1, size)
+        self._queue: queue.LifoQueue[DecompInterface] = queue.LifoQueue(maxsize=self._size)
+        self._created: list[DecompInterface] = []
+        self._created_lock = threading.Lock()
+
+    def _create(self) -> "DecompInterface":
+        decompiler = self._factory()
+        with self._created_lock:
+            self._created.append(decompiler)
+        return decompiler
+
+    def _ensure_available(self) -> "DecompInterface":
+        try:
+            return self._queue.get_nowait()
+        except queue.Empty:
+            with self._created_lock:
+                if len(self._created) < self._size:
+                    pass
+                else:
+                    return self._queue.get()
+            return self._create()
+
+    @contextmanager
+    def acquire(self):
+        decompiler = self._ensure_available()
+        try:
+            yield decompiler
+        finally:
+            self._queue.put(decompiler)
+
+    def invalidate_all(self) -> None:
+        with self._created_lock:
+            decompilers = list(self._created)
+
+        for decompiler in decompilers:
+            for method_name in ("flushCache", "resetDecompiler"):
+                method = getattr(decompiler, method_name, None)
+                if method is not None:
+                    method()
+                    break
+
+    def dispose(self) -> None:
+        with self._created_lock:
+            decompilers = list(self._created)
+            self._created.clear()
+
+        while True:
+            try:
+                self._queue.get_nowait()
+            except queue.Empty:
+                break
+
+        for decompiler in decompilers:
+            for method_name in ("dispose", "closeProgram"):
+                method = getattr(decompiler, method_name, None)
+                if method is not None:
+                    method()
+                    break

--- a/src/pyghidra_mcp/gui_context.py
+++ b/src/pyghidra_mcp/gui_context.py
@@ -24,9 +24,8 @@ logger = logging.getLogger(__name__)
 
 def _run_on_swing(fn, *args, **kwargs):
     import jpype
-    from java.lang import Runnable  # type: ignore
-
     from ghidra.util import Swing
+    from java.lang import Runnable  # type: ignore
 
     result_box: list[Any] = [None]
     exc_box: list[BaseException | None] = [None]
@@ -457,10 +456,10 @@ class GuiPyGhidraContext(IndexingMixin):
     def import_binary(
         self, binary_path: str | Path, relative_path: Path | None = None
     ) -> str | list[str]:
-        from java.io import File  # type: ignore
-
         from ghidra.app.util.importer import ProgramLoader
         from ghidra.util.task import TaskMonitor
+        from java.io import File  # type: ignore
+
         from pyghidra_mcp.context import PyGhidraContext
 
         binary_path = Path(binary_path)

--- a/src/pyghidra_mcp/gui_context.py
+++ b/src/pyghidra_mcp/gui_context.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from pyghidra_mcp.context import ProgramInfo
+from pyghidra_mcp.decompiler_pool import DecompilerPool
 from pyghidra_mcp.import_detection import is_ghidra_importable
 from pyghidra_mcp.import_planning import ImportCandidate, build_import_plan
 from pyghidra_mcp.indexing_mixin import IndexingMixin
@@ -23,8 +24,9 @@ logger = logging.getLogger(__name__)
 
 def _run_on_swing(fn, *args, **kwargs):
     import jpype
-    from ghidra.util import Swing
     from java.lang import Runnable  # type: ignore
+
+    from ghidra.util import Swing
 
     result_box: list[Any] = [None]
     exc_box: list[BaseException | None] = [None]
@@ -53,7 +55,7 @@ class GuiPyGhidraContext(IndexingMixin):
         project_spec: ProjectSpec,
         *,
         pyghidra_mcp_dir: Path | None = None,
-        readiness_timeout: float = 30.0,
+        readiness_timeout: float = 240.0,
         readiness_interval: float = 0.2,
     ):
         self.project_spec = project_spec
@@ -455,10 +457,10 @@ class GuiPyGhidraContext(IndexingMixin):
     def import_binary(
         self, binary_path: str | Path, relative_path: Path | None = None
     ) -> str | list[str]:
-        from ghidra.app.util.importer import ProgramLoader
-        from ghidra.util.task import TaskMonitor
         from java.io import File  # type: ignore
 
+        from ghidra.app.util.importer import ProgramLoader
+        from ghidra.util.task import TaskMonitor
         from pyghidra_mcp.context import PyGhidraContext
 
         binary_path = Path(binary_path)
@@ -587,7 +589,7 @@ class GuiPyGhidraContext(IndexingMixin):
             name=program.getName(),
             program=program,
             flat_api=FlatProgramAPI(program),
-            decompiler=self._setup_decompiler(program),
+            decompiler_pool=self._create_decompiler_pool(program),
             metadata={},
             ghidra_analysis_complete=False,
             file_path=None,
@@ -632,13 +634,12 @@ class GuiPyGhidraContext(IndexingMixin):
         return decompiler
 
     @staticmethod
+    def _create_decompiler_pool(program) -> DecompilerPool:
+        return DecompilerPool(lambda: GuiPyGhidraContext._setup_decompiler(program), size=2)
+
+    @staticmethod
     def _dispose_decompiler(program_info: ProgramInfo) -> None:
-        decompiler = program_info.decompiler
-        for method_name in ("dispose", "closeProgram"):
-            method = getattr(decompiler, method_name, None)
-            if method is not None:
-                try:
-                    method()
-                except Exception:
-                    logger.debug("Failed to dispose decompiler with %s", method_name, exc_info=True)
-                return
+        try:
+            program_info.decompiler_pool.dispose()
+        except Exception:
+            logger.debug("Failed to dispose decompiler pool", exc_info=True)

--- a/src/pyghidra_mcp/gui_launcher.py
+++ b/src/pyghidra_mcp/gui_launcher.py
@@ -53,8 +53,9 @@ class GuiPyGhidraMcpLauncher(PyGhidraLauncher):
 
     def _launch(self) -> None:
         """Start the Ghidra GUI without blocking the caller."""
-        from ghidra import Ghidra
         from java.lang import Runtime, Thread  # type: ignore
+
+        from ghidra import Ghidra
 
         if sys.platform == "win32":
             appid = ctypes.c_wchar_p(self.app_info.name)

--- a/src/pyghidra_mcp/mcp_tools.py
+++ b/src/pyghidra_mcp/mcp_tools.py
@@ -4,6 +4,7 @@ MCP Tool handlers for pyghidra-mcp.
 This module contains all MCP tool implementations with centralized error handling.
 """
 
+import asyncio
 import functools
 import logging
 from typing import Literal, cast
@@ -33,6 +34,8 @@ from pyghidra_mcp.models import (
     SearchMode,
     StringSearchResults,
     SymbolSearchResults,
+    VariableRenameResponse,
+    VariableTypeResponse,
 )
 from pyghidra_mcp.tools import GhidraTools
 
@@ -96,8 +99,6 @@ def mcp_error_handler(func):
         except Exception as e:
             raise handle_error(e) from e
 
-    import asyncio
-
     return async_wrapper if asyncio.iscoroutinefunction(func) else sync_wrapper
 
 
@@ -113,26 +114,33 @@ async def decompile_function(
     include_callees: bool = False,
     include_strings: bool = False,
     include_xrefs: bool = False,
+    timeout_sec: int = 30,
 ) -> list[DecompiledFunction]:
     """Decompile function(s) to pseudo-C by name or address.
 
     Accepts a single target or a list for batch decompilation.
     Rich response flags attach callees, strings, and/or xrefs to each result.
+    `timeout_sec` applies per target.
     """
     pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
     targets = [name_or_address] if isinstance(name_or_address, str) else name_or_address
     results: list[DecompiledFunction] = []
+
+    def _decompile_target(target: str) -> DecompiledFunction:
+        result = tools.decompile_function_by_name_or_addr(target, timeout=timeout_sec)
+        if include_callees:
+            result.callees = tools.get_callees(target)
+        if include_strings:
+            result.referenced_strings = tools.get_referenced_strings(target)
+        if include_xrefs:
+            result.xrefs = tools.list_xrefs(target)
+        return result
+
     for target in targets:
         try:
-            result = tools.decompile_function_by_name_or_addr(target)
-            if include_callees:
-                result.callees = tools.get_callees(target)
-            if include_strings:
-                result.referenced_strings = tools.get_referenced_strings(target)
-            if include_xrefs:
-                result.xrefs = tools.list_xrefs(target)
+            result = await asyncio.to_thread(_decompile_target, target)
             results.append(result)
         except Exception as e:
             results.append(DecompiledFunction(name=target, code="", error=str(e)))
@@ -262,6 +270,52 @@ def rename_function(
     )
     result = cast(dict, result)
     return RenameResponse(binary_name=binary_name, **result)
+
+
+@mcp_error_handler
+def rename_variable(
+    binary_name: str,
+    function_name_or_address: str,
+    variable_name: str,
+    new_name: str,
+    ctx: Context,
+) -> VariableRenameResponse:
+    """Rename a function parameter or local variable by exact name within a function.
+
+    Missing or ambiguous names return an error instead of guessing.
+    """
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
+    program_info = pyghidra_context.get_program_info(binary_name)
+    tools = GhidraTools(program_info)
+    result = _run_for_context(
+        pyghidra_context,
+        lambda: tools.rename_variable(function_name_or_address, variable_name, new_name),
+    )
+    result = cast(dict, result)
+    return VariableRenameResponse(binary_name=binary_name, **result)
+
+
+@mcp_error_handler
+def set_variable_type(
+    binary_name: str,
+    function_name_or_address: str,
+    variable_name: str,
+    type_name: str,
+    ctx: Context,
+) -> VariableTypeResponse:
+    """Set the data type for a function parameter or local variable by exact name.
+
+    Missing or ambiguous names return an error instead of guessing.
+    """
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
+    program_info = pyghidra_context.get_program_info(binary_name)
+    tools = GhidraTools(program_info)
+    result = _run_for_context(
+        pyghidra_context,
+        lambda: tools.set_variable_type(function_name_or_address, variable_name, type_name),
+    )
+    result = cast(dict, result)
+    return VariableTypeResponse(binary_name=binary_name, **result)
 
 
 @mcp_error_handler

--- a/src/pyghidra_mcp/models.py
+++ b/src/pyghidra_mcp/models.py
@@ -75,6 +75,25 @@ class RenameResponse(BaseModel):
     new_name: str
 
 
+class VariableRenameResponse(BaseModel):
+    binary_name: str
+    function_name: str
+    function_address: str
+    variable_kind: str
+    old_name: str
+    new_name: str
+
+
+class VariableTypeResponse(BaseModel):
+    binary_name: str
+    function_name: str
+    function_address: str
+    variable_kind: str
+    variable_name: str
+    old_type: str
+    new_type: str
+
+
 class CommentResponse(BaseModel):
     binary_name: str
     address: str

--- a/src/pyghidra_mcp/server.py
+++ b/src/pyghidra_mcp/server.py
@@ -51,6 +51,8 @@ def register_common_tools(server: FastMCP) -> None:
     server.tool()(mcp_tools.list_project_binaries)
     server.tool()(mcp_tools.list_project_binary_metadata)
     server.tool()(mcp_tools.rename_function)
+    server.tool()(mcp_tools.rename_variable)
+    server.tool()(mcp_tools.set_variable_type)
     server.tool()(mcp_tools.set_comment)
     server.tool()(mcp_tools.delete_project_binary)
     server.tool()(mcp_tools.list_exports)
@@ -355,7 +357,7 @@ def run_mcp_server(mcp: FastMCP, transport: str) -> None:
     help="Location to store GZFs of analyzed binaries.",
 )
 @click.argument("input_paths", type=click.Path(exists=True), nargs=-1)
-def main(
+def main(  # noqa: C901
     transport: str,
     input_paths: list[Path],
     project_path: Path,
@@ -416,10 +418,16 @@ def main(
         ensure_macos_framework_python()
         launcher = GuiPyGhidraMcpLauncher(project_spec.gpr_path)
         launcher.start()
+        gui_server_error: list[BaseException] = []
 
         def gui_server_thread() -> None:
-            init_gui_context(mcp=mcp, project_spec=project_spec, input_paths=input_paths)
-            run_mcp_server(mcp, transport)
+            try:
+                init_gui_context(mcp=mcp, project_spec=project_spec, input_paths=input_paths)
+                run_mcp_server(mcp, transport)
+            except BaseException as exc:
+                gui_server_error.append(exc)
+                logger.exception("GUI MCP server failed during startup or runtime.")
+                launcher.request_shutdown()
 
         server_thread = threading.Thread(
             target=gui_server_thread,
@@ -435,6 +443,8 @@ def main(
             context = getattr(mcp, "_pyghidra_context", None)
             if context is not None:
                 context.close()
+        if gui_server_error:
+            raise RuntimeError("GUI MCP server failed to start.") from gui_server_error[0]
         return
 
     init_pyghidra_context(

--- a/src/pyghidra_mcp/tools.py
+++ b/src/pyghidra_mcp/tools.py
@@ -72,11 +72,46 @@ class GhidraTools:
         """Initialize with a Ghidra ProgramInfo object"""
         self.program_info = program_info
         self.program = program_info.program
-        self.decompiler = program_info.decompiler
+        self.decompiler_pool = program_info.decompiler_pool
 
     def _get_filename(self, func: "Function"):
         max_path_len = 50
         return f"{func.getSymbol().getName(True)[:max_path_len]}-{func.entryPoint}"
+
+    def _resolve_function_variable(
+        self,
+        function_name_or_address: str,
+        variable_name: str,
+    ) -> tuple["Function", str, typing.Any]:
+        func = self.find_function(function_name_or_address)
+        function_name = str(func.getName())
+
+        matches: list[tuple[str, typing.Any]] = []
+        for param in func.getParameters():
+            if str(param.getName()) == variable_name:
+                matches.append(("parameter", param))
+        for local in func.getLocalVariables():
+            if str(local.getName()) == variable_name:
+                matches.append(("local", local))
+
+        if not matches:
+            raise ValueError(f"Variable '{variable_name}' not found in function '{function_name}'.")
+        if len(matches) > 1:
+            kinds = ", ".join(kind for kind, _ in matches)
+            raise ValueError(
+                f"Ambiguous variable '{variable_name}' in function '{function_name}' ({kinds})."
+            )
+
+        variable_kind, variable = matches[0]
+        return func, variable_kind, variable
+
+    def _parse_data_type(self, type_name: str):
+        from ghidra.util.data import DataTypeParser  # type: ignore
+        from ghidra.util.data.DataTypeParser import AllowedDataTypes  # type: ignore
+
+        dtm = self.program.getDataTypeManager()
+        parser = DataTypeParser(dtm, dtm, typing.cast(typing.Any, None), AllowedDataTypes.DYNAMIC)
+        return parser.parse(type_name)
 
     def _lookup_functions(
         self,
@@ -248,14 +283,15 @@ class GhidraTools:
         """Finds and decompiles a function in a specified binary and returns its pseudo-C code."""
 
         func = self.find_function(name_or_address)
-        return self.decompile_function(func)
+        return self.decompile_function(func, timeout=timeout)
 
     def decompile_function(self, func: "Function", timeout: int = 0) -> DecompiledFunction:
         """Decompiles a function in a specified binary and returns its pseudo-C code."""
         from ghidra.util.task import ConsoleTaskMonitor
 
         monitor = ConsoleTaskMonitor()
-        result: DecompileResults = self.decompiler.decompileFunction(func, timeout, monitor)
+        with self.decompiler_pool.acquire() as decompiler:
+            result: DecompileResults = decompiler.decompileFunction(func, timeout, monitor)
         if "" == result.getErrorMessage():
             code = result.decompiledFunction.getC()
             sig = result.decompiledFunction.getSignature()
@@ -817,6 +853,69 @@ class GhidraTools:
         }
 
     @handle_exceptions
+    def rename_variable(
+        self,
+        function_name_or_address: str,
+        variable_name: str,
+        new_name: str,
+    ) -> dict:
+        from ghidra.program.model.symbol import SourceType
+
+        func, variable_kind, variable = self._resolve_function_variable(
+            function_name_or_address, variable_name
+        )
+        old_name = str(variable_name)
+        function_name = str(func.getName())
+        function_address = str(func.getEntryPoint())
+        with ghidra_transaction(
+            self.program,
+            f"pyghidra-mcp: rename {variable_kind} {old_name} -> {new_name}",
+        ):
+            variable.setName(new_name, SourceType.USER_DEFINED)
+
+        self.invalidate_decompiler_cache()
+        return {
+            "function_name": function_name,
+            "function_address": function_address,
+            "variable_kind": variable_kind,
+            "old_name": old_name,
+            "new_name": new_name,
+        }
+
+    @handle_exceptions
+    def set_variable_type(
+        self,
+        function_name_or_address: str,
+        variable_name: str,
+        type_name: str,
+    ) -> dict:
+        from ghidra.program.model.symbol import SourceType
+
+        func, variable_kind, variable = self._resolve_function_variable(
+            function_name_or_address, variable_name
+        )
+        function_name = str(func.getName())
+        function_address = str(func.getEntryPoint())
+        old_type = str(variable.getDataType().getDisplayName())
+        data_type = self._parse_data_type(type_name)
+
+        with ghidra_transaction(
+            self.program,
+            f"pyghidra-mcp: set {variable_kind} type {variable_name} -> {type_name}",
+        ):
+            variable.setDataType(data_type, SourceType.USER_DEFINED)
+
+        self.invalidate_decompiler_cache()
+        return {
+            "function_name": function_name,
+            "function_address": function_address,
+            "variable_kind": variable_kind,
+            "variable_name": str(variable.getName()),
+            "old_type": old_type,
+            "new_type": str(variable.getDataType().getDisplayName()),
+        }
+
+    @handle_exceptions
     def set_comment(self, target: str, comment: str, comment_type: str) -> dict:
         try:
             from ghidra.program.model.listing import CommentType
@@ -877,18 +976,10 @@ class GhidraTools:
         }
 
     def invalidate_decompiler_cache(self) -> None:
-        for method_name in ("flushCache", "resetDecompiler"):
-            method = getattr(self.decompiler, method_name, None)
-            if method is not None:
-                try:
-                    method()
-                except Exception:
-                    logger.debug(
-                        "Failed to invalidate decompiler cache with %s",
-                        method_name,
-                        exc_info=True,
-                    )
-                return
+        try:
+            self.decompiler_pool.invalidate_all()
+        except Exception:
+            logger.debug("Failed to invalidate decompiler cache", exc_info=True)
 
     def _parse_address(self, address: str):
         addr_str = address[2:] if address.lower().startswith("0x") else address

--- a/tests/integration/test_rename_variable.py
+++ b/tests/integration/test_rename_variable.py
@@ -1,0 +1,143 @@
+import json
+import os
+import tempfile
+
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from pyghidra_mcp.context import PyGhidraContext
+
+
+@pytest.fixture(scope="module")
+def variable_test_binary():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".c", delete=False) as f:
+        f.write(
+            """
+#include <stdio.h>
+
+int helper(int count) {
+    int total = count + 1;
+    printf("%d\\n", total);
+    return total;
+}
+
+int main(void) {
+    return helper(3);
+}
+"""
+        )
+        c_file = f.name
+
+    bin_file = c_file.replace(".c", "")
+    os.system(f"gcc -g -O0 -o {bin_file} {c_file}")
+
+    yield bin_file
+
+    os.unlink(c_file)
+    os.unlink(bin_file)
+
+
+@pytest.fixture(scope="module")
+def variable_server_params(variable_test_binary, ghidra_env, isolated_project_root):
+    return StdioServerParameters(
+        command="python",
+        args=[
+            "-m",
+            "pyghidra_mcp",
+            "--project-path",
+            str(isolated_project_root / "variable_server_params"),
+            "--project-name",
+            "variable_server_params_project",
+            "--wait-for-analysis",
+            variable_test_binary,
+        ],
+        env=ghidra_env,
+    )
+
+
+@pytest.mark.asyncio
+async def test_rename_variable_tool(variable_server_params, variable_test_binary):
+    async with stdio_client(variable_server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            binary_name = PyGhidraContext._gen_unique_bin_name(variable_test_binary)
+            symbols_result = await session.call_tool(
+                "search_symbols_by_name",
+                {
+                    "binary_name": binary_name,
+                    "query": "^helper$",
+                    "functions_only": True,
+                },
+            )
+            symbols_payload = json.loads(symbols_result.content[0].text)
+            helper_name = symbols_payload["symbols"][0]["name"]
+
+            rename_result = await session.call_tool(
+                "rename_variable",
+                {
+                    "binary_name": binary_name,
+                    "function_name_or_address": helper_name,
+                    "variable_name": "count",
+                    "new_name": "item_count",
+                },
+            )
+            rename_payload = json.loads(rename_result.content[0].text)
+            assert rename_payload["function_name"] == helper_name
+            assert rename_payload["variable_kind"] == "parameter"
+            assert rename_payload["old_name"] == "count"
+            assert rename_payload["new_name"] == "item_count"
+
+            decompile_result = await session.call_tool(
+                "decompile_function",
+                {
+                    "binary_name": binary_name,
+                    "name_or_address": helper_name,
+                },
+            )
+            decompile_payload = json.loads(decompile_result.content[0].text)
+            assert "item_count" in decompile_payload["code"]
+
+
+@pytest.mark.asyncio
+async def test_set_variable_type_tool(variable_server_params, variable_test_binary):
+    async with stdio_client(variable_server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            binary_name = PyGhidraContext._gen_unique_bin_name(variable_test_binary)
+            symbols_result = await session.call_tool(
+                "search_symbols_by_name",
+                {
+                    "binary_name": binary_name,
+                    "query": "^helper$",
+                    "functions_only": True,
+                },
+            )
+            symbols_payload = json.loads(symbols_result.content[0].text)
+            helper_name = symbols_payload["symbols"][0]["name"]
+
+            type_result = await session.call_tool(
+                "set_variable_type",
+                {
+                    "binary_name": binary_name,
+                    "function_name_or_address": helper_name,
+                    "variable_name": "count",
+                    "type_name": "long",
+                },
+            )
+            type_payload = json.loads(type_result.content[0].text)
+            assert type_payload["function_name"] == helper_name
+            assert type_payload["variable_kind"] == "parameter"
+            assert type_payload["variable_name"] == "count"
+            assert type_payload["old_type"] == "int"
+            assert type_payload["new_type"] == "long"
+
+            decompile_result = await session.call_tool(
+                "decompile_function",
+                {
+                    "binary_name": binary_name,
+                    "name_or_address": helper_name,
+                },
+            )
+            decompile_payload = json.loads(decompile_result.content[0].text)
+            assert "long count" in decompile_payload["code"]

--- a/tests/unit/test_gui_context.py
+++ b/tests/unit/test_gui_context.py
@@ -91,7 +91,7 @@ def test_refresh_programs_resyncs_existing_program_state():
         name="sample",
         program=program,
         flat_api=None,
-        decompiler=Mock(),
+        decompiler_pool=Mock(),
         metadata={},
         ghidra_analysis_complete=False,
     )

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -1,8 +1,19 @@
+import asyncio
 from unittest.mock import Mock
 
+import pytest
+
 from pyghidra_mcp.gui_context import GuiPyGhidraContext
-from pyghidra_mcp.mcp_tools import goto, list_project_binaries, set_comment
-from pyghidra_mcp.models import ProgramInfo
+from pyghidra_mcp.mcp_tools import (
+    decompile_function,
+    goto,
+    list_project_binaries,
+    rename_variable,
+    search_symbols_by_name,
+    set_comment,
+    set_variable_type,
+)
+from pyghidra_mcp.models import ProgramInfo, SymbolInfo
 
 
 def test_list_project_binaries_uses_project_wide_context_listing():
@@ -57,6 +68,175 @@ def test_set_comment_uses_tool_path(monkeypatch):
     assert response.binary_name == "sample"
     assert response.address == "1000042e3"
     assert response.comment_type == "decompiler"
+
+
+def test_rename_variable_uses_tool_path(monkeypatch):
+    pyghidra_context = Mock()
+    pyghidra_context.get_program_info.return_value = Mock()
+
+    fake_tools = Mock()
+    fake_tools.rename_variable.return_value = {
+        "function_name": "helper",
+        "function_address": "100001000",
+        "variable_kind": "parameter",
+        "old_name": "count",
+        "new_name": "item_count",
+    }
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = pyghidra_context
+
+    monkeypatch.setattr("pyghidra_mcp.mcp_tools.GhidraTools", lambda _program_info: fake_tools)
+
+    response = rename_variable(
+        binary_name="sample",
+        function_name_or_address="helper",
+        variable_name="count",
+        new_name="item_count",
+        ctx=ctx,
+    )
+
+    fake_tools.rename_variable.assert_called_once_with("helper", "count", "item_count")
+    assert response.binary_name == "sample"
+    assert response.function_name == "helper"
+    assert response.function_address == "100001000"
+    assert response.variable_kind == "parameter"
+    assert response.old_name == "count"
+    assert response.new_name == "item_count"
+
+
+def test_set_variable_type_uses_tool_path(monkeypatch):
+    pyghidra_context = Mock()
+    pyghidra_context.get_program_info.return_value = Mock()
+
+    fake_tools = Mock()
+    fake_tools.set_variable_type.return_value = {
+        "function_name": "helper",
+        "function_address": "100001000",
+        "variable_kind": "local",
+        "variable_name": "total",
+        "old_type": "int",
+        "new_type": "long",
+    }
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = pyghidra_context
+
+    monkeypatch.setattr("pyghidra_mcp.mcp_tools.GhidraTools", lambda _program_info: fake_tools)
+
+    response = set_variable_type(
+        binary_name="sample",
+        function_name_or_address="helper",
+        variable_name="total",
+        type_name="long",
+        ctx=ctx,
+    )
+
+    fake_tools.set_variable_type.assert_called_once_with("helper", "total", "long")
+    assert response.binary_name == "sample"
+    assert response.function_name == "helper"
+    assert response.function_address == "100001000"
+    assert response.variable_kind == "local"
+    assert response.variable_name == "total"
+    assert response.old_type == "int"
+    assert response.new_type == "long"
+
+
+@pytest.mark.asyncio
+async def test_decompile_function_offloads_with_timeout(monkeypatch):
+    pyghidra_context = Mock()
+    pyghidra_context.get_program_info.return_value = Mock()
+
+    fake_tools = Mock()
+    decompiled = Mock()
+    decompiled.callees = None
+    decompiled.referenced_strings = None
+    decompiled.xrefs = None
+    fake_tools.decompile_function_by_name_or_addr.return_value = decompiled
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = pyghidra_context
+
+    monkeypatch.setattr("pyghidra_mcp.mcp_tools.GhidraTools", lambda _program_info: fake_tools)
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    response = await decompile_function(
+        binary_name="sample",
+        name_or_address="entry",
+        timeout_sec=17,
+        ctx=ctx,
+    )
+
+    fake_tools.decompile_function_by_name_or_addr.assert_called_once_with("entry", timeout=17)
+    assert response == [decompiled]
+
+
+@pytest.mark.asyncio
+async def test_decompile_does_not_block_other_tool_calls(monkeypatch):
+    pyghidra_context = Mock()
+    pyghidra_context.get_program_info.return_value = Mock()
+
+    fake_tools = Mock()
+    decompiled = Mock()
+    fake_tools.search_symbols_by_name.return_value = [
+        SymbolInfo(
+            name="entry",
+            address="1000",
+            type="Function",
+            namespace="Global",
+            source="USER_DEFINED",
+            refcount=1,
+            external=False,
+        )
+    ]
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = pyghidra_context
+
+    monkeypatch.setattr("pyghidra_mcp.mcp_tools.GhidraTools", lambda _program_info: fake_tools)
+
+    decompile_started = asyncio.Event()
+    release_decompile = asyncio.Event()
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        decompile_started.set()
+        await release_decompile.wait()
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    fake_tools.decompile_function_by_name_or_addr.return_value = decompiled
+
+    decompile_task = asyncio.create_task(
+        decompile_function(
+            binary_name="sample",
+            name_or_address="entry",
+            timeout_sec=30,
+            ctx=ctx,
+        )
+    )
+
+    await decompile_started.wait()
+
+    symbols = search_symbols_by_name(
+        binary_name="sample",
+        query="entry",
+        ctx=ctx,
+    )
+
+    fake_tools.search_symbols_by_name.assert_called_once_with(
+        "entry", functions_only=False, offset=0, limit=25
+    )
+    assert symbols.symbols[0].name == "entry"
+    assert not decompile_task.done()
+
+    release_decompile.set()
+    response = await decompile_task
+    assert response == [decompiled]
 
 
 def test_goto_uses_gui_context():

--- a/tests/unit/test_search_regex.py
+++ b/tests/unit/test_search_regex.py
@@ -44,7 +44,7 @@ def _make_tools(functions=None, symbols=None):
     tools = GhidraTools.__new__(GhidraTools)
     tools.program_info = program_info
     tools.program = program_info.program
-    tools.decompiler = Mock()
+    tools.decompiler_pool = Mock()
 
     if functions is not None:
         tools.get_all_functions = Mock(return_value=functions)


### PR DESCRIPTION
## Summary
- add  and 
- move MCP decompilation off the async request loop and add per-program decompiler pooling
- expose  for 
- update README and tool descriptions

## Testing
- pre-commit hooks
- focused unit tests
- 
