### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -e ..
           pip install -e .[dev]
           pip install build
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,27 @@
+# pyghidra-mcp v0.2.0 Release Draft
+
+## Highlights
+
+- Adds GUI-backed mode with `pyghidra-mcp --gui`, letting MCP tools drive a live Ghidra CodeBrowser while sharing the same project and open programs.
+- Adds GUI tools for opening programs, changing the active program, and navigating to functions or addresses.
+- Adds live edit workflows for renaming functions and variables, setting comments, changing variable types, and setting function prototypes.
+- Adds an optional `pyghidra-mcp-cli` package with grouped analysis, edit, and GUI commands for users who prefer a command-line client over direct MCP calls.
+- Improves agent-facing tool output by keeping descriptions concise, resolving comment targets more flexibly, and surfacing thunk metadata in symbol search results.
+- Improves decompilation and analysis stability with serialized Ghidra bundle-host setup, decompiler cleanup, CI timeouts, and macOS GUI smoke coverage.
+- Adds setup diagrams and documentation for headless MCP, GUI-backed MCP, and CLI workflows.
+
+## Compatibility
+
+- Core package: `pyghidra-mcp==0.2.0`
+- CLI package: `pyghidra-mcp-cli==0.2.0`
+- The CLI development extra now requires `pyghidra-mcp>=0.2.0` so CLI commands match the server tool surface.
+- GUI mode requires `--transport streamable-http`; stdio remains the default for headless workflows.
+
+## Publish Checklist
+
+- Verify the release prep PR is green on local repo Linux, CLI, and macOS smoke/compatibility workflows.
+- Publish GitHub release `v0.2.0`.
+- Confirm both release workflows publish:
+  - `pyghidra-mcp` from the repository root.
+  - `pyghidra-mcp-cli` from `cli/`.
+- Recheck scheduled PyPI package workflows after publication; the current failures are expected against the older PyPI packages.

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyghidra-mcp-cli"
-version = "0.1.0"
+version = "0.2.0"
 description = "Command-line client for pyghidra-mcp server"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -21,7 +21,7 @@ dev = [
     "ruff>=0.11.4",
     "pyright>=1.1.0",
     "tomli>=2.0.1",
-    "pyghidra-mcp>=0.1.14",
+    "pyghidra-mcp>=0.2.0",
     "pre-commit>=3.0.0",
 ]
 
@@ -42,6 +42,9 @@ packages = [
 [tool.ruff]
 target-version = "py310"
 line-length = 100
+
+[tool.uv.sources]
+pyghidra-mcp = { path = "..", editable = true }
 
 [tool.ruff.lint]
 select = [

--- a/cli/src/pyghidra_mcp_cli/__init__.py
+++ b/cli/src/pyghidra_mcp_cli/__init__.py
@@ -4,5 +4,5 @@ A command-line client for the pyghidra-mcp server, providing an agent-friendly
 interface to interact with Ghidra binary analysis via CLI
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __author__ = "clearbluejar"

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -2387,8 +2387,8 @@ wheels = [
 
 [[package]]
 name = "pyghidra-mcp"
-version = "0.1.14"
-source = { registry = "https://pypi.org/simple" }
+version = "0.2.0"
+source = { editable = "../" }
 dependencies = [
     { name = "chromadb" },
     { name = "click" },
@@ -2397,14 +2397,49 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "pyghidra" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/46/43df820a715944e5b4b5c7d1073f9b70ff062619858da3e30b8a065d6d39/pyghidra_mcp-0.1.14.tar.gz", hash = "sha256:70a54f04831f002d6435a2f13f3cdf2d72d41243dfc4486d70bfed42c7826fd6", size = 38506, upload-time = "2026-02-06T07:30:07.42Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/94/ae2f4bfed8c32f5b445efcb2f794147eaff73f9b74a32c5e483e0cc9c4d2/pyghidra_mcp-0.1.14-py3-none-any.whl", hash = "sha256:1152b9096283cf3b479e2d8597cb73c405631bcacf9922c4c29699ef12333c18", size = 40103, upload-time = "2026-02-06T07:30:06.186Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", marker = "extra == 'dev'" },
+    { name = "chromadb", specifier = ">=1.3.5" },
+    { name = "click", specifier = ">=8.2.1" },
+    { name = "click-option-group", specifier = ">=0.5.9" },
+    { name = "ghidra-stubs", marker = "extra == 'dev'", specifier = ">=11.3.2" },
+    { name = "ghidrecomp", specifier = ">=0.5.8" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
+    { name = "mcp", extras = ["cli"], marker = "extra == 'dev'", specifier = ">=1.26.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "pyghidra", specifier = ">=2.2.1" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.1" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.2.1" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.4" },
+    { name = "tomli", marker = "extra == 'dev'", specifier = ">=2.0.1" },
+    { name = "tomli-w", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "uv", marker = "extra == 'dev'", specifier = ">=0.8.11" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "aiohttp" },
+    { name = "ghidra-stubs", specifier = ">=11.3.2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
+    { name = "pre-commit", specifier = ">=3.0.0" },
+    { name = "pyright", specifier = ">=1.1.0" },
+    { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "pytest-cov", specifier = ">=6.2.1" },
+    { name = "ruff", specifier = ">=0.11.4" },
+    { name = "tomli", specifier = ">=2.0.1" },
+    { name = "tomli-w", specifier = ">=1.0.0" },
+    { name = "uv", specifier = ">=0.8.11" },
 ]
 
 [[package]]
 name = "pyghidra-mcp-cli"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -2431,7 +2466,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.9.4" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pydantic", specifier = ">=2.0" },
-    { name = "pyghidra-mcp", marker = "extra == 'dev'", specifier = ">=0.1.14" },
+    { name = "pyghidra-mcp", marker = "extra == 'dev'", editable = "../" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyghidra-mcp"
-version = "0.1.14"
+version = "0.2.0"
 description = "Python Command-Line Ghidra MCP"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -118,7 +118,7 @@ ignore = ["F821", "E402"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["pyghidra_mcp"]
-known-third-party = ["jpype", "ghidrecomp"]
+known-third-party = ["ghidra", "ghidrecomp", "java", "jpype"]
 
 combine-as-imports = true
 split-on-trailing-comma = true

--- a/src/pyghidra_mcp/__init__.py
+++ b/src/pyghidra_mcp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.14"
+__version__ = "0.2.0"
 __author__ = "clearbluejar"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "pyghidra-mcp"
-version = "0.1.14"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
- bump core `pyghidra-mcp` and CLI `pyghidra-mcp-cli` to `0.2.0`
- align the CLI dev dependency on `pyghidra-mcp>=0.2.0` and use the local parent checkout for CLI uv dev syncs
- add a v0.2.0 release draft covering GUI mode, edit tools, CLI support, and CI/stability work
- make the CLI release workflow install the local core package first so release CI is not blocked before the core package reaches PyPI

## Notes
- PR #84 (`Gui context`) is not included in this release prep; this keeps v0.2.0 focused on the already-merged GUI/edit/CLI work.
- `src/pyghidra_mcp/gui_launcher.py` has a Ruff import-order cleanup from the release checks.

## Verification
- `uv run ruff check .`
- `uv run pytest tests/unit/`
- `cd cli && uv run ruff check .`
- `cd cli && uv run pytest tests/unit/`
- `uvx uv==0.11.7 lock --check`
- `cd cli && uvx uv==0.11.7 lock --check`
- `uv build`
- `cd cli && uv build`
- commit hooks: Ruff, Ruff format, Pyright, unit tests, integration smoke test
