### PR TITLE
Add function prototype editing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,8 @@ Per-item errors are returned inline (other targets still succeed):
 
 - `set_variable_type(binary_name: str, function_name_or_address: str, variable_name: str, type_name: str)`: Set the data type for a function parameter or local variable by exact name within a specific function. If the name is missing or ambiguous within that function, the tool returns an error instead of guessing. `type_name` is parsed using Ghidra's datatype parser against the program datatype manager.
 
+- `set_function_prototype(binary_name: str, function_name_or_address: str, prototype: str)`: Set a function prototype from a full signature string. The tool always runs the prototype through Ghidra's native signature parser and returns the underlying parser or apply error if the prototype is invalid.
+
 - `set_comment(binary_name: str, target: str, comment: str, comment_type: str)`: Set a function/decompiler comment or listing comment. Supported `comment_type` values are `decompiler`, `plate`, `pre`, `eol`, `post`, and `repeatable`.
 
 #### GUI Control Tools (`--gui` only)
@@ -466,7 +468,7 @@ Per-item errors are returned inline (other targets still succeed):
 These tools are only available when `pyghidra-mcp` is started with `--gui` and control what the GUI is showing rather than mutating project data directly:
 
 - `list_open_programs()`: List programs currently open in the Ghidra GUI.
-- `open_program_in_gui(binary_name: str)`: Open a project binary in CodeBrowser.
+- `open_program_in_gui(binary_name: str, new_window: bool = True)`: Open a project binary in CodeBrowser. By default this opens a new CodeBrowser window. Set `new_window=false` to reuse a visible CodeBrowser when possible.
 - `set_current_program(binary_name: str)`: Make an open program the active/current program in the primary GUI tool context.
 - `goto(binary_name: str, target: str, target_type: str)`: Navigate the Ghidra GUI to an address or function. `target_type` must be `address` or `function`.
 

--- a/src/pyghidra_mcp/mcp_tools.py
+++ b/src/pyghidra_mcp/mcp_tools.py
@@ -24,6 +24,7 @@ from pyghidra_mcp.models import (
     CrossReferenceInfos,
     DecompiledFunction,
     ExportInfos,
+    FunctionPrototypeResponse,
     GotoResponse,
     ImportInfos,
     ImportRequestResult,
@@ -269,7 +270,7 @@ def rename_function(
     new_name: str,
     ctx: Context,
 ) -> RenameResponse:
-    """Rename a function using a Ghidra transaction."""
+    """Rename a function."""
     pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
@@ -289,10 +290,7 @@ def rename_variable(
     new_name: str,
     ctx: Context,
 ) -> VariableRenameResponse:
-    """Rename a function parameter or local variable by exact name within a function.
-
-    Missing or ambiguous names return an error instead of guessing.
-    """
+    """Rename a parameter or local by exact name."""
     pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
@@ -312,10 +310,7 @@ def set_variable_type(
     type_name: str,
     ctx: Context,
 ) -> VariableTypeResponse:
-    """Set the data type for a function parameter or local variable by exact name.
-
-    Missing or ambiguous names return an error instead of guessing.
-    """
+    """Set a parameter or local type by exact name."""
     pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
@@ -328,6 +323,25 @@ def set_variable_type(
 
 
 @mcp_error_handler
+def set_function_prototype(
+    binary_name: str,
+    function_name_or_address: str,
+    prototype: str,
+    ctx: Context,
+) -> FunctionPrototypeResponse:
+    """Set a function prototype. Invalid input returns Ghidra's error."""
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
+    program_info = pyghidra_context.get_program_info(binary_name)
+    tools = GhidraTools(program_info)
+    result = _run_for_context(
+        pyghidra_context,
+        lambda: tools.set_function_prototype(function_name_or_address, prototype),
+    )
+    result = cast(dict, result)
+    return FunctionPrototypeResponse(binary_name=binary_name, **result)
+
+
+@mcp_error_handler
 def set_comment(
     binary_name: str,
     target: str,
@@ -335,7 +349,7 @@ def set_comment(
     comment_type: Literal["decompiler", "plate", "pre", "eol", "post", "repeatable"],
     ctx: Context,
 ) -> CommentResponse:
-    """Set a comment in the decompiler or listing."""
+    """Set a decompiler or listing comment."""
     pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)

--- a/src/pyghidra_mcp/models.py
+++ b/src/pyghidra_mcp/models.py
@@ -94,6 +94,14 @@ class VariableTypeResponse(BaseModel):
     new_type: str
 
 
+class FunctionPrototypeResponse(BaseModel):
+    binary_name: str
+    function_name: str
+    function_address: str
+    old_prototype: str
+    new_prototype: str
+
+
 class CommentResponse(BaseModel):
     binary_name: str
     address: str

--- a/src/pyghidra_mcp/server.py
+++ b/src/pyghidra_mcp/server.py
@@ -53,6 +53,7 @@ def register_common_tools(server: FastMCP) -> None:
     server.tool()(mcp_tools.rename_function)
     server.tool()(mcp_tools.rename_variable)
     server.tool()(mcp_tools.set_variable_type)
+    server.tool()(mcp_tools.set_function_prototype)
     server.tool()(mcp_tools.set_comment)
     server.tool()(mcp_tools.delete_project_binary)
     server.tool()(mcp_tools.list_exports)

--- a/src/pyghidra_mcp/tools.py
+++ b/src/pyghidra_mcp/tools.py
@@ -921,6 +921,48 @@ class GhidraTools:
         }
 
     @handle_exceptions
+    def set_function_prototype(
+        self,
+        function_name_or_address: str,
+        prototype: str,
+    ) -> dict:
+        from ghidra.app.cmd.function import ApplyFunctionSignatureCmd
+        from ghidra.app.util.parser import FunctionSignatureParser
+        from ghidra.program.model.symbol import SourceType
+        from ghidra.util.task import TaskMonitor
+
+        func = self.find_function(function_name_or_address)
+        function_name = str(func.getName())
+        function_address = str(func.getEntryPoint())
+        old_prototype = str(func.getSignature())
+
+        parser = FunctionSignatureParser(
+            self.program.getDataTypeManager(), typing.cast(typing.Any, None)
+        )
+        parsed_signature = parser.parse(func.getSignature(False), prototype)
+        cmd = ApplyFunctionSignatureCmd(
+            func.getEntryPoint(),
+            parsed_signature,
+            SourceType.USER_DEFINED,
+        )
+
+        with ghidra_transaction(
+            self.program,
+            f"pyghidra-mcp: set function prototype {function_name}",
+        ):
+            if not cmd.applyTo(self.program, TaskMonitor.DUMMY):
+                message = cmd.getStatusMsg() or f"Failed to apply function prototype: {prototype}"
+                raise ValueError(message)
+
+        self.invalidate_decompiler_cache()
+        return {
+            "function_name": function_name,
+            "function_address": function_address,
+            "old_prototype": old_prototype,
+            "new_prototype": str(func.getSignature()),
+        }
+
+    @handle_exceptions
     def set_comment(self, target: str, comment: str, comment_type: str) -> dict:
         try:
             from ghidra.program.model.listing import CommentType

--- a/tests/integration/test_rename_variable.py
+++ b/tests/integration/test_rename_variable.py
@@ -1,12 +1,11 @@
 import json
 import os
+import sys
 import tempfile
 
 import pytest
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
-
-from pyghidra_mcp.context import PyGhidraContext
 
 
 def _callee_name(callee):
@@ -22,23 +21,33 @@ def _find_function_one_name(callees) -> str:
 
 
 async def _resolve_function_one_name(session: ClientSession, binary_name: str) -> str:
-    for target in ("main", "_main", "entry"):
-        try:
-            decompile_result = await session.call_tool(
-                "decompile_function",
-                {
-                    "binary_name": binary_name,
-                    "name_or_address": target,
-                    "include_callees": True,
-                },
-            )
-            decompile_payload = json.loads(decompile_result.content[0].text)
-            callees = decompile_payload.get("callees") or []
-            return _find_function_one_name(callees)
-        except Exception:
-            pass
+    symbols_result = await session.call_tool(
+        "search_symbols_by_name",
+        {
+            "binary_name": binary_name,
+            "query": "function_one",
+            "functions_only": True,
+        },
+    )
+    symbols_payload = json.loads(symbols_result.content[0].text)
+    symbols = symbols_payload.get("symbols") or []
+    try:
+        return next(
+            symbol["name"]
+            for symbol in symbols
+            if isinstance(symbol, dict) and str(symbol.get("name", "")).endswith("function_one")
+        )
+    except StopIteration as exc:
+        raise AssertionError("Unable to resolve function_one by symbol search") from exc
 
-    raise AssertionError("Unable to resolve function_one from entry/main callees")
+
+async def _resolve_binary_name(session: ClientSession) -> str:
+    binaries_result = await session.call_tool("list_project_binaries", {})
+    binaries_payload = json.loads(binaries_result.content[0].text)
+    programs = binaries_payload.get("programs") or []
+    if len(programs) != 1:
+        raise AssertionError(f"Expected exactly one imported binary, got {programs}")
+    return programs[0]["name"]
 
 
 @pytest.fixture(scope="module")
@@ -78,7 +87,7 @@ int main(void) {
 @pytest.fixture(scope="module")
 def variable_server_params(variable_test_binary, ghidra_env, isolated_project_root):
     return StdioServerParameters(
-        command="python",
+        command=sys.executable,
         args=[
             "-m",
             "pyghidra_mcp",
@@ -98,7 +107,7 @@ async def test_rename_variable_tool(variable_server_params, variable_test_binary
     async with stdio_client(variable_server_params) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
-            binary_name = PyGhidraContext._gen_unique_bin_name(variable_test_binary)
+            binary_name = await _resolve_binary_name(session)
             function_name = await _resolve_function_one_name(session, binary_name)
 
             rename_result = await session.call_tool(
@@ -137,7 +146,7 @@ async def test_set_variable_type_tool(variable_server_params, variable_test_bina
     async with stdio_client(variable_server_params) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
-            binary_name = PyGhidraContext._gen_unique_bin_name(variable_test_binary)
+            binary_name = await _resolve_binary_name(session)
             function_name = await _resolve_function_one_name(session, binary_name)
 
             type_result = await session.call_tool(
@@ -170,3 +179,57 @@ async def test_set_variable_type_tool(variable_server_params, variable_test_bina
             assert reset_payload["variable_name"] == "count"
             assert reset_payload["old_type"] == "long"
             assert reset_payload["new_type"] == "int"
+
+
+@pytest.mark.asyncio
+async def test_set_function_prototype_tool(variable_server_params, variable_test_binary):
+    async with stdio_client(variable_server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            binary_name = await _resolve_binary_name(session)
+            function_name = await _resolve_function_one_name(session, binary_name)
+
+            prototype_result = await session.call_tool(
+                "set_function_prototype",
+                {
+                    "binary_name": binary_name,
+                    "function_name_or_address": function_name,
+                    "prototype": "long function_one(long count)",
+                },
+            )
+            prototype_payload = json.loads(prototype_result.content[0].text)
+            assert prototype_payload["function_name"] == function_name
+            assert prototype_payload["old_prototype"] == "int __cdecl function_one(int count)"
+            assert prototype_payload["new_prototype"] == "long __cdecl function_one(long count)"
+
+            decompile_result = await session.call_tool(
+                "decompile_function",
+                {
+                    "binary_name": binary_name,
+                    "name_or_address": function_name,
+                },
+            )
+            decompile_payload = json.loads(decompile_result.content[0].text)
+            assert "long function_one(long count)" in decompile_payload["signature"]
+
+
+@pytest.mark.asyncio
+async def test_set_function_prototype_surfaces_parser_errors(
+    variable_server_params, variable_test_binary
+):
+    async with stdio_client(variable_server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            binary_name = await _resolve_binary_name(session)
+            function_name = await _resolve_function_one_name(session, binary_name)
+            result = await session.call_tool(
+                "set_function_prototype",
+                {
+                    "binary_name": binary_name,
+                    "function_name_or_address": function_name,
+                    "prototype": "long function_one(size_t count)",
+                },
+            )
+
+            assert result.isError is True
+            assert "Can't resolve datatype: size_t" in result.content[0].text

--- a/tests/integration/test_rename_variable.py
+++ b/tests/integration/test_rename_variable.py
@@ -199,8 +199,10 @@ async def test_set_function_prototype_tool(variable_server_params, variable_test
             )
             prototype_payload = json.loads(prototype_result.content[0].text)
             assert prototype_payload["function_name"] == function_name
-            assert prototype_payload["old_prototype"] == "int __cdecl function_one(int count)"
-            assert prototype_payload["new_prototype"] == "long __cdecl function_one(long count)"
+            assert prototype_payload["old_prototype"].endswith("function_one(int count)")
+            assert prototype_payload["new_prototype"].endswith("function_one(long count)")
+            assert prototype_payload["old_prototype"].startswith("int ")
+            assert prototype_payload["new_prototype"].startswith("long ")
 
             decompile_result = await session.call_tool(
                 "decompile_function",

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -11,6 +11,7 @@ from pyghidra_mcp.mcp_tools import (
     rename_variable,
     search_symbols_by_name,
     set_comment,
+    set_function_prototype,
     set_variable_type,
 )
 from pyghidra_mcp.models import ProgramInfo, SymbolInfo
@@ -140,6 +141,40 @@ def test_set_variable_type_uses_tool_path(monkeypatch):
     assert response.variable_name == "total"
     assert response.old_type == "int"
     assert response.new_type == "long"
+
+
+def test_set_function_prototype_uses_tool_path(monkeypatch):
+    pyghidra_context = Mock()
+    pyghidra_context.get_program_info.return_value = Mock()
+
+    fake_tools = Mock()
+    fake_tools.set_function_prototype.return_value = {
+        "function_name": "function_one",
+        "function_address": "100001000",
+        "old_prototype": "int function_one(int count)",
+        "new_prototype": "long function_one(long count)",
+    }
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = pyghidra_context
+
+    monkeypatch.setattr("pyghidra_mcp.mcp_tools.GhidraTools", lambda _program_info: fake_tools)
+
+    response = set_function_prototype(
+        binary_name="sample",
+        function_name_or_address="function_one",
+        prototype="long function_one(long count)",
+        ctx=ctx,
+    )
+
+    fake_tools.set_function_prototype.assert_called_once_with(
+        "function_one", "long function_one(long count)"
+    )
+    assert response.binary_name == "sample"
+    assert response.function_name == "function_one"
+    assert response.function_address == "100001000"
+    assert response.old_prototype == "int function_one(int count)"
+    assert response.new_prototype == "long function_one(long count)"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add  to the MCP/server tool surface
- apply prototypes through Ghidra's native signature parser and return parser/apply errors
- tighten edit-tool FastMCP docstrings and update related docs/tests

## Validation
- pre-commit hooks passed locally
- targeted integration smoke for variable/prototype editing passed locally
