### PR TITLE
Allow GUI mode to create missing projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Run the [Python package](https://pypi.org/p/pyghidra-mcp) as a CLI command using
 uvx pyghidra-mcp # Creates pyghidra_mcp_projects directory by default
 ```
 
-To launch and control a live Ghidra GUI from MCP, use `--gui` with `streamable-http` and an existing `.gpr` project:
+To launch and control a live Ghidra GUI from MCP, use `--gui` with `streamable-http`:
 
 ```bash
 uvx pyghidra-mcp \
@@ -231,7 +231,8 @@ uvx pyghidra-mcp \
   --transport streamable-http \
   --host 127.0.0.1 \
   --port 8000 \
-  --project-path /absolute/path/to/my_project.gpr
+  --project-path /absolute/path/to/ghidra-projects \
+  --project-name my_project
 ```
 
 > [!IMPORTANT]
@@ -371,7 +372,7 @@ pyghidra-mcp --project-path ~/existing/ghidra/my_research.gpr
 Use GUI mode when you want MCP actions to operate against the same live program objects that Ghidra is displaying.
 
 - `--gui` requires `--transport streamable-http` (or `--transport http` as an alias)
-- `--project-path` must resolve to an existing Ghidra project: pass a `.gpr` directly or pass a project directory with `--project-name`
+- `--project-path` can be a project directory plus `--project-name`, or an existing `.gpr` file. Missing projects are created automatically.
 - Ghidra is launched by `pyghidra-mcp`, which keeps GUI and MCP transactions in the same JVM
 - GUI-only tools are only exposed when running with `--gui`
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyghidra-mcp-cli"
-version = "0.2.0"
+version = "0.2.1"
 description = "Command-line client for pyghidra-mcp server"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -21,7 +21,7 @@ dev = [
     "ruff>=0.11.4",
     "pyright>=1.1.0",
     "tomli>=2.0.1",
-    "pyghidra-mcp>=0.2.0",
+    "pyghidra-mcp>=0.2.1",
     "pre-commit>=3.0.0",
 ]
 

--- a/cli/src/pyghidra_mcp_cli/__init__.py
+++ b/cli/src/pyghidra_mcp_cli/__init__.py
@@ -4,5 +4,5 @@ A command-line client for the pyghidra-mcp server, providing an agent-friendly
 interface to interact with Ghidra binary analysis via CLI
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "clearbluejar"

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -2387,7 +2387,7 @@ wheels = [
 
 [[package]]
 name = "pyghidra-mcp"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "../" }
 dependencies = [
     { name = "chromadb" },
@@ -2439,7 +2439,7 @@ dev = [
 
 [[package]]
 name = "pyghidra-mcp-cli"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyghidra-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python Command-Line Ghidra MCP"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pyghidra_mcp/__init__.py
+++ b/src/pyghidra_mcp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "clearbluejar"
 
 

--- a/src/pyghidra_mcp/gui_context.py
+++ b/src/pyghidra_mcp/gui_context.py
@@ -50,12 +50,16 @@ def _open_gui_project(front_end_tool, project_spec):
     if active_project is not None:
         return active_project
 
+    project_spec.project_directory.mkdir(exist_ok=True, parents=True)
     project_manager = front_end_tool.getProjectManager()
     locator = ProjectLocator(
         str(project_spec.project_directory.absolute()),
         project_spec.project_name,
     )
-    opened_project = project_manager.openProject(locator, True, False)
+    if locator.exists():
+        opened_project = project_manager.openProject(locator, True, False)
+    else:
+        opened_project = project_manager.createProject(locator, None, True)
     front_end_tool.setActiveProject(opened_project)
     return opened_project
 
@@ -226,6 +230,7 @@ class GuiPyGhidraContext(IndexingMixin):
                 if program_info is not None:
                     tool = self._find_tool_for_program(program_info.program)
                     live_program_manager = tool.getService(ProgramManager)
+                    self._start_gui_analysis_if_needed(program_info.program)
                     self.schedule_indexing(expected_path)
                     return {
                         "name": program_info.name,
@@ -546,6 +551,8 @@ class GuiPyGhidraContext(IndexingMixin):
                 .monitor(TaskMonitor.DUMMY)
                 .load()
             )
+            loaded_program = load_results.getPrimaryDomainObject()
+            self._mark_program_not_to_ask_to_analyze(loaded_program)
             domain_file = load_results.getPrimary().save(TaskMonitor.DUMMY)
         finally:
             if load_results is not None:
@@ -604,6 +611,27 @@ class GuiPyGhidraContext(IndexingMixin):
     @staticmethod
     def _is_binary_file(path: Path) -> bool:
         return is_ghidra_importable(path)
+
+    @staticmethod
+    def _mark_program_not_to_ask_to_analyze(program) -> None:
+        from ghidra.program.util import GhidraProgramUtilities
+
+        if GhidraProgramUtilities.shouldAskToAnalyze(program):
+            GhidraProgramUtilities.markProgramNotToAskToAnalyze(program)
+
+    def _start_gui_analysis_if_needed(self, program) -> None:
+        from ghidra.app.plugin.core.analysis import AutoAnalysisManager
+        from ghidra.program.util import GhidraProgramUtilities
+        from ghidra.util.task import TaskMonitor
+
+        is_analyzed = getattr(GhidraProgramUtilities, "isAnalyzed", None)
+        if callable(is_analyzed) and is_analyzed(program):
+            return
+
+        self._mark_program_not_to_ask_to_analyze(program)
+        analysis_manager = AutoAnalysisManager.getAnalysisManager(program)
+        if not analysis_manager.isAnalyzing():
+            analysis_manager.startAnalysis(TaskMonitor.DUMMY)
 
     @staticmethod
     def _import_done_callback(future: concurrent.futures.Future) -> None:
@@ -668,10 +696,14 @@ class GuiPyGhidraContext(IndexingMixin):
 
     @staticmethod
     def _is_program_analysis_complete(program) -> bool:
+        from ghidra.app.plugin.core.analysis import AutoAnalysisManager
         from ghidra.program.util import GhidraProgramUtilities
 
         try:
-            return not bool(GhidraProgramUtilities.shouldAskToAnalyze(program))
+            if not bool(GhidraProgramUtilities.isAnalyzed(program)):
+                return False
+            analysis_manager = AutoAnalysisManager.getAnalysisManager(program)
+            return not bool(analysis_manager.isAnalyzing())
         except Exception:
             logger.debug("Could not determine GUI program analysis state", exc_info=True)
             return False

--- a/src/pyghidra_mcp/server.py
+++ b/src/pyghidra_mcp/server.py
@@ -359,7 +359,7 @@ def run_mcp_server(mcp: FastMCP, transport: str) -> None:
     help="Location to store GZFs of analyzed binaries.",
 )
 @click.argument("input_paths", type=click.Path(exists=True), nargs=-1)
-def main(  # noqa: C901
+def main(
     transport: str,
     input_paths: list[Path],
     project_path: Path,
@@ -411,10 +411,6 @@ def main(  # noqa: C901
             raise click.UsageError("--gui requires --transport streamable-http or --transport http")
         if list_project_binaries or delete_project_binary:
             raise click.UsageError("GUI mode does not support project-management CLI actions yet")
-        if not project_spec.gpr_path.exists():
-            raise click.UsageError(
-                f"GUI mode currently requires an existing Ghidra project: {project_spec.gpr_path}"
-            )
 
         register_gui_tools(mcp)
         ensure_macos_framework_python()

--- a/tests/unit/test_gui_context.py
+++ b/tests/unit/test_gui_context.py
@@ -194,11 +194,15 @@ def test_wait_for_gui_ready_opens_requested_project_when_frontend_is_idle(monkey
     )
 
     opened_project = Mock()
-    project_manager = Mock(openProject=Mock(return_value=opened_project))
+    project_manager = Mock(
+        createProject=Mock(),
+        openProject=Mock(return_value=opened_project),
+    )
     front_end_tool = Mock(
         getProjectManager=Mock(return_value=project_manager),
         setActiveProject=Mock(),
     )
+    locator = Mock(exists=Mock(return_value=True))
     app_info = Mock(
         getActiveProject=Mock(side_effect=[None, None, opened_project]),
         getFrontEndTool=Mock(return_value=front_end_tool),
@@ -208,7 +212,7 @@ def test_wait_for_gui_ready_opens_requested_project_when_frontend_is_idle(monkey
     monkeypatch.setitem(
         sys.modules,
         "ghidra.framework.model",
-        Mock(ProjectLocator=Mock(return_value="locator")),
+        Mock(ProjectLocator=Mock(return_value=locator)),
     )
     monkeypatch.setattr(
         gui_context_module,
@@ -221,8 +225,57 @@ def test_wait_for_gui_ready_opens_requested_project_when_frontend_is_idle(monkey
 
     assert project is opened_project
     gui_context_module._run_on_swing.assert_called_once()
-    project_manager.openProject.assert_called_once_with("locator", True, False)
+    project_manager.openProject.assert_called_once_with(locator, True, False)
+    project_manager.createProject.assert_not_called()
     front_end_tool.setActiveProject.assert_called_once_with(opened_project)
+
+
+def test_wait_for_gui_ready_creates_requested_project_when_missing(monkeypatch, tmp_path):
+    project_dir = tmp_path / "proj"
+    project_gpr = project_dir / "proj.gpr"
+
+    project_spec = Mock(
+        project_directory=project_dir,
+        gpr_path=project_gpr,
+        project_name="proj",
+    )
+
+    created_project = Mock()
+    project_manager = Mock(
+        createProject=Mock(return_value=created_project),
+        openProject=Mock(),
+    )
+    front_end_tool = Mock(
+        getProjectManager=Mock(return_value=project_manager),
+        setActiveProject=Mock(),
+    )
+    locator = Mock(exists=Mock(return_value=False))
+    app_info = Mock(
+        getActiveProject=Mock(side_effect=[None, None, created_project]),
+        getFrontEndTool=Mock(return_value=front_end_tool),
+    )
+
+    monkeypatch.setitem(sys.modules, "ghidra.framework.main", Mock(AppInfo=app_info))
+    monkeypatch.setitem(
+        sys.modules,
+        "ghidra.framework.model",
+        Mock(ProjectLocator=Mock(return_value=locator)),
+    )
+    monkeypatch.setattr(
+        gui_context_module,
+        "_run_on_swing",
+        Mock(side_effect=lambda fn, *args, **kwargs: fn(*args, **kwargs)),
+    )
+    monkeypatch.setattr(gui_context_module.time, "sleep", Mock())
+
+    project = GuiPyGhidraContext.wait_for_gui_ready(project_spec, timeout=1, interval=0)
+
+    assert project is created_project
+    assert project_dir.exists()
+    gui_context_module._run_on_swing.assert_called_once()
+    project_manager.createProject.assert_called_once_with(locator, None, True)
+    project_manager.openProject.assert_not_called()
+    front_end_tool.setActiveProject.assert_called_once_with(created_project)
 
 
 def test_wait_for_gui_ready_tolerates_frontend_not_running_yet(monkeypatch, tmp_path):
@@ -276,6 +329,7 @@ def test_open_program_in_gui_default_launches_new_window():
     context._tool_is_visible = Mock(return_value=False)
     context.refresh_programs = Mock()
     context.schedule_indexing = Mock()
+    context._start_gui_analysis_if_needed = Mock()
     context.run_on_swing = Mock(side_effect=lambda fn, *args, **kwargs: fn(*args, **kwargs))
     program_manager = Mock(getCurrentProgram=Mock(return_value=Mock()))
     tool = Mock(getService=Mock(return_value=program_manager))
@@ -295,6 +349,7 @@ def test_open_program_in_gui_default_launches_new_window():
     result = context.open_program_in_gui("/prog")
 
     tool_services.launchDefaultTool.assert_called_once()
+    context._start_gui_analysis_if_needed.assert_called_once()
     assert result["path"] == "/prog"
 
 
@@ -315,6 +370,7 @@ def test_open_program_in_gui_new_window_launches_default_tool():
     context._tool_is_visible = Mock(return_value=True)
     context.refresh_programs = Mock()
     context.schedule_indexing = Mock()
+    context._start_gui_analysis_if_needed = Mock()
     context.run_on_swing = Mock(side_effect=lambda fn, *args, **kwargs: fn(*args, **kwargs))
     tool = Mock(getService=Mock(return_value=program_manager))
     context._find_tool_for_program = Mock(return_value=tool)
@@ -334,6 +390,7 @@ def test_open_program_in_gui_new_window_launches_default_tool():
 
     tool_services.launchDefaultTool.assert_called_once()
     program_manager.openProgram.assert_not_called()
+    context._start_gui_analysis_if_needed.assert_called_once()
     assert result["path"] == "/prog"
 
 
@@ -355,6 +412,7 @@ def test_open_program_in_gui_reuses_visible_tool_when_requested():
     context.refresh_programs = Mock()
     context._programs_lock = threading.RLock()
     context.schedule_indexing = Mock()
+    context._start_gui_analysis_if_needed = Mock()
     context.run_on_swing = Mock(side_effect=lambda fn, *args, **kwargs: fn(*args, **kwargs))
     tool = Mock(getService=Mock(return_value=program_manager))
     context._find_tool_for_program = Mock(return_value=tool)
@@ -373,6 +431,7 @@ def test_open_program_in_gui_reuses_visible_tool_when_requested():
 
     tool_services.launchDefaultTool.assert_not_called()
     program_manager.openProgram.assert_called_once()
+    context._start_gui_analysis_if_needed.assert_called_once_with("program")
     assert result["path"] == "/prog"
 
 
@@ -409,3 +468,135 @@ def test_tool_is_visible_prefers_frame_visibility():
     )
 
     assert context._tool_is_visible(tool) is True
+
+
+def test_mark_program_not_to_ask_to_analyze_only_when_needed(monkeypatch):
+    program = Mock()
+    utilities = Mock(
+        shouldAskToAnalyze=Mock(return_value=True),
+        markProgramNotToAskToAnalyze=Mock(),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "ghidra.program.util",
+        Mock(GhidraProgramUtilities=utilities),
+    )
+
+    GuiPyGhidraContext._mark_program_not_to_ask_to_analyze(program)
+
+    utilities.shouldAskToAnalyze.assert_called_once_with(program)
+    utilities.markProgramNotToAskToAnalyze.assert_called_once_with(program)
+
+
+def test_is_program_analysis_complete_requires_analyzed_flag(monkeypatch):
+    program = Mock()
+    utilities = Mock(isAnalyzed=Mock(return_value=False))
+    auto_analysis_manager = Mock()
+    monkeypatch.setitem(
+        sys.modules,
+        "ghidra.program.util",
+        Mock(GhidraProgramUtilities=utilities),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "ghidra.app.plugin.core.analysis",
+        Mock(AutoAnalysisManager=auto_analysis_manager),
+    )
+
+    assert GuiPyGhidraContext._is_program_analysis_complete(program) is False
+    auto_analysis_manager.getAnalysisManager.assert_not_called()
+
+
+def test_is_program_analysis_complete_false_while_gui_analysis_runs(monkeypatch):
+    program = Mock()
+    utilities = Mock(isAnalyzed=Mock(return_value=True))
+    analysis_manager = Mock(isAnalyzing=Mock(return_value=True))
+    auto_analysis_manager = Mock(getAnalysisManager=Mock(return_value=analysis_manager))
+    monkeypatch.setitem(
+        sys.modules,
+        "ghidra.program.util",
+        Mock(GhidraProgramUtilities=utilities),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "ghidra.app.plugin.core.analysis",
+        Mock(AutoAnalysisManager=auto_analysis_manager),
+    )
+
+    assert GuiPyGhidraContext._is_program_analysis_complete(program) is False
+    auto_analysis_manager.getAnalysisManager.assert_called_once_with(program)
+
+
+def test_is_program_analysis_complete_true_after_gui_analysis_finishes(monkeypatch):
+    program = Mock()
+    utilities = Mock(isAnalyzed=Mock(return_value=True))
+    analysis_manager = Mock(isAnalyzing=Mock(return_value=False))
+    auto_analysis_manager = Mock(getAnalysisManager=Mock(return_value=analysis_manager))
+    monkeypatch.setitem(
+        sys.modules,
+        "ghidra.program.util",
+        Mock(GhidraProgramUtilities=utilities),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "ghidra.app.plugin.core.analysis",
+        Mock(AutoAnalysisManager=auto_analysis_manager),
+    )
+
+    assert GuiPyGhidraContext._is_program_analysis_complete(program) is True
+    auto_analysis_manager.getAnalysisManager.assert_called_once_with(program)
+
+
+def test_start_gui_analysis_marks_no_prompt_and_starts_background_analysis(monkeypatch):
+    context = GuiPyGhidraContext.__new__(GuiPyGhidraContext)
+    program = Mock()
+    utilities = Mock(isAnalyzed=Mock(return_value=False))
+    analysis_manager = Mock(
+        isAnalyzing=Mock(return_value=False),
+        startAnalysis=Mock(),
+    )
+    auto_analysis_manager = Mock(getAnalysisManager=Mock(return_value=analysis_manager))
+    task_monitor = Mock(DUMMY="dummy-monitor")
+    context._mark_program_not_to_ask_to_analyze = Mock()
+    monkeypatch.setitem(
+        sys.modules,
+        "ghidra.program.util",
+        Mock(GhidraProgramUtilities=utilities),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "ghidra.app.plugin.core.analysis",
+        Mock(AutoAnalysisManager=auto_analysis_manager),
+    )
+    monkeypatch.setitem(sys.modules, "ghidra.util.task", Mock(TaskMonitor=task_monitor))
+
+    context._start_gui_analysis_if_needed(program)
+
+    utilities.isAnalyzed.assert_called_once_with(program)
+    context._mark_program_not_to_ask_to_analyze.assert_called_once_with(program)
+    auto_analysis_manager.getAnalysisManager.assert_called_once_with(program)
+    analysis_manager.startAnalysis.assert_called_once_with("dummy-monitor")
+
+
+def test_start_gui_analysis_skips_analyzed_program(monkeypatch):
+    context = GuiPyGhidraContext.__new__(GuiPyGhidraContext)
+    program = Mock()
+    utilities = Mock(isAnalyzed=Mock(return_value=True))
+    auto_analysis_manager = Mock()
+    context._mark_program_not_to_ask_to_analyze = Mock()
+    monkeypatch.setitem(
+        sys.modules,
+        "ghidra.program.util",
+        Mock(GhidraProgramUtilities=utilities),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "ghidra.app.plugin.core.analysis",
+        Mock(AutoAnalysisManager=auto_analysis_manager),
+    )
+    monkeypatch.setitem(sys.modules, "ghidra.util.task", Mock(TaskMonitor=Mock()))
+
+    context._start_gui_analysis_if_needed(program)
+
+    context._mark_program_not_to_ask_to_analyze.assert_not_called()
+    auto_analysis_manager.getAnalysisManager.assert_not_called()

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest.mock import Mock
 
+import click.testing
+
 import pyghidra_mcp.server as server
 
 
@@ -105,3 +107,60 @@ def test_init_pyghidra_context_wait_for_analysis_indexes_for_streamable_server(m
     fake_context.analyze_project.assert_called_once_with()
     fake_context.schedule_indexing.assert_not_called()
     fake_context.schedule_startup_indexing.assert_called_once_with(max_binaries=1)
+
+
+def test_gui_mode_allows_missing_project_for_auto_create(monkeypatch, tmp_path):
+    launcher_state = {}
+
+    class FakeLauncher:
+        def __init__(self, gpr_path):
+            launcher_state["gpr_path"] = gpr_path
+
+        def start(self):
+            launcher_state["started"] = True
+
+        def run_gui_event_loop(self):
+            launcher_state["event_loop"] = True
+
+        def request_shutdown(self):
+            launcher_state["shutdown"] = True
+
+        def wait_for_shutdown(self):
+            return True
+
+    class FakeThread:
+        def __init__(self, target, name, daemon):
+            self.target = target
+            self.name = name
+            self.daemon = daemon
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr(server, "register_gui_tools", Mock())
+    monkeypatch.setattr(server, "ensure_macos_framework_python", Mock())
+    monkeypatch.setattr(server, "GuiPyGhidraMcpLauncher", FakeLauncher)
+    monkeypatch.setattr(server.threading, "Thread", FakeThread)
+    monkeypatch.setattr(server, "init_gui_context", Mock())
+    monkeypatch.setattr(server, "run_mcp_server", Mock())
+    if hasattr(server.mcp, "_pyghidra_context"):
+        delattr(server.mcp, "_pyghidra_context")
+
+    runner = click.testing.CliRunner()
+    result = runner.invoke(
+        server.main,
+        [
+            "--gui",
+            "--transport",
+            "http",
+            "--project-path",
+            str(tmp_path),
+            "--project-name",
+            "new_project",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert launcher_state["gpr_path"] == tmp_path / "new_project.gpr"
+    assert launcher_state["started"] is True
+    server.init_gui_context.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "pyghidra-mcp"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
- let GUI mode create missing Ghidra projects through the front-end project manager instead of failing before launch
- suppress the CodeBrowser analyze prompt for MCP-imported/opened GUI programs and start Ghidra background analysis from MCP
- bump core and CLI packages to 0.2.1 for a patch release
- update README GUI startup docs

## Tests
- uv run ruff check .
- uv run pytest tests/unit/ -q
- uv run --directory cli pytest tests/unit/ -q
- uv run pyright src/
- pre-commit commit hooks: ruff, ruff-format, pyright, pytest unit tests, pytest integration smoke test
