### PR TITLE
Improve comment target resolution and thunk search info

### DIFF
--- a/src/pyghidra_mcp/models.py
+++ b/src/pyghidra_mcp/models.py
@@ -152,6 +152,8 @@ class SymbolInfo(BaseModel):
     source: str
     refcount: int
     external: bool
+    is_thunk: bool = False
+    thunk_target: str | None = None
 
 
 class SymbolSearchResults(BaseModel):

--- a/src/pyghidra_mcp/tools.py
+++ b/src/pyghidra_mcp/tools.py
@@ -391,6 +391,33 @@ class GhidraTools:
     def _symbol_to_info(self, symbol, rm) -> SymbolInfo:
         """Convert a Ghidra Symbol to a SymbolInfo model."""
         ref_count = len(list(rm.getReferencesTo(symbol.getAddress())))
+        is_thunk = False
+        thunk_target = None
+
+        try:
+            func = self.program.getFunctionManager().getFunctionAt(symbol.getAddress())
+        except Exception:
+            func = None
+
+        if func is not None:
+            try:
+                is_thunk = bool(func.isThunk())
+            except Exception:
+                is_thunk = False
+
+            if is_thunk:
+                try:
+                    thunked = func.getThunkedFunction(True)
+                except TypeError:
+                    thunked = func.getThunkedFunction(False)
+                except Exception:
+                    thunked = None
+
+                if thunked is not None:
+                    thunk_target = (
+                        f"{thunked.getSymbol().getName(True)} @ {thunked.getEntryPoint()}"
+                    )
+
         return SymbolInfo(
             name=symbol.getName(),
             address=str(symbol.getAddress()),
@@ -399,6 +426,27 @@ class GhidraTools:
             source=str(symbol.getSource()),
             refcount=ref_count,
             external=symbol.isExternal(),
+            is_thunk=is_thunk,
+            thunk_target=thunk_target,
+        )
+
+    @classmethod
+    def _symbol_sort_key(cls, query: str, symbol, info: SymbolInfo) -> tuple:
+        names = {str(symbol.getName())}
+        try:
+            names.add(str(symbol.getName(True)))
+        except TypeError:
+            pass
+
+        query_lc = query.lower()
+        exact_name = any(name.lower() == query_lc for name in names)
+        return (
+            0 if exact_name else 1,
+            1 if info.is_thunk else 0,
+            1 if info.external else 0,
+            -info.refcount,
+            info.name.lower(),
+            info.address,
         )
 
     @handle_exceptions
@@ -422,11 +470,15 @@ class GhidraTools:
         else:
             symbols = self.get_all_symbols(True) if is_regex else self.find_symbols(query)
 
-        results = [
-            self._symbol_to_info(sym, rm)
-            for sym in symbols
-            if self._symbol_matches_query(query, sym)
-        ]
+        matches = []
+        for sym in symbols:
+            if not self._symbol_matches_query(query, sym):
+                continue
+            info = self._symbol_to_info(sym, rm)
+            matches.append((sym, info))
+
+        matches.sort(key=lambda item: self._symbol_sort_key(query, item[0], item[1]))
+        results = [info for _, info in matches]
         return results[offset : limit + offset]
 
     @handle_exceptions
@@ -1008,7 +1060,7 @@ class GhidraTools:
             allowed = ["decompiler", *listing_comment_types.keys()]
             raise ValueError(f"Invalid comment_type '{comment_type}'. Expected one of: {allowed}")
 
-        addr = self._parse_address(target)
+        addr = self._resolve_comment_target_address(target)
         with ghidra_transaction(
             self.program,
             f"pyghidra-mcp: set {normalized_type} comment @ {addr}",
@@ -1034,3 +1086,28 @@ class GhidraTools:
         if addr is None:
             raise ValueError(f"Invalid address: {address}")
         return addr
+
+    def _resolve_comment_target_address(self, target: str):
+        try:
+            return self._parse_address(target)
+        except Exception:
+            pass
+
+        if target.isdigit():
+            addr = self.program.getAddressFactory().getDefaultAddressSpace().getAddress(int(target))
+            if addr is not None:
+                return addr
+
+        try:
+            return self.find_symbol(target).getAddress()
+        except Exception:
+            pass
+
+        try:
+            return self.find_function(target).getEntryPoint()
+        except Exception:
+            pass
+
+        raise ValueError(
+            f"Could not resolve comment target '{target}' as an address, symbol, or function."
+        )

--- a/tests/integration/test_concurrent_streamable_client.py
+++ b/tests/integration/test_concurrent_streamable_client.py
@@ -216,6 +216,15 @@ async def invoke_mutation_tools(base_url: str, server_binary_path):
                     "comment_type": "decompiler",
                 },
             )
+            listing_comment_response = await session.call_tool(
+                "set_comment",
+                {
+                    "binary_name": binary_name,
+                    "target": new_name,
+                    "comment": "Listing comment via symbol resolution.",
+                    "comment_type": "plate",
+                },
+            )
             symbol_response = await session.call_tool(
                 "search_symbols_by_name",
                 {"binary_name": binary_name, "query": new_name},
@@ -225,7 +234,13 @@ async def invoke_mutation_tools(base_url: str, server_binary_path):
                 {"binary_name": binary_name, "name_or_address": new_name},
             )
 
-            return rename_response, comment_response, symbol_response, decompile_response
+            return (
+                rename_response,
+                comment_response,
+                listing_comment_response,
+                symbol_response,
+                decompile_response,
+            )
 
 
 @pytest.mark.asyncio
@@ -348,6 +363,7 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
     (
         rename_response,
         comment_response,
+        listing_comment_response,
         symbol_response,
         decompile_response,
     ) = await invoke_mutation_tools(streamable_base_url, streamable_binary)
@@ -364,9 +380,15 @@ async def test_concurrent_streamable_client_invocations(streamable_server):
     assert comment.comment_type == "decompiler"
     assert comment.comment == "Renamed during concurrent streamable integration test."
 
+    listing_comment_result = json.loads(listing_comment_response.content[0].text)
+    listing_comment = CommentResponse(**listing_comment_result)
+    assert listing_comment.comment_type == "plate"
+    assert listing_comment.comment == "Listing comment via symbol resolution."
+
     symbol_result = json.loads(symbol_response.content[0].text)
     symbol_search = SymbolSearchResults(**symbol_result)
     assert any(renamed_name in symbol.name for symbol in symbol_search.symbols)
+    assert all(hasattr(symbol, "is_thunk") for symbol in symbol_search.symbols)
 
     decompile_result = json.loads(decompile_response.content[0].text)
     decompiled = DecompiledFunction(**decompile_result)

--- a/tests/integration/test_search_symbols.py
+++ b/tests/integration/test_search_symbols.py
@@ -28,3 +28,5 @@ async def test_search_symbols_by_name(server_params, func_prefix):
             assert len(search_results.symbols) >= 2
             assert any(name_one in s.name for s in search_results.symbols)
             assert any(name_two in s.name for s in search_results.symbols)
+            assert all(hasattr(symbol, "is_thunk") for symbol in search_results.symbols)
+            assert all(symbol.is_thunk is False for symbol in search_results.symbols)

--- a/tests/unit/test_comment_resolution.py
+++ b/tests/unit/test_comment_resolution.py
@@ -1,0 +1,67 @@
+import sys
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from pyghidra_mcp.tools import GhidraTools
+
+
+def _make_tools():
+    tools = GhidraTools.__new__(GhidraTools)
+    tools.program = Mock()
+    tools.decompiler_pool = Mock()
+    tools.invalidate_decompiler_cache = Mock()
+    return tools
+
+
+def _install_listing_module(monkeypatch):
+    listing_module = SimpleNamespace(
+        CommentType=SimpleNamespace(PLATE=0, PRE=1, EOL=2, POST=3, REPEATABLE=4)
+    )
+    monkeypatch.setitem(sys.modules, "ghidra.program.model.listing", listing_module)
+
+
+def test_set_comment_resolves_symbol_target(monkeypatch):
+    tools = _make_tools()
+    _install_listing_module(monkeypatch)
+    monkeypatch.setattr(
+        "pyghidra_mcp.tools.ghidra_transaction",
+        lambda *_args, **_kwargs: nullcontext(),
+    )
+
+    addr = Mock()
+    addr.__str__ = Mock(return_value="10001000")
+    symbol = Mock()
+    symbol.getAddress.return_value = addr
+
+    tools._parse_address = Mock(side_effect=ValueError("not an address"))
+    tools.find_symbol = Mock(return_value=symbol)
+    tools.find_function = Mock(side_effect=AssertionError("should not fall back to function"))
+
+    result = tools.set_comment("safe_exec", "note", "plate")
+
+    tools.program.getListing.return_value.setComment.assert_called_once_with(addr, 0, "note")
+    assert result["address"] == "10001000"
+    assert result["comment_type"] == "plate"
+
+
+def test_set_comment_resolves_decimal_address(monkeypatch):
+    tools = _make_tools()
+    _install_listing_module(monkeypatch)
+    monkeypatch.setattr(
+        "pyghidra_mcp.tools.ghidra_transaction",
+        lambda *_args, **_kwargs: nullcontext(),
+    )
+
+    parsed_addr = Mock()
+    parsed_addr.__str__ = Mock(return_value="1000")
+    tools._parse_address = Mock(side_effect=ValueError("hex parse failed"))
+    tools.find_symbol = Mock(side_effect=ValueError("not a symbol"))
+    tools.find_function = Mock(side_effect=ValueError("not a function"))
+    addr_space = tools.program.getAddressFactory.return_value.getDefaultAddressSpace.return_value
+    addr_space.getAddress.return_value = parsed_addr
+
+    result = tools.set_comment("4096", "note", "plate")
+
+    tools.program.getListing.return_value.setComment.assert_called_once_with(parsed_addr, 0, "note")
+    assert result["address"] == "1000"

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -226,6 +226,7 @@ async def test_decompile_does_not_block_other_tool_calls(monkeypatch):
             source="USER_DEFINED",
             refcount=1,
             external=False,
+            is_thunk=False,
         )
     ]
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -191,6 +191,8 @@ def test_symbol_info_model():
         source="user",
         refcount=5,
         external=False,
+        is_thunk=True,
+        thunk_target="real_target @ 0x2000",
     )
     assert symbol.name == "test_symbol"
     assert symbol.address == "0x1234"
@@ -199,6 +201,8 @@ def test_symbol_info_model():
     assert symbol.source == "user"
     assert symbol.refcount == 5
     assert symbol.external is False
+    assert symbol.is_thunk is True
+    assert symbol.thunk_target == "real_target @ 0x2000"
 
 
 def test_symbol_search_results_model():
@@ -213,6 +217,7 @@ def test_symbol_search_results_model():
                 source="user",
                 refcount=5,
                 external=False,
+                is_thunk=False,
             ),
             SymbolInfo(
                 name="test_symbol2",
@@ -222,6 +227,7 @@ def test_symbol_search_results_model():
                 source="analysis",
                 refcount=1,
                 external=False,
+                is_thunk=False,
             ),
         ]
     )

--- a/tests/unit/test_search_regex.py
+++ b/tests/unit/test_search_regex.py
@@ -30,6 +30,8 @@ def _make_mock_function(name, address="0x1000", qualified_name=None):
     func.getSymbol.return_value = sym
     func.getEntryPoint.return_value = address
     func.isExternal.return_value = False
+    func.isThunk.return_value = False
+    func.getThunkedFunction.return_value = None
     func.thunk = False
     return func
 
@@ -210,3 +212,37 @@ class TestSearchAllSymbols:
         tools = _make_tools(symbols=self._syms())
         tools.search_symbols_by_name("main")
         tools.find_symbols.assert_called_once()
+
+    def test_exact_non_thunk_symbol_ranks_before_thunk(self):
+        """Exact body matches should rank before thunk wrappers with the same name."""
+        rm = Mock()
+        rm.getReferencesTo.return_value = []
+
+        body_sym = _make_mock_symbol("safe_exec", "0x2000")
+        thunk_sym = _make_mock_symbol("safe_exec", "0x1000")
+
+        body_func = Mock()
+        body_func.isThunk.return_value = False
+        body_func.getThunkedFunction.return_value = None
+
+        thunk_target = Mock()
+        thunk_target.getSymbol.return_value.getName.return_value = "safe_exec"
+        thunk_target.getEntryPoint.return_value = "0x2000"
+        thunk_func = Mock()
+        thunk_func.isThunk.return_value = True
+        thunk_func.getThunkedFunction.return_value = thunk_target
+
+        tools = _make_tools(symbols=[thunk_sym, body_sym])
+        tools.program.getReferenceManager.return_value = rm
+        fm = tools.program.getFunctionManager.return_value
+        fm.getFunctionAt.side_effect = lambda addr: {
+            "0x1000": thunk_func,
+            "0x2000": body_func,
+        }.get(addr)
+
+        results = tools.search_symbols_by_name("safe_exec")
+
+        assert [s.address for s in results] == ["0x2000", "0x1000"]
+        assert results[0].is_thunk is False
+        assert results[1].is_thunk is True
+        assert results[1].thunk_target == "safe_exec @ 0x2000"


### PR DESCRIPTION
## Summary
- let `set_comment` resolve decimal addresses, symbols, and function names for listing comments
- surface thunk metadata in symbol search results
- rank non-thunk exact matches ahead of thunk wrappers

## Why
These are model-facing papercuts from live use:
- `set_comment` should not require a raw hex address for non-decompiler comment types
- symbol search should make thunk/body ambiguity explicit and stop returning the thunk first for exact matches
