### PR TITLE
Optimize export/import pagination

### DIFF
--- a/src/pyghidra_mcp/tools.py
+++ b/src/pyghidra_mcp/tools.py
@@ -486,29 +486,51 @@ class GhidraTools:
         self, query: str | None = None, offset: int = 0, limit: int = 25
     ) -> list[ExportInfo]:
         """Lists all exported functions and symbols from a specified binary."""
+        if limit <= 0:
+            return []
+
+        pattern = re.compile(query, re.IGNORECASE) if query else None
         exports = []
+        matches_seen = 0
         symbols = self.program.getSymbolTable().getAllSymbols(True)
         for symbol in symbols:
             if symbol.isExternalEntryPoint():
-                if query and not re.search(query, symbol.getName(), re.IGNORECASE):
+                if pattern and not pattern.search(symbol.getName()):
+                    continue
+                if matches_seen < offset:
+                    matches_seen += 1
                     continue
                 exports.append(ExportInfo(name=symbol.getName(), address=str(symbol.getAddress())))
-        return exports[offset : limit + offset]
+                matches_seen += 1
+                if len(exports) >= limit:
+                    break
+        return exports
 
     @handle_exceptions
     def list_imports(
         self, query: str | None = None, offset: int = 0, limit: int = 25
     ) -> list[ImportInfo]:
         """Lists all imported functions and symbols for a specified binary."""
+        if limit <= 0:
+            return []
+
+        pattern = re.compile(query, re.IGNORECASE) if query else None
         imports = []
+        matches_seen = 0
         symbols = self.program.getSymbolTable().getExternalSymbols()
         for symbol in symbols:
-            if query and not re.search(query, symbol.getName(), re.IGNORECASE):
+            if pattern and not pattern.search(symbol.getName()):
+                continue
+            if matches_seen < offset:
+                matches_seen += 1
                 continue
             imports.append(
                 ImportInfo(name=symbol.getName(), library=str(symbol.getParentNamespace()))
             )
-        return imports[offset : limit + offset]
+            matches_seen += 1
+            if len(imports) >= limit:
+                break
+        return imports
 
     @handle_exceptions
     def list_xrefs(self, name_or_address: str) -> list[CrossReferenceInfo]:

--- a/tests/unit/test_bounded_pagination.py
+++ b/tests/unit/test_bounded_pagination.py
@@ -1,0 +1,121 @@
+from unittest.mock import Mock
+
+from pyghidra_mcp.tools import GhidraTools
+
+
+class _FakeSymbol:
+    def __init__(
+        self,
+        name: str,
+        address: str,
+        *,
+        external_entry: bool = True,
+        namespace: str = "libc.so",
+    ):
+        self._name = name
+        self._address = address
+        self._external_entry = external_entry
+        self._namespace = namespace
+
+    def getName(self):  # noqa: N802
+        return self._name
+
+    def getAddress(self):  # noqa: N802
+        return self._address
+
+    def getParentNamespace(self):  # noqa: N802
+        return self._namespace
+
+    def isExternalEntryPoint(self):  # noqa: N802
+        return self._external_entry
+
+
+def _make_tools(program):
+    tools = GhidraTools.__new__(GhidraTools)
+    tools.program = program
+    return tools
+
+
+def test_list_exports_stops_after_requested_page():
+    yielded = []
+    symbols = [
+        _FakeSymbol("export_0", "0x1000"),
+        _FakeSymbol("export_1", "0x1001"),
+        _FakeSymbol("export_2", "0x1002"),
+        _FakeSymbol("export_3", "0x1003"),
+        _FakeSymbol("export_4", "0x1004"),
+    ]
+
+    def iter_symbols():
+        for symbol in symbols:
+            yielded.append(symbol.getName())
+            yield symbol
+
+    program = Mock()
+    program.getSymbolTable.return_value.getAllSymbols.return_value = iter_symbols()
+
+    results = _make_tools(program).list_exports(query="export", offset=1, limit=2)
+
+    assert [result.name for result in results] == ["export_1", "export_2"]
+    assert yielded == ["export_0", "export_1", "export_2"]
+    program.getSymbolTable.return_value.getAllSymbols.assert_called_once_with(True)
+
+
+def test_list_exports_skips_non_entry_points_without_counting_them():
+    yielded = []
+    symbols = [
+        _FakeSymbol("label_0", "0x1000", external_entry=False),
+        _FakeSymbol("export_0", "0x1001"),
+        _FakeSymbol("export_1", "0x1002"),
+        _FakeSymbol("export_2", "0x1003"),
+        _FakeSymbol("export_3", "0x1004"),
+    ]
+
+    def iter_symbols():
+        for symbol in symbols:
+            yielded.append(symbol.getName())
+            yield symbol
+
+    program = Mock()
+    program.getSymbolTable.return_value.getAllSymbols.return_value = iter_symbols()
+
+    results = _make_tools(program).list_exports(query="export", offset=1, limit=2)
+
+    assert [result.name for result in results] == ["export_1", "export_2"]
+    assert yielded == ["label_0", "export_0", "export_1", "export_2"]
+
+
+def test_list_imports_stops_after_requested_page():
+    yielded = []
+    symbols = [
+        _FakeSymbol("import_0", "0x2000"),
+        _FakeSymbol("import_1", "0x2001"),
+        _FakeSymbol("import_2", "0x2002"),
+        _FakeSymbol("import_3", "0x2003"),
+        _FakeSymbol("import_4", "0x2004"),
+    ]
+
+    def iter_symbols():
+        for symbol in symbols:
+            yielded.append(symbol.getName())
+            yield symbol
+
+    program = Mock()
+    program.getSymbolTable.return_value.getExternalSymbols.return_value = iter_symbols()
+
+    results = _make_tools(program).list_imports(query="import", offset=1, limit=2)
+
+    assert [result.name for result in results] == ["import_1", "import_2"]
+    assert yielded == ["import_0", "import_1", "import_2"]
+    program.getSymbolTable.return_value.getExternalSymbols.assert_called_once_with()
+
+
+def test_list_imports_returns_empty_without_scanning_when_limit_is_zero():
+    program = Mock()
+    program.getSymbolTable.return_value.getExternalSymbols.side_effect = AssertionError(
+        "should not scan imports"
+    )
+
+    results = _make_tools(program).list_imports(query="import", offset=0, limit=0)
+
+    assert results == []


### PR DESCRIPTION
## Summary

  Optimize `list_exports` and `list_imports` pagination so they stop scanning once the requested page is filled.

  Previously, both tools collected every matching export/import and sliced afterward. This PR changes them to skip up to `offset`, collect up to `limit`, and break early.

  ## Changes

  - Add bounded pagination to `list_exports`
  - Add bounded pagination to `list_imports`
  - Return early when `limit <= 0`
  - Compile the optional regex query once per call
  - Add unit tests proving symbol iterators are not fully consumed

  ## Testing

  - `uv run ruff check src/pyghidra_mcp/tools.py tests/unit/test_bounded_pagination.py`
  - `uv run pytest tests/unit`

  Full unit suite passes: `112 passed`.