### PR TITLE
Optimize literal code search pagination

### DIFF
--- a/src/pyghidra_mcp/tools.py
+++ b/src/pyghidra_mcp/tools.py
@@ -569,26 +569,28 @@ class GhidraTools:
 
     def _search_code_literal(
         self,
-        literal_results: typing.Any,
+        query: str,
         limit: int,
         offset: int,
         include_full_code: bool,
         preview_length: int,
     ) -> list[CodeSearchResult]:
+        assert self.program_info.code_collection is not None
         search_results: list[CodeSearchResult] = []
+
+        # Apply offset and limit
+        literal_results = self.program_info.code_collection.get(
+            where_document={"$contains": query},
+            include=["documents", "metadatas"],
+            limit=limit,
+            offset=offset,
+        )
         if literal_results and literal_results.get("documents"):
-            # Apply offset and limit
             docs = literal_results["documents"] or []
-            metadatas = literal_results["metadatas"] or []
+            metadatas = literal_results.get("metadatas") or []
 
-            # Paginate
-            start_idx = offset
-            end_idx = offset + limit
-            paginated_docs = docs[start_idx:end_idx]
-            paginated_meta = metadatas[start_idx:end_idx] if metadatas else []
-
-            for i, doc in enumerate(paginated_docs):
-                metadata = paginated_meta[i] if i < len(paginated_meta) else {}
+            for i, doc in enumerate(docs):
+                metadata = metadatas[i] if i < len(metadatas) else {}
                 code = doc
                 preview = None
 
@@ -720,10 +722,15 @@ class GhidraTools:
                 "Code indexing is not complete for this binary. Please try again later."
             )
 
-        # ALWAYS get literal count (reuse for literal mode search)
-        literal_results = self.program_info.code_collection.get(where_document={"$contains": query})
+        # ALWAYS get literal count
+        literal_results = self.program_info.code_collection.get(
+            where_document={"$contains": query},
+            include=[],
+        )
         literal_total = (
-            len(literal_results["ids"]) if literal_results and literal_results.get("ids") else 0
+            len(literal_results["ids"])
+            if literal_results and literal_results.get("ids")
+            else 0
         )
 
         # Total functions in collection (absolute total)
@@ -740,7 +747,7 @@ class GhidraTools:
 
         if search_mode == SearchMode.LITERAL:
             search_results = self._search_code_literal(
-                literal_results, limit, offset, include_full_code, preview_length
+                query, limit, offset, include_full_code, preview_length
             )
         else:
             search_results, estimated_total = self._search_code_semantic(

--- a/tests/unit/test_search_code_optimization.py
+++ b/tests/unit/test_search_code_optimization.py
@@ -1,0 +1,182 @@
+from unittest.mock import Mock
+
+from pyghidra_mcp.models import SearchMode
+from pyghidra_mcp.tools import GhidraTools
+
+
+class _FakeCodeCollection:
+    def __init__(self, documents, query_results=None):
+        self.documents = documents
+        self.query_results = query_results or documents
+        self.count_calls = 0
+        self.get_calls = []
+        self.query_calls = []
+
+    def count(self):
+        self.count_calls += 1
+        return len(self.documents)
+
+    def get(self, where_document=None, include=None, limit=None, offset=None):
+        self.get_calls.append(
+            {
+                "where_document": where_document,
+                "include": include,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+        query = (where_document or {}).get("$contains")
+        matches = [
+            row for row in self.documents if query is None or query in row["document"]
+        ]
+        page_offset = offset or 0
+        page = (
+            matches[page_offset:]
+            if limit is None
+            else matches[page_offset : page_offset + limit]
+        )
+
+        result = {"ids": [row["id"] for row in page]}
+        if include != []:
+            result["documents"] = [row["document"] for row in page]
+            result["metadatas"] = [row["metadata"] for row in page]
+        return result
+
+    def query(self, query_texts, n_results):
+        self.query_calls.append({"query_texts": query_texts, "n_results": n_results})
+        page = self.query_results[:n_results]
+        return {
+            "documents": [[row["document"] for row in page]],
+            "metadatas": [[row["metadata"] for row in page]],
+            "distances": [[row.get("distance", 0.0) for row in page]],
+        }
+
+
+def _make_tools(code_collection):
+    program_info = Mock()
+    program_info.code_collection = code_collection
+    tools = GhidraTools.__new__(GhidraTools)
+    tools.program_info = program_info
+    tools.program = program_info.program
+    tools.decompiler_pool = Mock()
+    return tools
+
+
+def test_search_code_semantic_uses_literal_id_count_without_literal_page_fetch():
+    code_collection = _FakeCodeCollection(
+        documents=[
+            {
+                "id": "func1",
+                "document": "printf alpha branch with extra text",
+                "metadata": {"function_name": "func1"},
+            },
+            {
+                "id": "func2",
+                "document": "printf beta branch with extra text",
+                "metadata": {"function_name": "func2"},
+            },
+            {
+                "id": "func3",
+                "document": "gamma branch without literal match",
+                "metadata": {"function_name": "func3"},
+            },
+        ],
+        query_results=[
+            {
+                "id": "func1",
+                "document": "printf alpha branch with extra text",
+                "metadata": {"function_name": "func1"},
+                "distance": 0.0,
+            },
+            {
+                "id": "func2",
+                "document": "printf beta branch with extra text",
+                "metadata": {"function_name": "func2"},
+                "distance": 1.0,
+            },
+        ],
+    )
+    tools = _make_tools(code_collection)
+
+    results = tools.search_code(
+        query="printf",
+        limit=1,
+        offset=1,
+        search_mode=SearchMode.SEMANTIC,
+        include_full_code=False,
+        preview_length=10,
+    )
+
+    assert code_collection.count_calls == 1
+    assert code_collection.get_calls == [
+        {
+            "where_document": {"$contains": "printf"},
+            "include": [],
+            "limit": None,
+            "offset": None,
+        }
+    ]
+    assert code_collection.query_calls == [
+        {"query_texts": ["printf"], "n_results": 2}
+    ]
+    assert results.literal_total == 2
+    assert results.total_functions == 3
+    assert results.returned_count == 1
+    assert results.results[0].function_name == "func2"
+    assert results.results[0].code == "printf bet..."
+
+
+def test_search_code_literal_fetches_only_requested_page():
+    code_collection = _FakeCodeCollection(
+        documents=[
+            {
+                "id": "func1",
+                "document": "printf alpha branch with extra text",
+                "metadata": {"function_name": "func1"},
+            },
+            {
+                "id": "func2",
+                "document": "printf beta branch with extra text",
+                "metadata": {"function_name": "func2"},
+            },
+            {
+                "id": "func3",
+                "document": "gamma branch without literal match",
+                "metadata": {"function_name": "func3"},
+            },
+        ]
+    )
+    tools = _make_tools(code_collection)
+
+    results = tools.search_code(
+        query="printf",
+        limit=1,
+        offset=1,
+        search_mode=SearchMode.LITERAL,
+        include_full_code=False,
+        preview_length=6,
+    )
+
+    assert code_collection.count_calls == 1
+    assert code_collection.get_calls == [
+        {
+            "where_document": {"$contains": "printf"},
+            "include": [],
+            "limit": None,
+            "offset": None,
+        },
+        {
+            "where_document": {"$contains": "printf"},
+            "include": ["documents", "metadatas"],
+            "limit": 1,
+            "offset": 1,
+        },
+    ]
+    assert code_collection.query_calls == []
+    assert results.literal_total == 2
+    assert results.semantic_total == 3
+    assert results.total_functions == 3
+    assert results.returned_count == 1
+    assert results.results[0].function_name == "func2"
+    assert results.results[0].preview == "printf..."
+    assert results.results[0].code == "printf..."


### PR DESCRIPTION
## Summary

  Optimize `search_code` literal handling so ChromaDB does less work for counts and paginated literal results.

  Previously, `search_code` fetched every literal match document up front, then sliced the requested page in Python. This PR keeps the existing tool behavior and response shape, but changes the Chroma calls to avoid loading
  unnecessary decompiled function bodies.

  ## Changes

  - Use `include=[]` when computing `literal_total`, so only matching IDs are fetched.
  - Fetch literal-mode results with Chroma `limit` and `offset` instead of slicing all matches in Python.
  - Keep `count()` direct and avoid adding a local cache.
  - Preserve the existing semantic search behavior and returned `CodeSearchResults` contract.
  - Add unit coverage for semantic and literal call patterns.

  ## Testing

  - Added `tests/unit/test_search_code_optimization.py`
  - Verified semantic mode counts literal matches without fetching literal result pages.
  - Verified literal mode fetches only the requested page.

  Tested with:

  - `uv run ruff check src/pyghidra_mcp/tools.py tests/unit/test_search_code_optimization.py`
  - `uv run pytest tests/unit`

  Full unit suite passes: `110 passed`.