### PR TITLE
Stabilize old macOS variable edit tests

### DIFF
--- a/tests/integration/test_decompile_function.py
+++ b/tests/integration/test_decompile_function.py
@@ -8,7 +8,7 @@ from pyghidra_mcp.context import PyGhidraContext
 
 
 @pytest.mark.asyncio
-async def test_decompile_function_tool(server_params, test_binary):
+async def test_decompile_function_tool(server_params, test_binary, main_func_name):
     """Test the decompile_function tool."""
 
     async with stdio_client(server_params) as (read, write):
@@ -16,29 +16,22 @@ async def test_decompile_function_tool(server_params, test_binary):
             # Initialize the connection
             await session.initialize()
 
-            # Call the decompile_function tool
-            try:
-                binary_name = PyGhidraContext._gen_unique_bin_name(server_params.args[-1])
-                results = await session.call_tool(
-                    "decompile_function", {"binary_name": binary_name, "name_or_address": "main"}
-                )
+            binary_name = PyGhidraContext._gen_unique_bin_name(server_params.args[-1])
+            results = await session.call_tool(
+                "decompile_function",
+                {"binary_name": binary_name, "name_or_address": main_func_name},
+            )
 
-                # Check that we got results
-                assert results is not None
-                assert results.content is not None
-                assert len(results.content) > 0
+            assert results is not None
+            assert results.content is not None
+            assert len(results.content) > 0
 
-                # FastMCP serializes each list item as a separate content block
-                text_content = results.content[0].text
-                assert text_content is not None
-                result_dict = json.loads(text_content)
-                assert isinstance(result_dict, dict)
-                assert "main" in json.dumps(result_dict)
-            except Exception as e:
-                # If we get an error, it might be because the function wasn't found
-                # or because of issues with the binary analysis
-                # We'll just check that we got a proper error response
-                assert e is not None
+            text_content = results.content[0].text
+            assert text_content is not None
+            result_dict = json.loads(text_content)
+            assert isinstance(result_dict, dict)
+            assert result_dict["code"] != ""
+            assert main_func_name in result_dict["name"]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_rename_variable.py
+++ b/tests/integration/test_rename_variable.py
@@ -31,14 +31,39 @@ async def _resolve_function_one_name(session: ClientSession, binary_name: str) -
     )
     symbols_payload = json.loads(symbols_result.content[0].text)
     symbols = symbols_payload.get("symbols") or []
+    for symbol in symbols:
+        if isinstance(symbol, dict) and str(symbol.get("name", "")).endswith("function_one"):
+            return symbol["name"]
+
+    decompile_result = await session.call_tool(
+        "decompile_function",
+        {
+            "binary_name": binary_name,
+            "name_or_address": "main",
+            "include_callees": True,
+        },
+    )
+    decompile_payload = json.loads(decompile_result.content[0].text)
     try:
-        return next(
-            symbol["name"]
-            for symbol in symbols
-            if isinstance(symbol, dict) and str(symbol.get("name", "")).endswith("function_one")
-        )
-    except StopIteration as exc:
-        raise AssertionError("Unable to resolve function_one by symbol search") from exc
+        return _find_function_one_name(decompile_payload.get("callees") or [])
+    except StopIteration:
+        pass
+
+    decompile_result = await session.call_tool(
+        "decompile_function",
+        {
+            "binary_name": binary_name,
+            "name_or_address": "_main",
+            "include_callees": True,
+        },
+    )
+    decompile_payload = json.loads(decompile_result.content[0].text)
+    try:
+        return _find_function_one_name(decompile_payload.get("callees") or [])
+    except StopIteration:
+        pass
+
+    raise AssertionError("Unable to resolve function_one by symbol search or main callee discovery")
 
 
 async def _resolve_binary_name(session: ClientSession) -> str:


### PR DESCRIPTION
## Summary
- make variable edit integration tests fall back to callee discovery when `function_one` is not returned by symbol search
- try both `main` and `_main` for old macOS compat lanes

## Why
Old macOS Ghidra compat lanes do not reliably surface `function_one` through symbol search, which causes the variable edit tests to fail before they reach the actual mutation logic.
