### PR TITLE
datatypes support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pyghidra>=2.2.1",
     "chromadb>=1.3.5",
     "ghidrecomp>=0.5.8",
+    "pycparser>=2.22",
 ]
 authors = [
     { name = "clearbluejar", email = "3752074+clearbluejar@users.noreply.github.com" },

--- a/src/pyghidra_mcp/gui_context.py
+++ b/src/pyghidra_mcp/gui_context.py
@@ -42,13 +42,19 @@ def _run_on_swing(fn, *args, **kwargs):
     return result_box[0]
 
 
-def _open_gui_project(front_end_tool, project_spec):
+def _project_matches_spec(project, project_spec: ProjectSpec) -> bool:
+    try:
+        locator = project.getProjectLocator()
+        marker_file = locator.getMarkerFile()
+        marker_path = Path(str(marker_file.getAbsolutePath())).resolve()
+        return marker_path == project_spec.gpr_path.resolve()
+    except Exception:
+        return False
+
+
+def _open_gui_project(front_end_tool, project_spec: ProjectSpec):
     from ghidra.framework.main import AppInfo
     from ghidra.framework.model import ProjectLocator
-
-    active_project = AppInfo.getActiveProject()
-    if active_project is not None:
-        return active_project
 
     project_spec.project_directory.mkdir(exist_ok=True, parents=True)
     project_manager = front_end_tool.getProjectManager()
@@ -56,6 +62,13 @@ def _open_gui_project(front_end_tool, project_spec):
         str(project_spec.project_directory.absolute()),
         project_spec.project_name,
     )
+
+    active_project = AppInfo.getActiveProject()
+    if active_project is not None:
+        if _project_matches_spec(active_project, project_spec):
+            return active_project
+        active_project.close()
+
     if locator.exists():
         opened_project = project_manager.openProject(locator, True, False)
     else:
@@ -110,7 +123,7 @@ class GuiPyGhidraContext(IndexingMixin):
                 project = AppInfo.getActiveProject()
             except Exception:
                 project = None
-            if project is not None:
+            if project is not None and _project_matches_spec(project, project_spec):
                 return project
 
             try:

--- a/src/pyghidra_mcp/header_import/__init__.py
+++ b/src/pyghidra_mcp/header_import/__init__.py
@@ -1,0 +1,16 @@
+from pyghidra_mcp.header_import.apply import CANONICAL_CATEGORY_ROOT, apply_header_import_plan
+from pyghidra_mcp.header_import.planning import (
+    build_header_import_plan,
+    build_header_import_plan_from_files,
+    build_header_import_plan_from_source,
+    translate_header_path,
+)
+
+__all__ = [
+    "CANONICAL_CATEGORY_ROOT",
+    "apply_header_import_plan",
+    "build_header_import_plan",
+    "build_header_import_plan_from_files",
+    "build_header_import_plan_from_source",
+    "translate_header_path",
+]

--- a/src/pyghidra_mcp/header_import/apply.py
+++ b/src/pyghidra_mcp/header_import/apply.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pyghidra_mcp.header_import.ir import (
+    ArrayType,
+    BuiltinType,
+    FunctionType,
+    HeaderImportPlan,
+    NamedType,
+    PointerType,
+)
+
+CANONICAL_CATEGORY_ROOT = "/pyghidra_mcp/imported_headers"
+INTERNAL_CATEGORY_ROOT = f"{CANONICAL_CATEGORY_ROOT}/__internal"
+
+
+@dataclass(frozen=True)
+class HeaderImportApplyResult:
+    category_root: str
+    created_types: tuple[str, ...]
+    updated_types: tuple[str, ...]
+    created_type_paths: tuple[str, ...] = ()
+    updated_type_paths: tuple[str, ...] = ()
+
+
+def apply_header_import_plan(program, plan: HeaderImportPlan) -> HeaderImportApplyResult:
+    plan.raise_for_errors()
+
+    from ghidra.program.model.data import (  # type: ignore
+        ArrayDataType,
+        ByteDataType,
+        CategoryPath,
+        CharDataType,
+        DataTypeConflictHandler,
+        DoubleDataType,
+        EnumDataType,
+        FloatDataType,
+        FunctionDefinitionDataType,
+        IntegerDataType,
+        LongLongDataType,
+        ParameterDefinitionImpl,
+        PointerDataType,
+        ShortDataType,
+        StructureDataType,
+        TypedefDataType,
+        UnionDataType,
+        UnsignedCharDataType,
+        UnsignedIntegerDataType,
+        UnsignedLongLongDataType,
+        UnsignedShortDataType,
+        VoidDataType,
+    )
+
+    dtm = program.getDataTypeManager()
+    ptr_size = program.getDefaultPointerSize()
+    root_category = CategoryPath(CANONICAL_CATEGORY_ROOT)
+    internal_category = CategoryPath(INTERNAL_CATEGORY_ROOT)
+
+    def pointer_to(data_type):
+        return PointerDataType(data_type)
+
+    def type_length(data_type):
+        length = data_type.getLength()
+        return ptr_size if length <= 0 else length
+
+    def add_or_replace(data_type):
+        return dtm.addDataType(data_type, DataTypeConflictHandler.REPLACE_HANDLER)
+
+    builtin_factories = {
+        "void": VoidDataType,
+        "char": CharDataType,
+        "bool": UnsignedCharDataType,
+        "_Bool": UnsignedCharDataType,
+        "unsigned char": UnsignedCharDataType,
+        "uint8_t": UnsignedCharDataType,
+        "signed char": ByteDataType,
+        "int8_t": ByteDataType,
+        "short": ShortDataType,
+        "int16_t": ShortDataType,
+        "unsigned short": UnsignedShortDataType,
+        "uint16_t": UnsignedShortDataType,
+        "int": IntegerDataType,
+        "int32_t": IntegerDataType,
+        "unsigned int": UnsignedIntegerDataType,
+        "uint32_t": UnsignedIntegerDataType,
+        "long long": LongLongDataType,
+        "int64_t": LongLongDataType,
+        "unsigned long long": UnsignedLongLongDataType,
+        "uint64_t": UnsignedLongLongDataType,
+        "float": FloatDataType,
+        "double": DoubleDataType,
+    }
+
+    def long_double_data_type():
+        try:
+            from ghidra.program.model.data import LongDoubleDataType  # type: ignore
+        except ImportError as exc:
+            raise ValueError(
+                "Builtin type 'long double' is not supported by this Ghidra runtime"
+            ) from exc
+        return LongDoubleDataType()
+
+    def builtin_data_type(name: str):
+        factory = builtin_factories.get(name)
+        if factory is not None:
+            return factory()
+        if name in {"long", "ptrdiff_t", "intptr_t"}:
+            return IntegerDataType() if ptr_size <= 4 else LongLongDataType()
+        if name in {"unsigned long", "size_t", "uintptr_t"}:
+            return UnsignedIntegerDataType() if ptr_size <= 4 else UnsignedLongLongDataType()
+        if name == "long double":
+            return long_double_data_type()
+        raise KeyError(name)
+
+    named_types: dict[str, object] = {}
+    created_types: list[str] = []
+    updated_types: list[str] = []
+    created_type_paths: list[str] = []
+    updated_type_paths: list[str] = []
+
+    def resolve_type(type_expr):
+        if isinstance(type_expr, BuiltinType):
+            return builtin_data_type(type_expr.name)
+        if isinstance(type_expr, NamedType):
+            try:
+                return named_types[type_expr.name]
+            except KeyError as exc:
+                raise ValueError(f"Unknown type reference '{type_expr.name}'") from exc
+        if isinstance(type_expr, PointerType):
+            return pointer_to(resolve_type(type_expr.target))
+        if isinstance(type_expr, ArrayType):
+            element_type = resolve_type(type_expr.element_type)
+            return ArrayDataType(element_type, type_expr.count, type_length(element_type))
+        if isinstance(type_expr, FunctionType):
+            raise ValueError("Inline function types must be declared as named typedefs")
+        raise TypeError(f"Unsupported type expression: {type_expr!r}")
+
+    def existing_type(path: str) -> bool:
+        return dtm.getDataType(path) is not None
+
+    def record_added_type(name: str, data_type, existed: bool) -> None:
+        path = str(data_type.getPathName())
+        if existed:
+            updated_types.append(name)
+            updated_type_paths.append(path)
+        else:
+            created_types.append(name)
+            created_type_paths.append(path)
+
+    enum_defs = {}
+    for enum_def in plan.enums:
+        enum_data_type = EnumDataType(root_category, enum_def.name, enum_def.width)
+        for member in enum_def.members:
+            enum_data_type.add(member.name, member.value)
+        enum_defs[enum_def.name] = enum_data_type
+        named_types[enum_def.name] = enum_data_type
+
+    function_defs = {}
+    for function_def in plan.function_types:
+        helper_name = function_def.name
+        category = root_category
+        if function_def.pointer_alias:
+            helper_name = f"__fn_{function_def.name}"
+            category = internal_category
+        function_data_type = FunctionDefinitionDataType(category, helper_name)
+        function_defs[function_def.name] = function_data_type
+        if not function_def.pointer_alias:
+            named_types[function_def.name] = function_data_type
+
+    composite_defs = {}
+    for composite in plan.composites:
+        if composite.kind == "struct":
+            structure = StructureDataType(root_category, composite.name, composite.size or 0)
+            composite_defs[composite.name] = structure
+            named_types[composite.name] = structure
+        else:
+            union = UnionDataType(root_category, composite.name)
+            composite_defs[composite.name] = union
+            named_types[composite.name] = union
+
+    for function_def in plan.function_types:
+        function_data_type = function_defs[function_def.name]
+        function_data_type.setReturnType(resolve_type(function_def.signature.return_type))
+        function_data_type.setArguments(
+            [
+                ParameterDefinitionImpl(param.name or f"arg{index}", resolve_type(param.type), "")
+                for index, param in enumerate(function_def.signature.parameters)
+            ]
+        )
+        if function_def.signature.variadic:
+            function_data_type.setVarArgs(True)
+
+    typedef_defs = {}
+    for function_def in plan.function_types:
+        if not function_def.pointer_alias:
+            continue
+        typedef_data_type = TypedefDataType(
+            root_category,
+            function_def.name,
+            pointer_to(function_defs[function_def.name]),
+        )
+        typedef_defs[function_def.name] = typedef_data_type
+        named_types[function_def.name] = typedef_data_type
+
+    remaining_typedefs = list(plan.typedefs)
+    while remaining_typedefs:
+        progress = False
+        unresolved = []
+        for typedef in remaining_typedefs:
+            try:
+                target = resolve_type(typedef.target)
+            except ValueError:
+                unresolved.append(typedef)
+                continue
+            typedef_data_type = TypedefDataType(root_category, typedef.name, target)
+            typedef_defs[typedef.name] = typedef_data_type
+            named_types[typedef.name] = typedef_data_type
+            progress = True
+        if progress:
+            remaining_typedefs = unresolved
+            continue
+        unresolved_names = ", ".join(sorted(typedef.name for typedef in unresolved))
+        raise ValueError(f"Unable to resolve typedef dependencies: {unresolved_names}")
+
+    for composite in plan.composites:
+        data_type = composite_defs[composite.name]
+        if isinstance(data_type, StructureDataType):
+            for field in composite.fields:
+                field_type = resolve_type(field.type)
+                data_type.replaceAtOffset(
+                    field.offset,
+                    field_type,
+                    type_length(field_type),
+                    field.name,
+                    field.comment,
+                )
+            continue
+        if isinstance(data_type, UnionDataType):
+            for field in composite.fields:
+                if field.offset not in {0, None}:
+                    raise ValueError(
+                        f"Union field '{composite.name}.{field.name}' must have offset 0"
+                    )
+                field_type = resolve_type(field.type)
+                data_type.add(field_type, field.name, field.comment)
+
+    for enum_def in plan.enums:
+        existed = existing_type(f"{CANONICAL_CATEGORY_ROOT}/{enum_def.name}")
+        named = add_or_replace(enum_defs[enum_def.name])
+        named_types[enum_def.name] = named
+        record_added_type(enum_def.name, named, existed)
+
+    for function_def in plan.function_types:
+        expected_path = (
+            f"{INTERNAL_CATEGORY_ROOT}/__fn_{function_def.name}"
+            if function_def.pointer_alias
+            else f"{CANONICAL_CATEGORY_ROOT}/{function_def.name}"
+        )
+        existed = existing_type(expected_path)
+        named = add_or_replace(function_defs[function_def.name])
+        function_defs[function_def.name] = named
+        if not function_def.pointer_alias:
+            named_types[function_def.name] = named
+            record_added_type(function_def.name, named, existed)
+
+    for composite_name in plan.composite_order:
+        existed = existing_type(f"{CANONICAL_CATEGORY_ROOT}/{composite_name}")
+        named = add_or_replace(composite_defs[composite_name])
+        named_types[composite_name] = named
+        record_added_type(composite_name, named, existed)
+
+    for typedef_name, typedef_data_type in typedef_defs.items():
+        existed = existing_type(f"{CANONICAL_CATEGORY_ROOT}/{typedef_name}")
+        named = add_or_replace(typedef_data_type)
+        named_types[typedef_name] = named
+        record_added_type(typedef_name, named, existed)
+
+    return HeaderImportApplyResult(
+        category_root=CANONICAL_CATEGORY_ROOT,
+        created_types=tuple(created_types),
+        updated_types=tuple(updated_types),
+        created_type_paths=tuple(created_type_paths),
+        updated_type_paths=tuple(updated_type_paths),
+    )

--- a/src/pyghidra_mcp/header_import/ir.py
+++ b/src/pyghidra_mcp/header_import/ir.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+Severity = Literal["error", "warning"]
+CompositeKind = Literal["struct", "union"]
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    severity: Severity
+    message: str
+    location: str | None = None
+
+
+class TypeExpr:
+    """Base class for normalized C type expressions."""
+
+
+@dataclass(frozen=True)
+class BuiltinType(TypeExpr):
+    name: str
+
+
+@dataclass(frozen=True)
+class NamedType(TypeExpr):
+    name: str
+
+
+@dataclass(frozen=True)
+class PointerType(TypeExpr):
+    target: TypeExpr
+
+
+@dataclass(frozen=True)
+class ArrayType(TypeExpr):
+    element_type: TypeExpr
+    count: int
+
+
+@dataclass(frozen=True)
+class FunctionParam:
+    name: str | None
+    type: TypeExpr
+
+
+@dataclass(frozen=True)
+class FunctionType(TypeExpr):
+    return_type: TypeExpr
+    parameters: tuple[FunctionParam, ...] = ()
+    variadic: bool = False
+
+
+@dataclass(frozen=True)
+class FieldDef:
+    name: str
+    type: TypeExpr
+    offset: int
+    comment: str = ""
+
+
+@dataclass(frozen=True)
+class CompositeDef:
+    kind: CompositeKind
+    name: str
+    fields: tuple[FieldDef, ...]
+    size: int | None = None
+    comment: str = ""
+    opaque: bool = False
+
+
+@dataclass(frozen=True)
+class EnumMember:
+    name: str
+    value: int
+
+
+@dataclass(frozen=True)
+class EnumDef:
+    name: str
+    members: tuple[EnumMember, ...]
+    width: int = 4
+
+
+@dataclass(frozen=True)
+class FunctionTypeDef:
+    name: str
+    signature: FunctionType
+    pointer_alias: bool = False
+
+
+@dataclass(frozen=True)
+class TypedefDef:
+    name: str
+    target: TypeExpr
+
+
+@dataclass(frozen=True)
+class HeaderImportPlan:
+    header_path: Path
+    resolved_local_includes: tuple[Path, ...] = ()
+    resolved_system_includes: tuple[str, ...] = ()
+    composites: tuple[CompositeDef, ...] = ()
+    enums: tuple[EnumDef, ...] = ()
+    function_types: tuple[FunctionTypeDef, ...] = ()
+    typedefs: tuple[TypedefDef, ...] = ()
+    composite_order: tuple[str, ...] = ()
+    diagnostics: tuple[Diagnostic, ...] = ()
+
+    def has_errors(self) -> bool:
+        return any(d.severity == "error" for d in self.diagnostics)
+
+    def error_messages(self) -> list[str]:
+        messages = []
+        for diagnostic in self.diagnostics:
+            if diagnostic.severity != "error":
+                continue
+            if diagnostic.location:
+                messages.append(f"{diagnostic.location}: {diagnostic.message}")
+            else:
+                messages.append(diagnostic.message)
+        return messages
+
+    def raise_for_errors(self) -> None:
+        errors = self.error_messages()
+        if errors:
+            raise ValueError("; ".join(errors))
+
+    @property
+    def definition_names(self) -> tuple[str, ...]:
+        names = [definition.name for definition in self.composites]
+        names.extend(definition.name for definition in self.enums)
+        names.extend(definition.name for definition in self.function_types)
+        names.extend(definition.name for definition in self.typedefs)
+        return tuple(names)
+
+
+def describe_type(type_expr: TypeExpr) -> str:
+    if isinstance(type_expr, BuiltinType):
+        return type_expr.name
+    if isinstance(type_expr, NamedType):
+        return type_expr.name
+    if isinstance(type_expr, PointerType):
+        return f"{describe_type(type_expr.target)} *"
+    if isinstance(type_expr, ArrayType):
+        return f"{describe_type(type_expr.element_type)}[{type_expr.count}]"
+    if isinstance(type_expr, FunctionType):
+        parts = [describe_type(param.type) for param in type_expr.parameters]
+        if type_expr.variadic:
+            parts.append("...")
+        return f"{describe_type(type_expr.return_type)} ({', '.join(parts)})"
+    raise TypeError(f"Unsupported type expression: {type_expr!r}")
+
+
+def iter_named_references(type_expr: TypeExpr, *, through_pointers: bool = True) -> list[str]:
+    if isinstance(type_expr, BuiltinType):
+        return []
+    if isinstance(type_expr, NamedType):
+        return [type_expr.name]
+    if isinstance(type_expr, PointerType):
+        if not through_pointers:
+            return []
+        return iter_named_references(type_expr.target, through_pointers=through_pointers)
+    if isinstance(type_expr, ArrayType):
+        return iter_named_references(type_expr.element_type, through_pointers=through_pointers)
+    if isinstance(type_expr, FunctionType):
+        refs = iter_named_references(type_expr.return_type, through_pointers=through_pointers)
+        for parameter in type_expr.parameters:
+            refs.extend(iter_named_references(parameter.type, through_pointers=through_pointers))
+        return refs
+    raise TypeError(f"Unsupported type expression: {type_expr!r}")
+
+
+@dataclass
+class PlanBuilder:
+    header_path: Path
+    local_includes: list[Path] = field(default_factory=list)
+    system_includes: list[str] = field(default_factory=list)
+    diagnostics: list[Diagnostic] = field(default_factory=list)
+
+    def add_diagnostic(
+        self,
+        severity: Severity,
+        message: str,
+        location: str | None = None,
+    ) -> None:
+        self.diagnostics.append(Diagnostic(severity=severity, message=message, location=location))

--- a/src/pyghidra_mcp/header_import/planning.py
+++ b/src/pyghidra_mcp/header_import/planning.py
@@ -1,0 +1,967 @@
+from __future__ import annotations
+
+import os
+import posixpath
+import re
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from pyghidra_mcp.header_import.ir import (
+    ArrayType,
+    BuiltinType,
+    CompositeDef,
+    FieldDef,
+    FunctionParam,
+    FunctionType,
+    FunctionTypeDef,
+    HeaderImportPlan,
+    NamedType,
+    PlanBuilder,
+    PointerType,
+    TypedefDef,
+)
+
+SUPPORTED_SYSTEM_HEADERS = {
+    "stdint.h": """
+        typedef signed char int8_t;
+        typedef short int16_t;
+        typedef int int32_t;
+        typedef long long int64_t;
+        typedef unsigned char uint8_t;
+        typedef unsigned short uint16_t;
+        typedef unsigned int uint32_t;
+        typedef unsigned long long uint64_t;
+        typedef long long intptr_t;
+        typedef unsigned long long uintptr_t;
+    """,
+    "stddef.h": """
+        typedef unsigned long size_t;
+        typedef long ptrdiff_t;
+    """,
+    "stdbool.h": "typedef unsigned char bool;",
+    "stdarg.h": "typedef void *va_list;",
+}
+
+ALLOWED_PREPROCESSOR_DIRECTIVES = ("#include", "#pragma once")
+BUILTIN_NAMES = {
+    "_Bool",
+    "bool",
+    "char",
+    "double",
+    "float",
+    "int",
+    "int8_t",
+    "int16_t",
+    "int32_t",
+    "int64_t",
+    "intptr_t",
+    "long",
+    "long double",
+    "long long",
+    "ptrdiff_t",
+    "short",
+    "signed char",
+    "size_t",
+    "uint8_t",
+    "uint16_t",
+    "uint32_t",
+    "uint64_t",
+    "uintptr_t",
+    "unsigned char",
+    "unsigned int",
+    "unsigned long",
+    "unsigned long long",
+    "unsigned short",
+    "void",
+}
+
+_INCLUDE_RE = re.compile(r'^\s*#include\s*([<"])([^">]+)[>"]')
+_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_LAYOUT_START_RE = re.compile(
+    r"^\s*(?:typedef\s+)?(?P<kind>struct|union)\s*(?P<tag>[A-Za-z_]\w*)?\s*\{\s*$"
+)
+_LAYOUT_END_RE = re.compile(r"^\s*\}\s*(?P<alias>[A-Za-z_]\w*)?\s*;\s*$")
+_INLINE_LAYOUT_RE = re.compile(
+    r"\b(?:typedef\s+)?(?P<kind>struct|union)\s*(?P<tag>[A-Za-z_]\w*)?\s*"
+    r"\{(?P<body>.*?)\}\s*(?P<alias>[A-Za-z_]\w*)?\s*;"
+)
+_OFFSET_RE = re.compile(r"/\*\s*0x([0-9A-Fa-f]+)\s*\*/")
+_SIZE_RE = re.compile(r"size=0x([0-9A-Fa-f]+)")
+
+
+@dataclass(frozen=True)
+class FieldLayout:
+    offset: int
+    comment: str = ""
+
+
+@dataclass(frozen=True)
+class CompositeLayout:
+    size: int | None
+    fields: tuple[FieldLayout, ...]
+
+
+class PlanningError(ValueError):
+    pass
+
+
+def translate_header_path(header_path: str | Path) -> str:
+    path_text = str(header_path)
+    source_path = PurePosixPath(path_text)
+    if not source_path.is_absolute():
+        return path_text
+
+    mappings = _header_path_mappings()
+    if not mappings:
+        return path_text
+
+    selected: tuple[PurePosixPath, Path] | None = None
+    for source_prefix, server_prefix in mappings:
+        if source_path != source_prefix and source_prefix not in source_path.parents:
+            continue
+        if selected is None or len(source_prefix.parts) > len(selected[0].parts):
+            selected = (source_prefix, server_prefix)
+
+    if selected is None:
+        return path_text
+
+    source_prefix, server_prefix = selected
+    relative_path = source_path.relative_to(source_prefix)
+    server_root = server_prefix.expanduser().resolve()
+    translated_path = (server_root / Path(*relative_path.parts)).resolve()
+    try:
+        translated_path.relative_to(server_root)
+    except ValueError as exc:
+        raise PlanningError(
+            f"Mapped header path escapes configured server root: {path_text}"
+        ) from exc
+    return str(translated_path)
+
+
+def _header_path_mappings() -> list[tuple[PurePosixPath, Path]]:
+    mapping_text = os.environ.get("PYGHIDRA_MCP_HEADER_PATH_MAP", "")
+    mappings: list[tuple[PurePosixPath, Path]] = []
+    for entry in mapping_text.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if "=" not in entry:
+            raise PlanningError("Invalid PYGHIDRA_MCP_HEADER_PATH_MAP entry: missing '='")
+        source_text, server_text = (part.strip() for part in entry.split("=", 1))
+        source_prefix = PurePosixPath(source_text)
+        server_prefix = Path(server_text).expanduser()
+        if not source_prefix.is_absolute() or not server_prefix.is_absolute():
+            raise PlanningError("PYGHIDRA_MCP_HEADER_PATH_MAP entries must use absolute paths")
+        mappings.append((source_prefix, server_prefix))
+    return mappings
+
+
+def build_header_import_plan(header_path: str | Path) -> HeaderImportPlan:
+    root = Path(header_path).expanduser().resolve()
+    if not root.exists():
+        raise PlanningError(f"Header file not found: {root}")
+    if root.is_dir():
+        raise PlanningError(f"Expected a file but received a directory: {root}")
+
+    builder = PlanBuilder(header_path=root)
+    local_sources: OrderedDict[Path, str] = OrderedDict()
+    system_headers: list[str] = []
+    _resolve_header_graph(root, builder, local_sources, system_headers, set())
+    return _build_plan_from_local_sources(root, builder, local_sources, system_headers)
+
+
+def build_header_import_plan_from_source(
+    header_content: str,
+    *,
+    header_name: str = "input.h",
+    include_files: dict[str, str] | None = None,
+) -> HeaderImportPlan:
+    root = _normalize_virtual_header_path(header_name or "input.h")
+    sources: dict[Path, str] = {root: header_content}
+    for include_name, include_content in (include_files or {}).items():
+        sources[_normalize_virtual_header_path(include_name)] = include_content
+
+    builder = PlanBuilder(header_path=root)
+    local_sources: OrderedDict[Path, str] = OrderedDict()
+    system_headers: list[str] = []
+    _resolve_virtual_header_graph(root, sources, builder, local_sources, system_headers, set())
+    return _build_plan_from_local_sources(root, builder, local_sources, system_headers)
+
+
+def build_header_import_plan_from_files(header_files: list[dict[str, str]]) -> HeaderImportPlan:
+    if not header_files:
+        raise PlanningError("header_files must contain at least one file")
+
+    root_file = header_files[0]
+    root_name = _header_file_field(root_file, "name", 0)
+    root_content = _header_file_field(root_file, "content", 0)
+    include_files: dict[str, str] = {}
+    seen_names = {_normalize_virtual_header_path(root_name)}
+
+    for index, header_file in enumerate(header_files[1:], start=1):
+        include_name = _header_file_field(header_file, "name", index)
+        include_path = _normalize_virtual_header_path(include_name)
+        if include_path in seen_names:
+            raise PlanningError(f"Duplicate header file name in header_files: {include_name}")
+        seen_names.add(include_path)
+        include_files[include_name] = _header_file_field(header_file, "content", index)
+
+    return build_header_import_plan_from_source(
+        root_content,
+        header_name=root_name,
+        include_files=include_files,
+    )
+
+
+def _header_file_field(header_file: dict[str, str], field_name: str, index: int) -> str:
+    value = header_file.get(field_name)
+    if not isinstance(value, str) or not value:
+        raise PlanningError(f"header_files[{index}] must include a non-empty '{field_name}' string")
+    return value
+
+
+def _build_plan_from_local_sources(
+    root: Path,
+    builder: PlanBuilder,
+    local_sources: OrderedDict[Path, str],
+    system_headers: list[str],
+) -> HeaderImportPlan:
+    synthetic_source, stub_line_count = _build_synthetic_translation_unit(
+        local_sources, system_headers
+    )
+
+    try:
+        from pycparser import c_ast, c_parser
+    except ImportError as exc:  # pragma: no cover - dependency install failure
+        raise PlanningError("pycparser is required to import reviewed headers") from exc
+
+    parser = c_parser.CParser()
+    try:
+        ast = parser.parse(synthetic_source, filename=str(root))
+    except Exception as exc:
+        raise PlanningError(f"Failed to parse header import translation unit: {exc}") from exc
+
+    layouts = _extract_layouts(local_sources)
+    top_level_nodes = [ext for ext in ast.ext if getattr(ext.coord, "line", 0) > stub_line_count]
+    tag_aliases = _collect_tag_aliases(top_level_nodes, c_ast)
+    composites, enums, function_types, typedefs = _collect_definitions(
+        top_level_nodes,
+        layouts,
+        tag_aliases,
+        builder,
+        c_ast,
+    )
+    _validate_named_references(composites, enums, function_types, typedefs, builder)
+    composite_order = _order_composites(composites, enums, function_types, typedefs, builder)
+
+    return HeaderImportPlan(
+        header_path=root,
+        resolved_local_includes=tuple(local_sources.keys()),
+        resolved_system_includes=tuple(system_headers),
+        composites=tuple(composites.values()),
+        enums=tuple(enums.values()),
+        function_types=tuple(function_types.values()),
+        typedefs=tuple(typedefs.values()),
+        composite_order=tuple(composite_order),
+        diagnostics=tuple(builder.diagnostics),
+    )
+
+
+def _normalize_virtual_header_path(path: str) -> Path:
+    normalized = posixpath.normpath(path.replace("\\", "/"))
+    if normalized in ("", "."):
+        normalized = "input.h"
+    return Path(normalized)
+
+
+def _resolve_header_graph(
+    path: Path,
+    builder: PlanBuilder,
+    local_sources: OrderedDict[Path, str],
+    system_headers: list[str],
+    resolving: set[Path],
+) -> None:
+    if path in local_sources:
+        return
+    if path in resolving:
+        builder.add_diagnostic(
+            "warning",
+            f"Detected include cycle involving {path}",
+            str(path),
+        )
+        return
+
+    text = path.read_text(encoding="utf-8")
+    resolving.add(path)
+    try:
+        _validate_preprocessor_directives(path, text, builder)
+
+        for delimiter, include_name in _scan_includes(text):
+            if delimiter == '"':
+                include_path = (path.parent / include_name).resolve()
+                if not include_path.exists():
+                    builder.add_diagnostic(
+                        "error",
+                        f"Missing local include '{include_name}'",
+                        str(path),
+                    )
+                    continue
+                _resolve_header_graph(
+                    include_path, builder, local_sources, system_headers, resolving
+                )
+                continue
+
+            if include_name not in SUPPORTED_SYSTEM_HEADERS:
+                builder.add_diagnostic(
+                    "error",
+                    f"Unsupported system include '{include_name}'",
+                    str(path),
+                )
+                continue
+            if include_name not in system_headers:
+                system_headers.append(include_name)
+    finally:
+        resolving.remove(path)
+
+    local_sources[path] = text
+    builder.local_includes.append(path)
+    for include_name in system_headers:
+        if include_name not in builder.system_includes:
+            builder.system_includes.append(include_name)
+
+
+def _resolve_virtual_header_graph(
+    path: Path,
+    sources: dict[Path, str],
+    builder: PlanBuilder,
+    local_sources: OrderedDict[Path, str],
+    system_headers: list[str],
+    resolving: set[Path],
+) -> None:
+    if path in local_sources or path in resolving:
+        return
+
+    text = sources[path]
+    resolving.add(path)
+    _validate_preprocessor_directives(path, text, builder)
+
+    for delimiter, include_name in _scan_includes(text):
+        if delimiter == '"':
+            include_path = _normalize_virtual_header_path(str(path.parent / include_name))
+            if include_path not in sources:
+                builder.add_diagnostic(
+                    "error",
+                    f"Missing local include '{include_name}'",
+                    str(path),
+                )
+                continue
+            _resolve_virtual_header_graph(
+                include_path,
+                sources,
+                builder,
+                local_sources,
+                system_headers,
+                resolving,
+            )
+            continue
+
+        if include_name not in SUPPORTED_SYSTEM_HEADERS:
+            builder.add_diagnostic(
+                "error",
+                f"Unsupported system include '{include_name}'",
+                str(path),
+            )
+            continue
+        if include_name not in system_headers:
+            system_headers.append(include_name)
+
+    resolving.remove(path)
+    local_sources[path] = text
+    builder.local_includes.append(path)
+    for include_name in system_headers:
+        if include_name not in builder.system_includes:
+            builder.system_includes.append(include_name)
+
+
+def _validate_preprocessor_directives(path: Path, text: str, builder: PlanBuilder) -> None:
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped.startswith("#"):
+            continue
+        if _is_allowed_preprocessor_directive(stripped):
+            continue
+        builder.add_diagnostic(
+            "error",
+            f"Unsupported preprocessor directive: {stripped}",
+            f"{path}:{line_number}",
+        )
+
+
+def _is_allowed_preprocessor_directive(stripped: str) -> bool:
+    if stripped == "#pragma once":
+        return True
+    return _INCLUDE_RE.fullmatch(stripped) is not None
+
+
+def _scan_includes(text: str) -> list[tuple[str, str]]:
+    includes: list[tuple[str, str]] = []
+    for line in text.splitlines():
+        match = _INCLUDE_RE.match(line)
+        if not match:
+            continue
+        includes.append((match.group(1), match.group(2).strip()))
+    return includes
+
+
+def _build_synthetic_translation_unit(
+    local_sources: OrderedDict[Path, str],
+    system_headers: list[str],
+) -> tuple[str, int]:
+    system_sections = [
+        SUPPORTED_SYSTEM_HEADERS[header_name].strip() for header_name in system_headers
+    ]
+    system_source = "\n\n".join(section for section in system_sections if section)
+    local_source = "\n\n".join(
+        _sanitize_source_for_parser(source) for source in local_sources.values()
+    )
+
+    if system_source and local_source:
+        synthetic_source = f"{system_source}\n\n{local_source}"
+    else:
+        synthetic_source = system_source or local_source
+
+    stub_lines = system_source.count("\n") + 1 if system_source else 0
+    return synthetic_source, stub_lines
+
+
+def _sanitize_source_for_parser(source: str) -> str:
+    lines: list[str] = []
+    for line in source.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#include") or stripped.startswith("#pragma once"):
+            lines.append("")
+            continue
+        lines.append(line)
+    return _strip_comments_preserving_lines("\n".join(lines))
+
+
+def _strip_comments_preserving_lines(source: str) -> str:
+    def replacer(match: re.Match[str]) -> str:
+        text = match.group(0)
+        newline_count = text.count("\n")
+        if newline_count == 0:
+            return " "
+        return "\n" * newline_count
+
+    return _COMMENT_RE.sub(replacer, source)
+
+
+def _extract_layouts(local_sources: OrderedDict[Path, str]) -> dict[str, CompositeLayout]:
+    layouts: dict[str, CompositeLayout] = {}
+    for path, source in local_sources.items():
+        per_file = _extract_file_layouts(path, source)
+        for name, layout in per_file.items():
+            layouts[name] = layout
+    return layouts
+
+
+def _extract_file_layouts(path: Path, source: str) -> dict[str, CompositeLayout]:
+    layouts: dict[str, CompositeLayout] = {}
+    lines = source.splitlines()
+    index = 0
+    while index < len(lines):
+        inline_layout = _extract_inline_layout(lines[index], path)
+        if inline_layout is not None:
+            name, layout = inline_layout
+            layouts[name] = layout
+            index += 1
+            continue
+
+        match = _LAYOUT_START_RE.match(lines[index])
+        if not match:
+            index += 1
+            continue
+
+        tag = match.group("tag")
+        fields: list[FieldLayout] = []
+        size = _extract_nearby_size(lines, index)
+        end_index = index + 1
+        alias: str | None = None
+        while end_index < len(lines):
+            end_match = _LAYOUT_END_RE.match(lines[end_index])
+            if end_match:
+                alias = end_match.group("alias")
+                break
+            offset_match = _OFFSET_RE.search(lines[end_index])
+            if offset_match:
+                comments = re.findall(r"/\*(.*?)\*/", lines[end_index])
+                trailing_comment = comments[-1].strip() if len(comments) > 1 else ""
+                fields.append(
+                    FieldLayout(offset=int(offset_match.group(1), 16), comment=trailing_comment)
+                )
+            end_index += 1
+
+        final_name = alias or tag
+        if final_name:
+            layouts[final_name] = CompositeLayout(size=size, fields=tuple(fields))
+        else:
+            raise PlanningError(f"Anonymous composite without typedef alias in {path}")
+        index = end_index + 1
+    return layouts
+
+
+def _extract_inline_layout(line: str, path: Path) -> tuple[str, CompositeLayout] | None:
+    match = _INLINE_LAYOUT_RE.search(line)
+    if not match:
+        return None
+
+    final_name = match.group("alias") or match.group("tag")
+    if not final_name:
+        raise PlanningError(f"Anonymous composite without typedef alias in {path}")
+
+    fields: list[FieldLayout] = []
+    for field_text in match.group("body").split(";"):
+        offset_match = _OFFSET_RE.search(field_text)
+        if not offset_match:
+            continue
+        comments = re.findall(r"/\*(.*?)\*/", field_text)
+        trailing_comment = comments[-1].strip() if len(comments) > 1 else ""
+        fields.append(FieldLayout(offset=int(offset_match.group(1), 16), comment=trailing_comment))
+
+    size_match = _SIZE_RE.search(line[: match.start()]) or _SIZE_RE.search(line)
+    size = int(size_match.group(1), 16) if size_match else None
+    return final_name, CompositeLayout(size=size, fields=tuple(fields))
+
+
+def _extract_nearby_size(lines: list[str], index: int) -> int | None:
+    window_start = max(0, index - 8)
+    window = "\n".join(lines[window_start:index])
+    match = _SIZE_RE.search(window)
+    if not match:
+        return None
+    return int(match.group(1), 16)
+
+
+def _collect_tag_aliases(top_level_nodes, c_ast) -> dict[tuple[str, str], str]:
+    aliases: dict[tuple[str, str], str] = {}
+    for node in top_level_nodes:
+        if not isinstance(node, c_ast.Typedef):
+            continue
+        tagged = _named_tagged_type(node.type, c_ast)
+        if not tagged:
+            continue
+        kind, tag_name, _has_body = tagged
+        aliases[(kind, tag_name)] = node.name
+    return aliases
+
+
+def _collect_definitions(top_level_nodes, layouts, tag_aliases, builder, c_ast):
+    composites: dict[str, CompositeDef] = {}
+    enums: dict[str, object] = {}
+    function_types: dict[str, FunctionTypeDef] = {}
+    typedefs: dict[str, TypedefDef] = {}
+
+    for node in top_level_nodes:
+        if isinstance(node, c_ast.Typedef):
+            _handle_typedef(
+                node,
+                layouts,
+                tag_aliases,
+                builder,
+                composites,
+                enums,
+                function_types,
+                typedefs,
+                c_ast,
+            )
+            continue
+        if isinstance(node, c_ast.Decl):
+            _handle_decl(node, layouts, tag_aliases, builder, composites, enums, c_ast)
+            continue
+
+    return composites, enums, function_types, typedefs
+
+
+def _handle_typedef(
+    node,
+    layouts,
+    tag_aliases,
+    builder,
+    composites,
+    enums,
+    function_types,
+    typedefs,
+    c_ast,
+) -> None:
+    tagged = _named_tagged_type(node.type, c_ast)
+    if tagged:
+        kind, tag_name, has_body = tagged
+        canonical_name = tag_aliases.get((kind, tag_name), node.name)
+        if kind in {"struct", "union"}:
+            if has_body:
+                composite = _build_composite_def(
+                    canonical_name,
+                    _unwrap_named_tagged_type(node.type, c_ast),
+                    layouts,
+                    tag_aliases,
+                    builder,
+                    c_ast,
+                )
+                composites[canonical_name] = composite
+            else:
+                composites.setdefault(
+                    canonical_name,
+                    CompositeDef(kind=kind, name=canonical_name, fields=(), size=0, opaque=True),
+                )
+            if node.name != canonical_name:
+                typedefs[node.name] = TypedefDef(name=node.name, target=NamedType(canonical_name))
+            return
+        if kind == "enum":
+            enum_node = _unwrap_named_tagged_type(node.type, c_ast)
+            if has_body:
+                enum_def = _build_enum_def(canonical_name, enum_node, builder, c_ast)
+                enums[canonical_name] = enum_def
+            if node.name != canonical_name:
+                typedefs[node.name] = TypedefDef(name=node.name, target=NamedType(canonical_name))
+            return
+
+    try:
+        converted = _convert_type(node.type, tag_aliases, builder, c_ast)
+    except PlanningError as exc:
+        builder.add_diagnostic("error", str(exc), _coord(node))
+        return
+
+    if isinstance(converted, FunctionType):
+        function_types[node.name] = FunctionTypeDef(name=node.name, signature=converted)
+        return
+    if isinstance(converted, PointerType) and isinstance(converted.target, FunctionType):
+        function_types[node.name] = FunctionTypeDef(
+            name=node.name,
+            signature=converted.target,
+            pointer_alias=True,
+        )
+        return
+    typedefs[node.name] = TypedefDef(name=node.name, target=converted)
+
+
+def _handle_decl(node, layouts, tag_aliases, builder, composites, enums, c_ast) -> None:
+    if isinstance(node.type, c_ast.FuncDecl):
+        return
+    if isinstance(node.type, (c_ast.Struct, c_ast.Union)):
+        try:
+            composite = _build_declared_composite(node.type, layouts, tag_aliases, builder, c_ast)
+        except PlanningError as exc:
+            builder.add_diagnostic("error", str(exc), _coord(node))
+            return
+        composites[composite.name] = composite
+        return
+    if isinstance(node.type, c_ast.Enum) and node.type.values is not None:
+        enum_name = tag_aliases.get(("enum", node.type.name), node.type.name)
+        if enum_name is None:
+            builder.add_diagnostic("error", "Anonymous enums are not supported", _coord(node))
+            return
+        enums[enum_name] = _build_enum_def(enum_name, node.type, builder, c_ast)
+
+
+def _build_declared_composite(node, layouts, tag_aliases, builder, c_ast) -> CompositeDef:
+    if node.name is None:
+        raise PlanningError("Anonymous composite declarations are not supported")
+    kind = _composite_kind(node)
+    canonical_name = tag_aliases.get((kind, node.name), node.name)
+    if node.decls is None:
+        return CompositeDef(kind=kind, name=canonical_name, fields=(), size=0, opaque=True)
+    return _build_composite_def(canonical_name, node, layouts, tag_aliases, builder, c_ast)
+
+
+def _build_composite_def(name, node, layouts, tag_aliases, builder, c_ast) -> CompositeDef:
+    layout = layouts.get(name)
+    if layout is None:
+        builder.add_diagnostic(
+            "error",
+            f"Missing layout metadata for composite '{name}'",
+            _coord(node),
+        )
+        layout = CompositeLayout(size=None, fields=())
+
+    if node.decls is None:
+        return CompositeDef(
+            kind=_composite_kind(node), name=name, fields=(), size=layout.size, opaque=True
+        )
+
+    if len(layout.fields) not in {0, len(node.decls)}:
+        builder.add_diagnostic(
+            "error",
+            (
+                f"Field count mismatch for composite '{name}': "
+                f"expected {len(node.decls)} offsets, found {len(layout.fields)}"
+            ),
+            _coord(node),
+        )
+
+    fields: list[FieldDef] = []
+    for index, decl in enumerate(node.decls):
+        if decl.bitsize is not None:
+            builder.add_diagnostic("error", "Bitfields are not supported", _coord(decl))
+            continue
+        if decl.name is None:
+            builder.add_diagnostic(
+                "error",
+                f"Anonymous fields are not supported in '{name}'",
+                _coord(decl),
+            )
+            continue
+        try:
+            field_type = _convert_type(decl.type, tag_aliases, builder, c_ast)
+        except PlanningError as exc:
+            builder.add_diagnostic("error", str(exc), _coord(decl))
+            continue
+        if index < len(layout.fields):
+            offset = layout.fields[index].offset
+            comment = layout.fields[index].comment
+        else:
+            offset = 0
+            comment = ""
+            builder.add_diagnostic(
+                "error",
+                f"Missing explicit offset comment for field '{decl.name}' in '{name}'",
+                _coord(decl),
+            )
+        fields.append(FieldDef(name=decl.name, type=field_type, offset=offset, comment=comment))
+
+    return CompositeDef(
+        kind=_composite_kind(node),
+        name=name,
+        fields=tuple(fields),
+        size=layout.size,
+    )
+
+
+def _build_enum_def(name, node, builder, c_ast):
+    members = []
+    next_value = 0
+    for enumerator in node.values.enumerators:
+        if enumerator.value is None:
+            value = next_value
+        else:
+            try:
+                value = _evaluate_integer_constant(enumerator.value, builder, c_ast)
+            except PlanningError as exc:
+                builder.add_diagnostic("error", str(exc), _coord(enumerator))
+                value = next_value
+        members.append((enumerator.name, value))
+        next_value = value + 1
+
+    from pyghidra_mcp.header_import.ir import EnumDef, EnumMember
+
+    return EnumDef(
+        name=name, members=tuple(EnumMember(member_name, value) for member_name, value in members)
+    )
+
+
+def _evaluate_integer_constant(node, builder, c_ast) -> int:
+    if isinstance(node, c_ast.Constant):
+        if node.type != "int":
+            raise PlanningError(f"Unsupported enum constant type '{node.type}'")
+        return int(node.value, 0)
+    if isinstance(node, c_ast.UnaryOp) and node.op in {"+", "-"}:
+        value = _evaluate_integer_constant(node.expr, builder, c_ast)
+        return value if node.op == "+" else -value
+    raise PlanningError("Only integer enum constants are supported")
+
+
+def _convert_type(node, tag_aliases, builder, c_ast):
+    if isinstance(node, c_ast.TypeDecl):
+        return _convert_type_decl(node, tag_aliases, builder, c_ast)
+    if isinstance(node, c_ast.PtrDecl):
+        return PointerType(_convert_type(node.type, tag_aliases, builder, c_ast))
+    if isinstance(node, c_ast.ArrayDecl):
+        if node.dim is None:
+            raise PlanningError("Flexible array members are not supported")
+        count = _evaluate_array_size(node.dim, c_ast)
+        return ArrayType(
+            element_type=_convert_type(node.type, tag_aliases, builder, c_ast),
+            count=count,
+        )
+    if isinstance(node, c_ast.FuncDecl):
+        params: list[FunctionParam] = []
+        variadic = False
+        args = node.args.params if node.args and node.args.params else []
+        for param in args:
+            if isinstance(param, c_ast.EllipsisParam):
+                variadic = True
+                continue
+            param_type = _convert_type(param.type, tag_aliases, builder, c_ast)
+            if len(args) == 1 and param.name is None and param_type == BuiltinType("void"):
+                continue
+            params.append(
+                FunctionParam(
+                    name=param.name,
+                    type=param_type,
+                )
+            )
+        return FunctionType(
+            return_type=_convert_type(node.type, tag_aliases, builder, c_ast),
+            parameters=tuple(params),
+            variadic=variadic,
+        )
+    raise PlanningError(f"Unsupported declaration node: {type(node).__name__}")
+
+
+def _convert_type_decl(node, tag_aliases, builder, c_ast):
+    inner = node.type
+    if isinstance(inner, c_ast.IdentifierType):
+        name = " ".join(inner.names)
+        if name in BUILTIN_NAMES:
+            return BuiltinType(name)
+        return NamedType(name)
+    if isinstance(inner, c_ast.Struct):
+        return _convert_tag_reference(inner, "struct", tag_aliases)
+    if isinstance(inner, c_ast.Union):
+        return _convert_tag_reference(inner, "union", tag_aliases)
+    if isinstance(inner, c_ast.Enum):
+        if inner.name is None:
+            raise PlanningError("Anonymous enums are not supported")
+        return NamedType(tag_aliases.get(("enum", inner.name), inner.name))
+    raise PlanningError(f"Unsupported type declaration node: {type(inner).__name__}")
+
+
+def _convert_tag_reference(node, kind: str, tag_aliases):
+    if node.name is None:
+        raise PlanningError("Anonymous composites are not supported")
+    return NamedType(tag_aliases.get((kind, node.name), node.name))
+
+
+def _evaluate_array_size(node, c_ast) -> int:
+    if isinstance(node, c_ast.Constant) and node.type == "int":
+        return int(node.value, 0)
+    raise PlanningError("Only fixed integer array sizes are supported")
+
+
+def _named_tagged_type(node, c_ast):
+    candidate = _unwrap_named_tagged_type(node, c_ast)
+    if candidate is None or candidate.name is None:
+        return None
+    if isinstance(candidate, c_ast.Struct):
+        return ("struct", candidate.name, candidate.decls is not None)
+    if isinstance(candidate, c_ast.Union):
+        return ("union", candidate.name, candidate.decls is not None)
+    if isinstance(candidate, c_ast.Enum):
+        return ("enum", candidate.name, candidate.values is not None)
+    return None
+
+
+def _unwrap_named_tagged_type(node, c_ast):
+    current = node
+    while isinstance(current, c_ast.TypeDecl):
+        current = current.type
+    if isinstance(current, (c_ast.Struct, c_ast.Union, c_ast.Enum)):
+        return current
+    return None
+
+
+def _composite_kind(node) -> str:
+    return "union" if node.__class__.__name__ == "Union" else "struct"
+
+
+def _validate_named_references(composites, enums, function_types, typedefs, builder) -> None:
+    known_names = set(BUILTIN_NAMES)
+    known_names.update(composites)
+    known_names.update(enums)
+    known_names.update(function_types)
+    known_names.update(typedefs)
+
+    def validate_type(type_expr, location: str) -> None:
+        if isinstance(type_expr, BuiltinType):
+            return
+        if isinstance(type_expr, NamedType):
+            if type_expr.name not in known_names:
+                builder.add_diagnostic(
+                    "error",
+                    f"Unknown referenced type '{type_expr.name}'",
+                    location,
+                )
+            return
+        if isinstance(type_expr, PointerType):
+            validate_type(type_expr.target, location)
+            return
+        if isinstance(type_expr, ArrayType):
+            validate_type(type_expr.element_type, location)
+            return
+        if isinstance(type_expr, FunctionType):
+            validate_type(type_expr.return_type, location)
+            for parameter in type_expr.parameters:
+                validate_type(parameter.type, location)
+
+    for composite in composites.values():
+        for field in composite.fields:
+            validate_type(field.type, f"{builder.header_path}:{composite.name}.{field.name}")
+    for function_def in function_types.values():
+        validate_type(function_def.signature, f"{builder.header_path}:{function_def.name}")
+    for typedef in typedefs.values():
+        validate_type(typedef.target, f"{builder.header_path}:{typedef.name}")
+
+
+def _order_composites(composites, enums, function_types, typedefs, builder) -> list[str]:
+    composite_names = set(composites)
+
+    def hard_dependencies(type_expr) -> set[str]:
+        if isinstance(type_expr, BuiltinType):
+            return set()
+        if isinstance(type_expr, NamedType):
+            target_name = type_expr.name
+            if target_name in composite_names:
+                return {target_name}
+            if target_name in enums or target_name in function_types:
+                return set()
+            if target_name in typedefs:
+                return hard_dependencies(typedefs[target_name].target)
+            return set()
+        if isinstance(type_expr, PointerType):
+            return set()
+        if isinstance(type_expr, ArrayType):
+            return hard_dependencies(type_expr.element_type)
+        if isinstance(type_expr, FunctionType):
+            deps = hard_dependencies(type_expr.return_type)
+            for parameter in type_expr.parameters:
+                deps.update(hard_dependencies(parameter.type))
+            return deps
+        return set()
+
+    dependency_map: dict[str, set[str]] = {}
+    for name, composite in composites.items():
+        deps: set[str] = set()
+        for field in composite.fields:
+            deps.update(hard_dependencies(field.type))
+        deps.discard(name)
+        dependency_map[name] = deps
+
+    ordered: list[str] = []
+    temporary: set[str] = set()
+    permanent: set[str] = set()
+
+    def visit(name: str) -> None:
+        if name in permanent:
+            return
+        if name in temporary:
+            builder.add_diagnostic(
+                "error",
+                f"Detected by-value composite dependency cycle involving '{name}'",
+                str(builder.header_path),
+            )
+            return
+        temporary.add(name)
+        for dependency in sorted(dependency_map.get(name, set())):
+            visit(dependency)
+        temporary.remove(name)
+        permanent.add(name)
+        ordered.append(name)
+
+    for name in sorted(composites):
+        visit(name)
+    return ordered
+
+
+def _coord(node) -> str | None:
+    coord = getattr(node, "coord", None)
+    return None if coord is None else str(coord)

--- a/src/pyghidra_mcp/mcp_tools.py
+++ b/src/pyghidra_mcp/mcp_tools.py
@@ -22,10 +22,15 @@ from pyghidra_mcp.models import (
     CodeSearchResults,
     CommentResponse,
     CrossReferenceInfos,
+    DataTypeAtAddressResponse,
+    DataTypeDescriptionResponse,
+    DataTypeSearchResults,
     DecompiledFunction,
     ExportInfos,
     FunctionPrototypeResponse,
+    FunctionReturnTypeResponse,
     GotoResponse,
+    HeaderImportResponse,
     ImportInfos,
     ImportRequestResult,
     OpenProgramInfo,
@@ -308,6 +313,7 @@ def set_variable_type(
     variable_name: str,
     type_name: str,
     ctx: Context,
+    variable_kind: Literal["parameter", "local"] | None = None,
 ) -> VariableTypeResponse:
     """Set a parameter or local type by exact name."""
     pyghidra_context: MCPContext = ctx.request_context.lifespan_context
@@ -315,7 +321,9 @@ def set_variable_type(
     tools = GhidraTools(program_info)
     result = _run_for_context(
         pyghidra_context,
-        lambda: tools.set_variable_type(function_name_or_address, variable_name, type_name),
+        lambda: tools.set_variable_type(
+            function_name_or_address, variable_name, type_name, variable_kind=variable_kind
+        ),
     )
     result = cast(dict, result)
     return VariableTypeResponse(binary_name=binary_name, **result)
@@ -341,6 +349,47 @@ def set_function_prototype(
 
 
 @mcp_error_handler
+def set_function_return_type(
+    binary_name: str,
+    function_name_or_address: str,
+    type_name_or_path: str,
+    ctx: Context,
+) -> FunctionReturnTypeResponse:
+    """Set only a function's return datatype by exact path, unique name, or parser string."""
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
+    program_info = pyghidra_context.get_program_info(binary_name)
+    tools = GhidraTools(program_info)
+    result = _run_for_context(
+        pyghidra_context,
+        lambda: tools.set_function_return_type(function_name_or_address, type_name_or_path),
+    )
+    result = cast(dict, result)
+    return FunctionReturnTypeResponse(binary_name=binary_name, **result)
+
+
+@mcp_error_handler
+def set_data_type_at_address(
+    binary_name: str,
+    address: str,
+    type_name_or_path: str,
+    ctx: Context,
+    clear_existing: bool = True,
+) -> DataTypeAtAddressResponse:
+    """Create data at an address using an exact datatype path, unique name, or parser string."""
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
+    program_info = pyghidra_context.get_program_info(binary_name)
+    tools = GhidraTools(program_info)
+    result = _run_for_context(
+        pyghidra_context,
+        lambda: tools.set_data_type_at_address(
+            address, type_name_or_path, clear_existing=clear_existing
+        ),
+    )
+    result = cast(dict, result)
+    return DataTypeAtAddressResponse(binary_name=binary_name, **result)
+
+
+@mcp_error_handler
 def set_comment(
     binary_name: str,
     target: str,
@@ -358,6 +407,85 @@ def set_comment(
     )
     result = cast(dict, result)
     return CommentResponse(binary_name=binary_name, **result)
+
+
+@mcp_error_handler
+def import_header_types(
+    binary_name: str,
+    header_path: str | None = None,
+    ctx: Context | None = None,
+    validate_only: bool = False,
+    *,
+    header_content: str | None = None,
+    header_name: str | None = None,
+    include_files: dict[str, str] | None = None,
+    header_files: list[dict[str, str]] | None = None,
+) -> HeaderImportResponse:
+    """Import reviewed C header types into Ghidra under the canonical importer category root."""
+    if ctx is None:
+        raise ValueError("MCP context is required")
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
+    program_info = pyghidra_context.get_program_info(binary_name)
+    tools = GhidraTools(program_info)
+    result = _run_for_context(
+        pyghidra_context,
+        lambda: tools.import_header_types(
+            header_path=header_path,
+            validate_only=validate_only,
+            header_content=header_content,
+            header_name=header_name,
+            include_files=include_files,
+            header_files=header_files,
+        ),
+    )
+    result = cast(dict, result)
+    return HeaderImportResponse(binary_name=binary_name, **result)
+
+
+@mcp_error_handler
+def list_data_types(
+    binary_name: str,
+    ctx: Context,
+    query: str = ".*",
+    category_path: str | None = None,
+    include_builtins: bool = False,
+    offset: int = 0,
+    limit: int = 50,
+) -> DataTypeSearchResults:
+    """List datatypes by regex, category subtree, and pagination."""
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
+    program_info = pyghidra_context.get_program_info(binary_name)
+    tools = GhidraTools(program_info)
+    result = _run_for_context(
+        pyghidra_context,
+        lambda: tools.list_data_types(
+            query=query,
+            category_path=category_path,
+            include_builtins=include_builtins,
+            offset=offset,
+            limit=limit,
+        ),
+    )
+    result = cast(dict, result)
+    return DataTypeSearchResults(**result)
+
+
+@mcp_error_handler
+def describe_data_type(
+    binary_name: str,
+    data_type_name_or_path: str,
+    ctx: Context,
+) -> DataTypeDescriptionResponse:
+    """Describe the current Ghidra datatype metadata and fields for a named datatype."""
+    pyghidra_context: MCPContext = ctx.request_context.lifespan_context
+    program_info = pyghidra_context.get_program_info(binary_name)
+    tools = GhidraTools(program_info)
+    result = _run_for_context(
+        pyghidra_context,
+        lambda: tools.describe_data_type(data_type_name_or_path),
+    )
+    result = cast(dict, result)
+    return DataTypeDescriptionResponse(binary_name=binary_name, **result)
 
 
 @mcp_error_handler

--- a/src/pyghidra_mcp/models.py
+++ b/src/pyghidra_mcp/models.py
@@ -62,6 +62,67 @@ class ImportRequestResult(BaseModel):
     message: str
 
 
+class HeaderImportDiagnostic(BaseModel):
+    severity: str
+    message: str
+    location: str | None = None
+
+
+class DataTypeReference(BaseModel):
+    name: str
+    display_name: str
+    path: str
+    category_path: str
+    kind: str
+    size: int
+
+
+class DataTypeSearchResults(BaseModel):
+    data_types: list[DataTypeReference]
+    total_matches: int
+
+
+class HeaderImportResponse(BaseModel):
+    binary_name: str
+    header_path: str
+    category_root: str
+    validate_only: bool = False
+    resolved_local_includes: list[str]
+    resolved_system_includes: list[str]
+    created_types: list[str]
+    updated_types: list[str]
+    created_type_refs: list[DataTypeReference] = Field(default_factory=list)
+    updated_type_refs: list[DataTypeReference] = Field(default_factory=list)
+    diagnostics: list[HeaderImportDiagnostic]
+
+
+class DataTypeFieldInfo(BaseModel):
+    ordinal: int
+    offset: int
+    length: int
+    field_name: str
+    type_name: str
+    type_path: str | None = None
+    comment: str | None = None
+
+
+class DataTypeDescriptionResponse(BaseModel):
+    binary_name: str
+    requested_name_or_path: str
+    name: str
+    display_name: str
+    path: str
+    category_path: str
+    kind: str
+    size: int
+    aligned_size: int
+    description: str | None = None
+    base_type_name: str | None = None
+    base_type_path: str | None = None
+    base_type_kind: str | None = None
+    fields: list[DataTypeFieldInfo]
+
+
 class GotoResponse(BaseModel):
     binary_name: str
     address: str
@@ -91,7 +152,29 @@ class VariableTypeResponse(BaseModel):
     variable_kind: str
     variable_name: str
     old_type: str
+    old_type_path: str | None = None
     new_type: str
+    new_type_path: str | None = None
+
+
+class FunctionReturnTypeResponse(BaseModel):
+    binary_name: str
+    function_name: str
+    function_address: str
+    old_return_type: str
+    old_return_type_path: str | None = None
+    new_return_type: str
+    new_return_type_path: str | None = None
+
+
+class DataTypeAtAddressResponse(BaseModel):
+    binary_name: str
+    address: str
+    old_type: str | None = None
+    old_type_path: str | None = None
+    new_type: str
+    new_type_path: str | None = None
+    length: int
 
 
 class FunctionPrototypeResponse(BaseModel):

--- a/src/pyghidra_mcp/server.py
+++ b/src/pyghidra_mcp/server.py
@@ -54,6 +54,8 @@ def register_common_tools(server: FastMCP) -> None:
     server.tool()(mcp_tools.rename_variable)
     server.tool()(mcp_tools.set_variable_type)
     server.tool()(mcp_tools.set_function_prototype)
+    server.tool()(mcp_tools.set_function_return_type)
+    server.tool()(mcp_tools.set_data_type_at_address)
     server.tool()(mcp_tools.set_comment)
     server.tool()(mcp_tools.delete_project_binary)
     server.tool()(mcp_tools.list_exports)
@@ -62,6 +64,9 @@ def register_common_tools(server: FastMCP) -> None:
     server.tool()(mcp_tools.search_strings)
     server.tool()(mcp_tools.read_bytes)
     server.tool()(mcp_tools.gen_callgraph)
+    server.tool()(mcp_tools.import_header_types)
+    server.tool()(mcp_tools.list_data_types)
+    server.tool()(mcp_tools.describe_data_type)
     server.tool()(mcp_tools.import_binary)
 
 

--- a/src/pyghidra_mcp/tools.py
+++ b/src/pyghidra_mcp/tools.py
@@ -82,28 +82,34 @@ class GhidraTools:
         self,
         function_name_or_address: str,
         variable_name: str,
+        variable_kind: typing.Literal["parameter", "local"] | None = None,
     ) -> tuple["Function", str, typing.Any]:
         func = self.find_function(function_name_or_address)
         function_name = str(func.getName())
 
         matches: list[tuple[str, typing.Any]] = []
-        for param in func.getParameters():
-            if str(param.getName()) == variable_name:
-                matches.append(("parameter", param))
-        for local in func.getLocalVariables():
-            if str(local.getName()) == variable_name:
-                matches.append(("local", local))
+        if variable_kind in {None, "parameter"}:
+            for param in func.getParameters():
+                if str(param.getName()) == variable_name:
+                    matches.append(("parameter", param))
+        if variable_kind in {None, "local"}:
+            for local in func.getLocalVariables():
+                if str(local.getName()) == variable_name:
+                    matches.append(("local", local))
 
         if not matches:
-            raise ValueError(f"Variable '{variable_name}' not found in function '{function_name}'.")
+            qualifier = f" {variable_kind}" if variable_kind else ""
+            raise ValueError(
+                f"Variable{qualifier} '{variable_name}' not found in function '{function_name}'."
+            )
         if len(matches) > 1:
             kinds = ", ".join(kind for kind, _ in matches)
             raise ValueError(
                 f"Ambiguous variable '{variable_name}' in function '{function_name}' ({kinds})."
             )
 
-        variable_kind, variable = matches[0]
-        return func, variable_kind, variable
+        resolved_variable_kind, variable = matches[0]
+        return func, resolved_variable_kind, variable
 
     def _parse_data_type(self, type_name: str):
         from ghidra.util.data import DataTypeParser  # type: ignore
@@ -112,6 +118,122 @@ class GhidraTools:
         dtm = self.program.getDataTypeManager()
         parser = DataTypeParser(dtm, dtm, typing.cast(typing.Any, None), AllowedDataTypes.DYNAMIC)
         return parser.parse(type_name)
+
+    def _iter_values(self, values):
+        if hasattr(values, "hasNext") and hasattr(values, "next"):
+            while values.hasNext():
+                yield values.next()
+            return
+        yield from values
+
+    def _data_type_path(self, data_type) -> str:
+        return str(data_type.getPathName())
+
+    def _data_type_category_path(self, data_type) -> str:
+        return str(data_type.getCategoryPath().getPath())
+
+    def _data_type_kind(self, data_type) -> str:
+        class_name = data_type.__class__.__name__.lower()
+        if "typedef" in class_name or (
+            hasattr(data_type, "getBaseDataType") and not hasattr(data_type, "getDefinedComponents")
+        ):
+            return "typedef"
+        if "structure" in class_name or class_name.startswith("struct"):
+            return "structure"
+        if "union" in class_name:
+            return "union"
+        if hasattr(data_type, "getDefinedComponents"):
+            return "composite"
+        if "enum" in class_name:
+            return "enum"
+        if "pointer" in class_name:
+            return "pointer"
+        if "array" in class_name:
+            return "array"
+        if "functiondefinition" in class_name or "functiondef" in class_name:
+            return "function_definition"
+        return class_name
+
+    def _data_type_size(self, data_type) -> int:
+        return int(data_type.getLength())
+
+    def _data_type_aligned_size(self, data_type) -> int:
+        aligned_length = getattr(data_type, "getAlignedLength", None)
+        if callable(aligned_length):
+            return int(aligned_length())
+        return self._data_type_size(data_type)
+
+    def _unwrap_typedef(self, data_type):
+        if self._data_type_kind(data_type) != "typedef":
+            return None
+        base_type = getattr(data_type, "getBaseDataType", None)
+        if callable(base_type):
+            return base_type()
+        data_type_getter = getattr(data_type, "getDataType", None)
+        if callable(data_type_getter):
+            return data_type_getter()
+        return None
+
+    def _serialize_data_type_field(self, component) -> dict:
+        field_type = component.getDataType()
+        field_name = component.getFieldName()
+        default_field_name = getattr(component, "getDefaultFieldName", None)
+        if field_name is None and callable(default_field_name):
+            field_name = default_field_name()
+        comment = component.getComment()
+        return {
+            "ordinal": int(component.getOrdinal()),
+            "offset": int(component.getOffset()),
+            "length": int(component.getLength()),
+            "field_name": "" if field_name is None else str(field_name),
+            "type_name": str(field_type.getDisplayName()),
+            "type_path": self._data_type_path(field_type),
+            "comment": None if comment is None else str(comment),
+        }
+
+    def _serialize_data_type_reference(self, data_type) -> dict:
+        return {
+            "name": str(data_type.getName()),
+            "display_name": str(data_type.getDisplayName()),
+            "path": self._data_type_path(data_type),
+            "category_path": self._data_type_category_path(data_type),
+            "kind": self._data_type_kind(data_type),
+            "size": self._data_type_size(data_type),
+        }
+
+    def _resolve_data_type(self, data_type_name_or_path: str):
+        dtm = self.program.getDataTypeManager()
+        all_data_types = list(self._iter_values(dtm.getAllDataTypes()))
+
+        if data_type_name_or_path.startswith("/"):
+            for data_type in all_data_types:
+                if self._data_type_path(data_type) == data_type_name_or_path:
+                    return data_type
+            raise ValueError(f"Data type '{data_type_name_or_path}' not found.")
+
+        matches = [
+            data_type
+            for data_type in all_data_types
+            if str(data_type.getName()) == data_type_name_or_path
+        ]
+        if not matches:
+            raise ValueError(f"Data type '{data_type_name_or_path}' not found.")
+        if len(matches) > 1:
+            candidates = ", ".join(sorted(self._data_type_path(data_type) for data_type in matches))
+            raise ValueError(
+                f"Ambiguous data type '{data_type_name_or_path}'. Matching paths: {candidates}"
+            )
+        return matches[0]
+
+    def _resolve_or_parse_data_type(self, type_name_or_path: str):
+        if type_name_or_path.startswith("/"):
+            return self._resolve_data_type(type_name_or_path)
+        try:
+            return self._resolve_data_type(type_name_or_path)
+        except ValueError as exact_error:
+            if "Ambiguous data type" in str(exact_error):
+                raise
+            return self._parse_data_type(type_name_or_path)
 
     def _lookup_functions(
         self,
@@ -945,31 +1067,36 @@ class GhidraTools:
         function_name_or_address: str,
         variable_name: str,
         type_name: str,
+        variable_kind: typing.Literal["parameter", "local"] | None = None,
     ) -> dict:
         from ghidra.program.model.symbol import SourceType
 
-        func, variable_kind, variable = self._resolve_function_variable(
-            function_name_or_address, variable_name
+        func, resolved_variable_kind, variable = self._resolve_function_variable(
+            function_name_or_address, variable_name, variable_kind
         )
         function_name = str(func.getName())
         function_address = str(func.getEntryPoint())
-        old_type = str(variable.getDataType().getDisplayName())
-        data_type = self._parse_data_type(type_name)
+        old_data_type = variable.getDataType()
+        old_type = str(old_data_type.getDisplayName())
+        data_type = self._resolve_or_parse_data_type(type_name)
 
         with ghidra_transaction(
             self.program,
-            f"pyghidra-mcp: set {variable_kind} type {variable_name} -> {type_name}",
+            f"pyghidra-mcp: set {resolved_variable_kind} type {variable_name} -> {type_name}",
         ):
             variable.setDataType(data_type, SourceType.USER_DEFINED)
 
         self.invalidate_decompiler_cache()
+        new_data_type = variable.getDataType()
         return {
             "function_name": function_name,
             "function_address": function_address,
-            "variable_kind": variable_kind,
+            "variable_kind": resolved_variable_kind,
             "variable_name": str(variable.getName()),
             "old_type": old_type,
-            "new_type": str(variable.getDataType().getDisplayName()),
+            "old_type_path": self._data_type_path(old_data_type),
+            "new_type": str(new_data_type.getDisplayName()),
+            "new_type_path": self._data_type_path(new_data_type),
         }
 
     @handle_exceptions
@@ -1012,6 +1139,104 @@ class GhidraTools:
             "function_address": function_address,
             "old_prototype": old_prototype,
             "new_prototype": str(func.getSignature()),
+        }
+
+    @handle_exceptions
+    def set_function_return_type(
+        self,
+        function_name_or_address: str,
+        type_name_or_path: str,
+    ) -> dict:
+        from ghidra.program.model.symbol import SourceType
+
+        func = self.find_function(function_name_or_address)
+        function_name = str(func.getName())
+        function_address = str(func.getEntryPoint())
+        old_return_type = func.getReturnType()
+        new_return_type = self._resolve_or_parse_data_type(type_name_or_path)
+
+        with ghidra_transaction(
+            self.program,
+            f"pyghidra-mcp: set function return type {function_name} -> {type_name_or_path}",
+        ):
+            func.setReturnType(new_return_type, SourceType.USER_DEFINED)
+
+        self.invalidate_decompiler_cache()
+        applied_return_type = func.getReturnType()
+        return {
+            "function_name": function_name,
+            "function_address": function_address,
+            "old_return_type": str(old_return_type.getDisplayName()),
+            "old_return_type_path": self._data_type_path(old_return_type),
+            "new_return_type": str(applied_return_type.getDisplayName()),
+            "new_return_type_path": self._data_type_path(applied_return_type),
+        }
+
+    def _address_add(self, address, offset: int):
+        add_no_wrap = getattr(address, "addNoWrap", None)
+        if callable(add_no_wrap):
+            return add_no_wrap(offset)
+        return address.add(offset)
+
+    def _validate_data_range(self, mem, start_addr, end_addr, requested_address: str) -> None:
+        if not mem.contains(start_addr):
+            raise ValueError(f"Address {requested_address} is not in mapped memory")
+        if not mem.contains(end_addr):
+            raise ValueError(f"Data type range {start_addr}..{end_addr} is not fully mapped")
+
+        get_block = getattr(mem, "getBlock", None)
+        if not callable(get_block):
+            return
+        start_block = get_block(start_addr)
+        end_block = get_block(end_addr)
+        if start_block is None or end_block is None:
+            raise ValueError(f"Data type range {start_addr}..{end_addr} is not fully mapped")
+        if start_block != end_block:
+            raise ValueError(f"Data type range {start_addr}..{end_addr} crosses memory blocks")
+
+    @handle_exceptions
+    def set_data_type_at_address(
+        self,
+        address: str,
+        type_name_or_path: str,
+        clear_existing: bool = True,
+    ) -> dict:
+        addr = self._parse_address(address)
+        mem = self.program.getMemory()
+        listing = self.program.getListing()
+        old_data = listing.getDefinedDataAt(addr)
+        old_data_type = old_data.getDataType() if old_data is not None else None
+        data_type = self._resolve_or_parse_data_type(type_name_or_path)
+        length = self._data_type_size(data_type)
+        if length <= 0:
+            length = int(self.program.getDefaultPointerSize())
+        if length <= 0:
+            raise ValueError(f"Data type '{type_name_or_path}' has non-positive length {length}")
+        try:
+            end_addr = self._address_add(addr, length - 1)
+        except Exception as exc:
+            raise ValueError(
+                f"Data type '{type_name_or_path}' of length {length} does not fit at address {addr}"
+            ) from exc
+        self._validate_data_range(mem, addr, end_addr, address)
+
+        with ghidra_transaction(
+            self.program,
+            f"pyghidra-mcp: set data type at {addr} -> {type_name_or_path}",
+        ):
+            if clear_existing:
+                listing.clearCodeUnits(addr, end_addr, False)
+            data = listing.createData(addr, data_type)
+
+        self.invalidate_decompiler_cache()
+        new_data_type = data.getDataType()
+        return {
+            "address": str(addr),
+            "old_type": None if old_data_type is None else str(old_data_type.getDisplayName()),
+            "old_type_path": None if old_data_type is None else self._data_type_path(old_data_type),
+            "new_type": str(new_data_type.getDisplayName()),
+            "new_type_path": self._data_type_path(new_data_type),
+            "length": int(data.getLength()),
         }
 
     @handle_exceptions
@@ -1072,6 +1297,206 @@ class GhidraTools:
             "address": str(addr),
             "comment": comment,
             "comment_type": normalized_type,
+        }
+
+    def _is_builtin_data_type(self, data_type) -> bool:
+        category_path = self._data_type_category_path(data_type).lower()
+        return category_path in {"/builtin", "/builtins", "/built-in"} or category_path.startswith(
+            ("/builtin/", "/builtins/", "/built-in/")
+        )
+
+    def _data_type_in_category_subtree(self, data_type, root: str) -> bool:
+        path = self._data_type_category_path(data_type)
+        return path == root or path.startswith(f"{root}/")
+
+    def _include_data_type_by_default(self, data_type, include_builtins: bool) -> bool:
+        from pyghidra_mcp.header_import import CANONICAL_CATEGORY_ROOT
+
+        if self._data_type_in_category_subtree(data_type, CANONICAL_CATEGORY_ROOT):
+            return True
+        if include_builtins:
+            return True
+        category_path = self._data_type_category_path(data_type)
+        return category_path not in {"", "/"} and not self._is_builtin_data_type(data_type)
+
+    def _data_type_matches_query(self, data_type, query: str) -> bool:
+        searchable = (
+            str(data_type.getName()),
+            str(data_type.getDisplayName()),
+            self._data_type_path(data_type),
+        )
+        return any(self._matches_query(query, value) for value in searchable)
+
+    @handle_exceptions
+    def list_data_types(
+        self,
+        query: str = ".*",
+        category_path: str | None = None,
+        include_builtins: bool = False,
+        offset: int = 0,
+        limit: int = 50,
+    ) -> dict:
+        if offset < 0:
+            raise ValueError("offset must be >= 0")
+        if limit < 0:
+            raise ValueError("limit must be >= 0")
+
+        matches = []
+        for data_type in self._iter_values(self.program.getDataTypeManager().getAllDataTypes()):
+            if category_path is not None and not self._data_type_in_category_subtree(
+                data_type, category_path
+            ):
+                continue
+            if category_path is None and not self._include_data_type_by_default(
+                data_type, include_builtins
+            ):
+                continue
+            if not self._data_type_matches_query(data_type, query):
+                continue
+            matches.append(data_type)
+
+        matches.sort(key=lambda data_type: self._data_type_path(data_type).lower())
+        paged_matches = matches[offset : offset + limit]
+        return {
+            "data_types": [
+                self._serialize_data_type_reference(data_type) for data_type in paged_matches
+            ],
+            "total_matches": len(matches),
+        }
+
+    @handle_exceptions
+    def describe_data_type(self, data_type_name_or_path: str) -> dict:
+        if not data_type_name_or_path:
+            raise ValueError("data_type_name_or_path is required.")
+
+        data_type = self._resolve_data_type(data_type_name_or_path)
+        kind = self._data_type_kind(data_type)
+        base_type = self._unwrap_typedef(data_type)
+        effective_type = base_type or data_type
+        fields: list[dict] = []
+
+        if hasattr(effective_type, "getDefinedComponents"):
+            fields = [
+                self._serialize_data_type_field(component)
+                for component in effective_type.getDefinedComponents()
+            ]
+
+        response = {
+            "requested_name_or_path": data_type_name_or_path,
+            "name": str(data_type.getName()),
+            "display_name": str(data_type.getDisplayName()),
+            "path": self._data_type_path(data_type),
+            "category_path": self._data_type_category_path(data_type),
+            "kind": kind,
+            "size": self._data_type_size(data_type),
+            "aligned_size": self._data_type_aligned_size(data_type),
+            "description": str(data_type.getDescription()) if data_type.getDescription() else None,
+            "base_type_name": None,
+            "base_type_path": None,
+            "base_type_kind": None,
+            "fields": fields,
+        }
+
+        if base_type is not None:
+            response.update(
+                {
+                    "base_type_name": str(base_type.getDisplayName()),
+                    "base_type_path": self._data_type_path(base_type),
+                    "base_type_kind": self._data_type_kind(base_type),
+                }
+            )
+
+        return response
+
+    @handle_exceptions
+    def import_header_types(
+        self,
+        header_path: str | None = None,
+        validate_only: bool = False,
+        *,
+        header_content: str | None = None,
+        header_name: str | None = None,
+        include_files: dict[str, str] | None = None,
+        header_files: list[dict[str, str]] | None = None,
+    ) -> dict:
+        from pyghidra_mcp.header_import import CANONICAL_CATEGORY_ROOT, apply_header_import_plan
+        from pyghidra_mcp.header_import.planning import (
+            build_header_import_plan,
+            build_header_import_plan_from_files,
+            build_header_import_plan_from_source,
+            translate_header_path,
+        )
+
+        mode_count = sum(
+            mode_enabled
+            for mode_enabled in (
+                header_path is not None,
+                header_content is not None,
+                header_files is not None,
+            )
+        )
+        if mode_count != 1:
+            raise ValueError("Use exactly one of header_path, header_content, or header_files")
+
+        if header_files is not None:
+            if header_name is not None or include_files is not None:
+                raise ValueError(
+                    "header_files cannot be combined with header_name or include_files"
+                )
+            plan = build_header_import_plan_from_files(header_files)
+        elif header_content is not None:
+            plan = build_header_import_plan_from_source(
+                header_content,
+                header_name=header_name or "input.h",
+                include_files=include_files,
+            )
+        else:
+            if not header_path:
+                raise ValueError("header_path is required")
+            plan = build_header_import_plan(translate_header_path(header_path))
+        diagnostics = [
+            {
+                "severity": diagnostic.severity,
+                "message": diagnostic.message,
+                "location": diagnostic.location,
+            }
+            for diagnostic in plan.diagnostics
+        ]
+
+        if validate_only:
+            return {
+                "header_path": str(plan.header_path),
+                "category_root": CANONICAL_CATEGORY_ROOT,
+                "validate_only": True,
+                "resolved_local_includes": [str(path) for path in plan.resolved_local_includes],
+                "resolved_system_includes": list(plan.resolved_system_includes),
+                "created_types": [],
+                "updated_types": [],
+                "created_type_refs": [],
+                "updated_type_refs": [],
+                "diagnostics": diagnostics,
+            }
+
+        with ghidra_transaction(self.program, "Import header types"):
+            apply_result = apply_header_import_plan(self.program, plan)
+        self.invalidate_decompiler_cache()
+
+        def serialize_paths(paths: tuple[str, ...]) -> list[dict]:
+            return [
+                self._serialize_data_type_reference(self._resolve_data_type(path)) for path in paths
+            ]
+
+        return {
+            "header_path": str(plan.header_path),
+            "category_root": apply_result.category_root,
+            "validate_only": False,
+            "resolved_local_includes": [str(path) for path in plan.resolved_local_includes],
+            "resolved_system_includes": list(plan.resolved_system_includes),
+            "created_types": list(apply_result.created_types),
+            "updated_types": list(apply_result.updated_types),
+            "created_type_refs": serialize_paths(apply_result.created_type_paths),
+            "updated_type_refs": serialize_paths(apply_result.updated_type_paths),
+            "diagnostics": diagnostics,
         }
 
     def invalidate_decompiler_cache(self) -> None:

--- a/tests/integration/test_import_header_types.py
+++ b/tests/integration/test_import_header_types.py
@@ -1,0 +1,155 @@
+import json
+
+import pytest
+from mcp import ClientSession
+from mcp.client.stdio import stdio_client
+
+
+@pytest.mark.asyncio
+async def test_import_header_types_creates_types_and_allows_prototype_use(
+    server_params_shared_object,
+    tmp_path,
+    func_prefix,
+):
+    header_path = tmp_path / "reviewed_types.h"
+    header_path.write_text(
+        """
+        #pragma once
+        #include <stdint.h>
+
+        typedef uint32_t Word;
+
+        /* size=0x10 */
+        typedef struct Node {
+            /* 0x000 */ struct Node *next;
+            /* 0x008 */ Word value;
+        } Node;
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    async with stdio_client(server_params_shared_object) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            binary_response = await session.call_tool("list_project_binaries", {})
+            programs = json.loads(binary_response.content[0].text)["programs"]
+            binary_name = programs[0]["name"]
+
+            content_validate_response = await session.call_tool(
+                "import_header_types",
+                {
+                    "binary_name": binary_name,
+                    "header_name": "api_types.h",
+                    "header_content": "#include <stdint.h>\ntypedef uint32_t ApiWord;\n/* size=0x8 */ typedef struct ApiNode { /* 0x000 */ ApiWord value; } ApiNode;",
+                    "validate_only": True,
+                },
+            )
+            content_validate_payload = json.loads(content_validate_response.content[0].text)
+            assert content_validate_payload["header_path"] == "api_types.h"
+            assert content_validate_payload["validate_only"] is True
+            assert content_validate_payload["diagnostics"] == []
+
+            import_response = await session.call_tool(
+                "import_header_types",
+                {
+                    "binary_name": binary_name,
+                    "header_path": str(header_path),
+                },
+            )
+            import_payload = json.loads(import_response.content[0].text)
+
+            assert import_payload["binary_name"] == binary_name
+            assert import_payload["category_root"] == "/pyghidra_mcp/imported_headers"
+            assert "Node" in import_payload["created_types"] or "Node" in import_payload["updated_types"]
+            assert "Word" in import_payload["created_types"] or "Word" in import_payload["updated_types"]
+            assert import_payload["diagnostics"] == []
+            type_refs = import_payload["created_type_refs"] + import_payload["updated_type_refs"]
+            node_path = next(ref["path"] for ref in type_refs if ref["name"] == "Node")
+            word_path = next(ref["path"] for ref in type_refs if ref["name"] == "Word")
+            assert node_path == "/pyghidra_mcp/imported_headers/Node"
+
+            list_response = await session.call_tool(
+                "list_data_types",
+                {
+                    "binary_name": binary_name,
+                    "query": "Node",
+                    "category_path": "/pyghidra_mcp/imported_headers",
+                },
+            )
+            list_payload = json.loads(list_response.content[0].text)
+            assert any(ref["path"] == node_path for ref in list_payload["data_types"])
+
+            node_response = await session.call_tool(
+                "describe_data_type",
+                {
+                    "binary_name": binary_name,
+                    "data_type_name_or_path": "Node",
+                },
+            )
+            node_payload = json.loads(node_response.content[0].text)
+            assert node_payload["binary_name"] == binary_name
+            assert node_payload["path"] == "/pyghidra_mcp/imported_headers/Node"
+            assert node_payload["kind"] == "structure"
+            assert node_payload["fields"][0]["field_name"] == "next"
+            assert node_payload["fields"][0]["offset"] == 0
+            assert node_payload["fields"][1]["field_name"] == "value"
+            assert node_payload["fields"][1]["offset"] == 8
+
+            word_response = await session.call_tool(
+                "describe_data_type",
+                {
+                    "binary_name": binary_name,
+                    "data_type_name_or_path": "Word",
+                },
+            )
+            word_payload = json.loads(word_response.content[0].text)
+            assert word_payload["path"] == "/pyghidra_mcp/imported_headers/Word"
+            assert word_payload["fields"] == []
+
+            node_path_response = await session.call_tool(
+                "describe_data_type",
+                {
+                    "binary_name": binary_name,
+                    "data_type_name_or_path": node_path,
+                },
+            )
+            node_path_payload = json.loads(node_path_response.content[0].text)
+            assert node_path_payload["path"] == node_path
+
+            function_name = f"{func_prefix}shared_func_two"
+            prototype_response = await session.call_tool(
+                "set_function_prototype",
+                {
+                    "binary_name": binary_name,
+                    "function_name_or_address": function_name,
+                    "prototype": f"void {function_name}(Node *node)",
+                },
+            )
+            prototype_payload = json.loads(prototype_response.content[0].text)
+            assert "Node * node" in prototype_payload["new_prototype"]
+
+            variable_type_response = await session.call_tool(
+                "set_variable_type",
+                {
+                    "binary_name": binary_name,
+                    "function_name_or_address": function_name,
+                    "variable_name": "node",
+                    "type_name": node_path,
+                    "variable_kind": "parameter",
+                },
+            )
+            variable_type_payload = json.loads(variable_type_response.content[0].text)
+            assert variable_type_payload["new_type_path"] == node_path
+
+            return_type_response = await session.call_tool(
+                "set_function_return_type",
+                {
+                    "binary_name": binary_name,
+                    "function_name_or_address": function_name,
+                    "type_name_or_path": word_path,
+                },
+            )
+            return_type_payload = json.loads(return_type_response.content[0].text)
+            assert return_type_payload["new_return_type_path"] == word_path

--- a/tests/integration/test_stdio_client.py
+++ b/tests/integration/test_stdio_client.py
@@ -32,6 +32,7 @@ async def test_stdio_client_list_tools(server_params):
             # Check that we have at least the decompile_function tool
             assert any(tool.name == "decompile_function" for tool in tools.tools)
             assert any(tool.name == "list_project_binaries" for tool in tools.tools)
+            assert any(tool.name == "describe_data_type" for tool in tools.tools)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_describe_data_type.py
+++ b/tests/unit/test_describe_data_type.py
@@ -1,0 +1,328 @@
+import sys
+import types
+from unittest.mock import Mock
+
+import pytest
+
+from pyghidra_mcp.tools import GhidraTools
+
+
+class FakeCategoryPath:
+    def __init__(self, path: str):
+        self._path = path
+
+    def getPath(self) -> str:
+        return self._path
+
+
+class BuiltinDataType:
+    def __init__(self, name: str, path: str, length: int):
+        self._name = name
+        self._path = path
+        self._length = length
+
+    def getName(self) -> str:
+        return self._name
+
+    def getDisplayName(self) -> str:
+        return self._name
+
+    def getPathName(self) -> str:
+        return self._path
+
+    def getCategoryPath(self):
+        category = self._path.rsplit("/", 1)[0] or "/"
+        return FakeCategoryPath(category)
+
+    def getLength(self) -> int:
+        return self._length
+
+    def getAlignedLength(self) -> int:
+        return self._length
+
+    def getDescription(self) -> str:
+        return ""
+
+
+class PointerDataType(BuiltinDataType):
+    pass
+
+
+class FakeDataTypeComponent:
+    def __init__(
+        self,
+        ordinal: int,
+        offset: int,
+        length: int,
+        field_name: str,
+        data_type,
+        comment: str | None = None,
+    ):
+        self._ordinal = ordinal
+        self._offset = offset
+        self._length = length
+        self._field_name = field_name
+        self._data_type = data_type
+        self._comment = comment
+
+    def getOrdinal(self) -> int:
+        return self._ordinal
+
+    def getOffset(self) -> int:
+        return self._offset
+
+    def getLength(self) -> int:
+        return self._length
+
+    def getFieldName(self) -> str:
+        return self._field_name
+
+    def getDefaultFieldName(self) -> str:
+        return self._field_name
+
+    def getDataType(self):
+        return self._data_type
+
+    def getComment(self) -> str | None:
+        return self._comment
+
+
+class StructureDataType(BuiltinDataType):
+    def __init__(self, name: str, path: str, length: int, components):
+        super().__init__(name, path, length)
+        self._components = components
+
+    def getDefinedComponents(self):
+        return list(self._components)
+
+    def getDescription(self) -> str:
+        return f"structure {self._name}"
+
+
+class TypedefDataType(BuiltinDataType):
+    def __init__(self, name: str, path: str, length: int, base_type):
+        super().__init__(name, path, length)
+        self._base_type = base_type
+
+    def getBaseDataType(self):
+        return self._base_type
+
+
+class FakeIterator:
+    def __init__(self, values):
+        self._values = list(values)
+        self._index = 0
+
+    def hasNext(self) -> bool:
+        return self._index < len(self._values)
+
+    def next(self):
+        value = self._values[self._index]
+        self._index += 1
+        return value
+
+
+class FakeDataTypeManager:
+    def __init__(self, data_types):
+        self._data_types = list(data_types)
+
+    def getAllDataTypes(self):
+        return FakeIterator(self._data_types)
+
+
+def _make_tools(*data_types: object) -> GhidraTools:
+    program = Mock()
+    program.getDataTypeManager.return_value = FakeDataTypeManager(data_types)
+    program_info = Mock()
+    program_info.program = program
+    program_info.decompiler_pool = Mock()
+    return GhidraTools(program_info)
+
+
+def test_describe_data_type_by_exact_name_returns_field_layout():
+    int_type = BuiltinDataType("int", "/builtin/int", 4)
+    node_type = StructureDataType(
+        "Node",
+        "/pyghidra_mcp/imported_headers/Node",
+        16,
+        [
+            FakeDataTypeComponent(0, 0, 8, "next", PointerDataType("Node *", "/builtin/NodePtr", 8)),
+            FakeDataTypeComponent(1, 8, 4, "value", int_type, "payload"),
+        ],
+    )
+    tools = _make_tools(node_type)
+
+    response = tools.describe_data_type("Node")
+
+    assert response["name"] == "Node"
+    assert response["kind"] == "structure"
+    assert response["path"] == "/pyghidra_mcp/imported_headers/Node"
+    assert response["fields"][0]["field_name"] == "next"
+    assert response["fields"][0]["offset"] == 0
+    assert response["fields"][1]["field_name"] == "value"
+    assert response["fields"][1]["type_name"] == "int"
+    assert response["fields"][1]["comment"] == "payload"
+
+
+def test_describe_data_type_rejects_ambiguous_exact_name():
+    first = BuiltinDataType("Node", "/types/Node", 4)
+    second = BuiltinDataType("Node", "/other/Node", 8)
+    tools = _make_tools(first, second)
+
+    with pytest.raises(ValueError, match="Ambiguous data type 'Node'"):
+        tools.describe_data_type("Node")
+
+
+def test_describe_data_type_typedef_reports_base_type_and_fields():
+    word_type = BuiltinDataType("Word", "/pyghidra_mcp/imported_headers/Word", 4)
+    runtime_struct = StructureDataType(
+        "Runtime",
+        "/pyghidra_mcp/imported_headers/Runtime",
+        8,
+        [FakeDataTypeComponent(0, 0, 4, "value", word_type)],
+    )
+    runtime_alias = TypedefDataType(
+        "RuntimeAlias",
+        "/pyghidra_mcp/imported_headers/RuntimeAlias",
+        8,
+        runtime_struct,
+    )
+    tools = _make_tools(runtime_alias)
+
+    response = tools.describe_data_type("/pyghidra_mcp/imported_headers/RuntimeAlias")
+
+    assert response["name"] == "RuntimeAlias"
+    assert response["kind"] == "typedef"
+    assert response["base_type_name"] == "Runtime"
+    assert response["base_type_path"] == "/pyghidra_mcp/imported_headers/Runtime"
+    assert response["base_type_kind"] == "structure"
+    assert response["fields"][0]["field_name"] == "value"
+
+
+def test_resolve_or_parse_data_type_resolves_full_path_first():
+    node_type = StructureDataType("Node", "/pyghidra_mcp/imported_headers/Node", 16, [])
+    tools = _make_tools(node_type)
+    tools._parse_data_type = Mock(side_effect=AssertionError("parser should not be used"))
+
+    result = tools._resolve_or_parse_data_type("/pyghidra_mcp/imported_headers/Node")
+
+    assert result is node_type
+
+
+def test_resolve_or_parse_data_type_preserves_ambiguous_name_error():
+    first = BuiltinDataType("Node", "/types/Node", 4)
+    second = BuiltinDataType("Node", "/other/Node", 8)
+    tools = _make_tools(first, second)
+    tools._parse_data_type = Mock(side_effect=AssertionError("parser should not be used"))
+
+    with pytest.raises(ValueError, match="Matching paths: /other/Node, /types/Node"):
+        tools._resolve_or_parse_data_type("Node")
+
+
+def test_resolve_or_parse_data_type_falls_back_to_parser_for_declarators():
+    parsed_type = PointerDataType("Node *", "/builtin/NodePtr", 8)
+    tools = _make_tools()
+    tools._parse_data_type = Mock(return_value=parsed_type)
+
+    result = tools._resolve_or_parse_data_type("Node *")
+
+    assert result is parsed_type
+    tools._parse_data_type.assert_called_once_with("Node *")
+
+
+def test_list_data_types_filters_by_category_query_and_paginates():
+    node_type = StructureDataType("Node", "/pyghidra_mcp/imported_headers/Node", 16, [])
+    word_type = TypedefDataType("Word", "/pyghidra_mcp/imported_headers/Word", 4, node_type)
+    builtin_type = BuiltinDataType("int", "/builtin/int", 4)
+    tools = _make_tools(word_type, builtin_type, node_type)
+
+    response = tools.list_data_types(
+        query="node|word",
+        category_path="/pyghidra_mcp/imported_headers",
+        offset=1,
+        limit=1,
+    )
+
+    assert response["total_matches"] == 2
+    assert [data_type["path"] for data_type in response["data_types"]] == [
+        "/pyghidra_mcp/imported_headers/Word"
+    ]
+
+
+def test_list_data_types_default_excludes_builtins_and_includes_project_types():
+    node_type = StructureDataType("Node", "/pyghidra_mcp/imported_headers/Node", 16, [])
+    runtime_type = StructureDataType("Runtime", "/project/Runtime", 8, [])
+    builtin_type = BuiltinDataType("int", "/builtin/int", 4)
+    tools = _make_tools(builtin_type, runtime_type, node_type)
+
+    response = tools.list_data_types(query=".*")
+
+    assert [data_type["path"] for data_type in response["data_types"]] == [
+        "/project/Runtime",
+        "/pyghidra_mcp/imported_headers/Node",
+    ]
+
+
+def _install_fake_source_type(monkeypatch):
+    ghidra = types.ModuleType("ghidra")
+    program = types.ModuleType("ghidra.program")
+    model = types.ModuleType("ghidra.program.model")
+    symbol = types.ModuleType("ghidra.program.model.symbol")
+    symbol.SourceType = types.SimpleNamespace(USER_DEFINED=object())
+    monkeypatch.setitem(sys.modules, "ghidra", ghidra)
+    monkeypatch.setitem(sys.modules, "ghidra.program", program)
+    monkeypatch.setitem(sys.modules, "ghidra.program.model", model)
+    monkeypatch.setitem(sys.modules, "ghidra.program.model.symbol", symbol)
+
+
+class FakeVariable:
+    def __init__(self, name: str, data_type):
+        self._name = name
+        self._data_type = data_type
+
+    def getName(self) -> str:
+        return self._name
+
+    def getDataType(self):
+        return self._data_type
+
+    def setDataType(self, data_type, _source_type):
+        self._data_type = data_type
+
+
+class FakeFunction:
+    def __init__(self, variable):
+        self._variable = variable
+
+    def getName(self) -> str:
+        return "helper"
+
+    def getEntryPoint(self) -> str:
+        return "1000"
+
+    def getParameters(self):
+        return []
+
+    def getLocalVariables(self):
+        return [self._variable]
+
+
+def test_set_variable_type_uses_exact_imported_datatype_path(monkeypatch):
+    _install_fake_source_type(monkeypatch)
+    int_type = BuiltinDataType("int", "/builtin/int", 4)
+    node_type = StructureDataType("Node", "/pyghidra_mcp/imported_headers/Node", 16, [])
+    variable = FakeVariable("node", int_type)
+    tools = _make_tools(node_type, int_type)
+    tools.find_function = Mock(return_value=FakeFunction(variable))
+
+    response = tools.set_variable_type(
+        "helper",
+        "node",
+        "/pyghidra_mcp/imported_headers/Node",
+        variable_kind="local",
+    )
+
+    assert variable.getDataType() is node_type
+    assert response["old_type_path"] == "/builtin/int"
+    assert response["new_type_path"] == "/pyghidra_mcp/imported_headers/Node"
+    assert response["variable_kind"] == "local"

--- a/tests/unit/test_header_import_apply.py
+++ b/tests/unit/test_header_import_apply.py
@@ -1,0 +1,323 @@
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock
+
+from pyghidra_mcp.header_import.apply import HeaderImportApplyResult, apply_header_import_plan
+from pyghidra_mcp.header_import.ir import BuiltinType, Diagnostic, HeaderImportPlan, TypedefDef
+from pyghidra_mcp.tools import GhidraTools
+
+
+def test_header_import_apply_result_preserves_name_fields_and_defaults_paths():
+    result = HeaderImportApplyResult(
+        category_root="/pyghidra_mcp/imported_headers",
+        created_types=("Node",),
+        updated_types=(),
+    )
+
+    assert result.created_types == ("Node",)
+    assert result.created_type_paths == ()
+    assert result.updated_type_paths == ()
+
+
+def test_ghidra_tools_import_header_types_validate_only(monkeypatch, tmp_path):
+    header_path = tmp_path / "sample.h"
+    header_path.write_text("typedef int Value;\n", encoding="utf-8")
+
+    plan = HeaderImportPlan(
+        header_path=header_path,
+        resolved_local_includes=(header_path,),
+        resolved_system_includes=("stdint.h",),
+        diagnostics=(Diagnostic(severity="warning", message="test warning"),),
+    )
+
+    monkeypatch.setattr(
+        "pyghidra_mcp.header_import.planning.build_header_import_plan",
+        lambda _header_path: plan,
+    )
+
+    program_info = Mock()
+    program_info.program = Mock()
+    program_info.decompiler_pool = Mock()
+    tools = GhidraTools(program_info)
+
+    response = tools.import_header_types(str(header_path), validate_only=True)
+
+    assert response["header_path"] == str(header_path)
+    assert response["validate_only"] is True
+    assert response["created_types"] == []
+    assert response["created_type_refs"] == []
+    assert response["updated_type_refs"] == []
+    assert "reused_types" not in response
+    assert "reused_type_refs" not in response
+    assert response["diagnostics"][0]["message"] == "test warning"
+
+
+def test_ghidra_tools_import_header_types_dispatches_content_mode(monkeypatch):
+    plan = HeaderImportPlan(
+        header_path=Path("api_types.h"),
+        resolved_local_includes=(),
+        resolved_system_includes=(),
+        diagnostics=(),
+    )
+    captured = {}
+
+    def fake_build_from_source(header_content, *, header_name, include_files):
+        captured["header_content"] = header_content
+        captured["header_name"] = header_name
+        captured["include_files"] = include_files
+        return plan
+
+    monkeypatch.setattr(
+        "pyghidra_mcp.header_import.planning.build_header_import_plan_from_source",
+        fake_build_from_source,
+    )
+
+    program_info = Mock()
+    program_info.program = Mock()
+    program_info.decompiler_pool = Mock()
+    tools = GhidraTools(program_info)
+
+    response = tools.import_header_types(
+        validate_only=True,
+        header_content="typedef int Count;",
+        header_name="api_types.h",
+        include_files={"shared.h": "typedef int Shared;"},
+    )
+
+    assert captured == {
+        "header_content": "typedef int Count;",
+        "header_name": "api_types.h",
+        "include_files": {"shared.h": "typedef int Shared;"},
+    }
+    assert response["header_path"] == "api_types.h"
+    assert response["validate_only"] is True
+
+
+def test_ghidra_tools_import_header_types_dispatches_file_list_mode(monkeypatch):
+    plan = HeaderImportPlan(
+        header_path=Path("api_types.h"),
+        resolved_local_includes=(),
+        resolved_system_includes=(),
+        diagnostics=(),
+    )
+    captured = {}
+
+    def fake_build_from_files(header_files):
+        captured["header_files"] = header_files
+        return plan
+
+    monkeypatch.setattr(
+        "pyghidra_mcp.header_import.planning.build_header_import_plan_from_files",
+        fake_build_from_files,
+    )
+
+    program_info = Mock()
+    program_info.program = Mock()
+    program_info.decompiler_pool = Mock()
+    tools = GhidraTools(program_info)
+
+    response = tools.import_header_types(
+        validate_only=True,
+        header_files=[
+            {"name": "api_types.h", "content": "typedef int Count;"},
+            {"name": "shared.h", "content": "typedef int Shared;"},
+        ],
+    )
+
+    assert captured == {
+        "header_files": [
+            {"name": "api_types.h", "content": "typedef int Count;"},
+            {"name": "shared.h", "content": "typedef int Shared;"},
+        ]
+    }
+    assert response["header_path"] == "api_types.h"
+    assert response["validate_only"] is True
+
+
+def test_ghidra_tools_import_header_types_applies_plan(monkeypatch, tmp_path):
+    header_path = tmp_path / "sample.h"
+    header_path.write_text("typedef int Value;\n", encoding="utf-8")
+
+    plan = HeaderImportPlan(
+        header_path=header_path,
+        resolved_local_includes=(header_path,),
+        resolved_system_includes=(),
+        diagnostics=(),
+    )
+
+    monkeypatch.setattr(
+        "pyghidra_mcp.header_import.planning.build_header_import_plan",
+        lambda _header_path: plan,
+    )
+    monkeypatch.setattr(
+        "pyghidra_mcp.header_import.apply_header_import_plan",
+        lambda _program, _plan: HeaderImportApplyResult(
+            category_root="/pyghidra_mcp/imported_headers",
+            created_types=("Node",),
+            updated_types=(),
+            created_type_paths=("/pyghidra_mcp/imported_headers/Node",),
+        ),
+    )
+
+    program_info = Mock()
+    program_info.program = Mock()
+    program_info.program.startTransaction.return_value = 42
+    program_info.decompiler_pool = Mock()
+    tools = GhidraTools(program_info)
+    tools.invalidate_decompiler_cache = Mock()
+    tools._resolve_data_type = Mock(side_effect=lambda path: path)
+    tools._serialize_data_type_reference = Mock(
+        side_effect=lambda path: {
+            "name": "Node",
+            "display_name": "Node",
+            "path": path,
+            "category_path": "/pyghidra_mcp/imported_headers",
+            "kind": "structure",
+            "size": 16,
+        }
+    )
+
+    response = tools.import_header_types(str(header_path), validate_only=False)
+
+    assert response["category_root"] == "/pyghidra_mcp/imported_headers"
+    assert response["created_types"] == ["Node"]
+    assert response["created_type_refs"][0]["path"] == "/pyghidra_mcp/imported_headers/Node"
+    program_info.program.startTransaction.assert_called_once_with("Import header types")
+    program_info.program.endTransaction.assert_called_once_with(42, True)
+    tools.invalidate_decompiler_cache.assert_called_once_with()
+
+
+class FakeCategoryPath:
+    def __init__(self, path):
+        self.path = path
+
+    def __str__(self):
+        return self.path
+
+
+class FakeDataTypeConflictHandler:
+    REPLACE_HANDLER = object()
+
+
+class FakeBuiltinDataType:
+    def __init__(self):
+        self.name = self.__class__.__name__
+        self.category = "/builtin"
+
+    def getLength(self):  # noqa: N802
+        return 0
+
+    def getPathName(self):  # noqa: N802
+        return f"{self.category}/{self.name}"
+
+
+class FakeIntegerDataType(FakeBuiltinDataType):
+    pass
+
+
+class FakeLongLongDataType(FakeBuiltinDataType):
+    pass
+
+
+class FakeUnsignedLongLongDataType(FakeBuiltinDataType):
+    pass
+
+
+class FakeTypedefDataType:
+    def __init__(self, category, name, target):
+        self.category = str(category)
+        self.name = name
+        self.target = target
+
+    def getPathName(self):  # noqa: N802
+        return f"{self.category}/{self.name}"
+
+
+class FakeDataTypeManager:
+    def __init__(self):
+        self.added = []
+
+    def getDataType(self, _path):  # noqa: N802
+        return None
+
+    def addDataType(self, data_type, _handler):  # noqa: N802
+        self.added.append(data_type)
+        return data_type
+
+
+class FakeProgramForHeaderApply:
+    def __init__(self, pointer_size):
+        self.pointer_size = pointer_size
+        self.dtm = FakeDataTypeManager()
+
+    def getDataTypeManager(self):  # noqa: N802
+        return self.dtm
+
+    def getDefaultPointerSize(self):  # noqa: N802
+        return self.pointer_size
+
+
+def _install_fake_ghidra_data_module(monkeypatch):
+    ghidra = ModuleType("ghidra")
+    program = ModuleType("ghidra.program")
+    model = ModuleType("ghidra.program.model")
+    data = ModuleType("ghidra.program.model.data")
+    for name in (
+        "ArrayDataType",
+        "ByteDataType",
+        "CharDataType",
+        "DoubleDataType",
+        "EnumDataType",
+        "FloatDataType",
+        "FunctionDefinitionDataType",
+        "ParameterDefinitionImpl",
+        "PointerDataType",
+        "ShortDataType",
+        "StructureDataType",
+        "UnionDataType",
+        "UnsignedCharDataType",
+        "UnsignedIntegerDataType",
+        "UnsignedShortDataType",
+        "VoidDataType",
+    ):
+        setattr(data, name, FakeBuiltinDataType)
+    data.CategoryPath = FakeCategoryPath
+    data.DataTypeConflictHandler = FakeDataTypeConflictHandler
+    data.IntegerDataType = FakeIntegerDataType
+    data.LongLongDataType = FakeLongLongDataType
+    data.UnsignedLongLongDataType = FakeUnsignedLongLongDataType
+    data.TypedefDataType = FakeTypedefDataType
+    monkeypatch.setitem(sys.modules, "ghidra", ghidra)
+    monkeypatch.setitem(sys.modules, "ghidra.program", program)
+    monkeypatch.setitem(sys.modules, "ghidra.program.model", model)
+    monkeypatch.setitem(sys.modules, "ghidra.program.model.data", data)
+
+
+def test_apply_header_import_plan_maps_intptr_t_to_pointer_sized_signed_type(monkeypatch):
+    _install_fake_ghidra_data_module(monkeypatch)
+    plan = HeaderImportPlan(
+        header_path=Path("types.h"),
+        typedefs=(TypedefDef(name="SignedPtr", target=BuiltinType("intptr_t")),),
+    )
+
+    program32 = FakeProgramForHeaderApply(pointer_size=4)
+    apply_header_import_plan(program32, plan)
+    assert isinstance(program32.dtm.added[0].target, FakeIntegerDataType)
+
+    program64 = FakeProgramForHeaderApply(pointer_size=8)
+    apply_header_import_plan(program64, plan)
+    assert isinstance(program64.dtm.added[0].target, FakeLongLongDataType)
+
+
+def test_apply_header_import_plan_keeps_uintptr_t_pointer_sized_unsigned(monkeypatch):
+    _install_fake_ghidra_data_module(monkeypatch)
+    plan = HeaderImportPlan(
+        header_path=Path("types.h"),
+        typedefs=(TypedefDef(name="UnsignedPtr", target=BuiltinType("uintptr_t")),),
+    )
+
+    program64 = FakeProgramForHeaderApply(pointer_size=8)
+    apply_header_import_plan(program64, plan)
+
+    assert isinstance(program64.dtm.added[0].target, FakeUnsignedLongLongDataType)

--- a/tests/unit/test_header_import_planning.py
+++ b/tests/unit/test_header_import_planning.py
@@ -1,0 +1,298 @@
+from pathlib import Path
+
+import pytest
+
+from pyghidra_mcp.header_import.ir import BuiltinType, FunctionType, NamedType, PointerType
+from pyghidra_mcp.header_import.planning import (
+    PlanningError,
+    build_header_import_plan,
+    build_header_import_plan_from_files,
+    build_header_import_plan_from_source,
+    translate_header_path,
+)
+
+
+def _write_header(path: Path, content: str) -> Path:
+    path.write_text(content.strip() + "\n", encoding="utf-8")
+    return path
+
+
+def test_build_header_import_plan_parses_reviewed_header_dialect(tmp_path):
+    header_path = _write_header(
+        tmp_path / "types.h",
+        """
+        #pragma once
+        #include <stdint.h>
+
+        typedef uint64_t Word;
+
+        /*
+         * Intrusive list node.
+         * size=0x10
+         */
+        typedef struct Node {
+            /* 0x000 */ struct Node *next;
+            /* 0x008 */ Word value;
+        } Node;
+        """,
+    )
+
+    plan = build_header_import_plan(header_path)
+
+    assert not plan.has_errors(), plan.error_messages()
+    assert plan.resolved_system_includes == ("stdint.h",)
+    assert plan.resolved_local_includes == (header_path.resolve(),)
+    assert plan.composite_order == ("Node",)
+
+    typedef_word = next(definition for definition in plan.typedefs if definition.name == "Word")
+    assert isinstance(typedef_word.target, BuiltinType)
+    assert typedef_word.target.name == "uint64_t"
+
+    node = next(definition for definition in plan.composites if definition.name == "Node")
+    assert node.size == 0x10
+    assert [field.name for field in node.fields] == ["next", "value"]
+    assert [field.offset for field in node.fields] == [0x0, 0x8]
+    assert isinstance(node.fields[0].type, PointerType)
+    assert isinstance(node.fields[0].type.target, NamedType)
+    assert node.fields[0].type.target.name == "Node"
+
+
+def test_build_header_import_plan_resolves_local_includes_and_function_typedefs(tmp_path):
+    shared_header = _write_header(
+        tmp_path / "shared.h",
+        """
+        #pragma once
+
+        struct Runtime;
+
+        typedef int InterruptHandler(struct Runtime *rt, void *opaque);
+        typedef int (*InterruptThunk)(struct Runtime *rt, void *opaque);
+        """,
+    )
+    root_header = _write_header(
+        tmp_path / "root.h",
+        f"""
+        #pragma once
+        #include \"{shared_header.name}\"
+
+        /* size=0x8 */
+        typedef struct Runtime {{
+            /* 0x000 */ InterruptHandler *handler;
+        }} Runtime;
+        """,
+    )
+
+    plan = build_header_import_plan(root_header)
+
+    assert not plan.has_errors(), plan.error_messages()
+    assert plan.resolved_local_includes == (shared_header.resolve(), root_header.resolve())
+
+    by_name = {definition.name: definition for definition in plan.function_types}
+    assert by_name["InterruptHandler"].pointer_alias is False
+    assert by_name["InterruptThunk"].pointer_alias is True
+
+    runtime = next(definition for definition in plan.composites if definition.name == "Runtime")
+    assert runtime.size == 0x8
+    assert runtime.fields[0].name == "handler"
+    assert runtime.fields[0].offset == 0x0
+
+
+def test_build_header_import_plan_reports_missing_include(tmp_path):
+    header_path = _write_header(
+        tmp_path / "broken.h",
+        """
+        #pragma once
+        #include \"missing.h\"
+        typedef int Count;
+        """,
+    )
+
+    plan = build_header_import_plan(header_path)
+
+    assert plan.has_errors()
+    assert any("Missing local include 'missing.h'" in message for message in plan.error_messages())
+
+
+def test_build_header_import_plan_handles_filesystem_include_cycles(tmp_path):
+    a_header = tmp_path / "a.h"
+    b_header = tmp_path / "b.h"
+    _write_header(
+        a_header,
+        """
+        #pragma once
+        #include "b.h"
+        typedef B A;
+        """,
+    )
+    _write_header(
+        b_header,
+        """
+        #pragma once
+        #include "a.h"
+        typedef int B;
+        """,
+    )
+
+    plan = build_header_import_plan(a_header)
+
+    assert not plan.has_errors(), plan.error_messages()
+    assert plan.resolved_local_includes == (b_header.resolve(), a_header.resolve())
+    assert [definition.name for definition in plan.typedefs] == ["B", "A"]
+    assert any("Detected include cycle" in diagnostic.message for diagnostic in plan.diagnostics)
+
+
+def test_build_header_import_plan_from_source_parses_root_header():
+    plan = build_header_import_plan_from_source(
+        """
+        #pragma once
+        #include <stdint.h>
+
+        typedef uint32_t Word;
+
+        /* size=0x8 */ typedef struct ApiNode { /* 0x000 */ Word value; } ApiNode;
+        """.strip(),
+        header_name="api_types.h",
+    )
+
+    assert not plan.has_errors(), plan.error_messages()
+    assert plan.header_path == Path("api_types.h")
+    assert plan.resolved_local_includes == (Path("api_types.h"),)
+    assert plan.resolved_system_includes == ("stdint.h",)
+    assert any(definition.name == "Word" for definition in plan.typedefs)
+    assert plan.composite_order == ("ApiNode",)
+    api_node = next(definition for definition in plan.composites if definition.name == "ApiNode")
+    assert api_node.size == 0x8
+    assert api_node.fields[0].offset == 0x0
+
+
+def test_build_header_import_plan_from_source_resolves_include_files():
+    plan = build_header_import_plan_from_source(
+        """
+        #pragma once
+        #include "shared.h"
+        typedef Count LocalCount;
+        """.strip(),
+        header_name="api/root.h",
+        include_files={
+            "api/shared.h": "typedef int Count;",
+        },
+    )
+
+    assert not plan.has_errors(), plan.error_messages()
+    assert plan.resolved_local_includes == (Path("api/shared.h"), Path("api/root.h"))
+    assert [definition.name for definition in plan.typedefs] == ["Count", "LocalCount"]
+
+
+def test_build_header_import_plan_from_source_handles_void_function_parameters():
+    plan = build_header_import_plan_from_source(
+        """
+        typedef int Fn(void);
+        typedef int (*FnPtr)(void);
+        typedef int (*WithPointer)(void *opaque);
+        """.strip(),
+        header_name="callbacks.h",
+    )
+
+    assert not plan.has_errors(), plan.error_messages()
+    by_name = {definition.name: definition for definition in plan.function_types}
+    assert by_name["Fn"].signature.parameters == ()
+    assert by_name["FnPtr"].pointer_alias is True
+    assert by_name["FnPtr"].signature.parameters == ()
+    assert isinstance(by_name["WithPointer"].signature, FunctionType)
+    assert len(by_name["WithPointer"].signature.parameters) == 1
+    assert by_name["WithPointer"].signature.parameters[0].name == "opaque"
+
+
+def test_build_header_import_plan_from_source_rejects_include_next():
+    plan = build_header_import_plan_from_source(
+        """
+        #include_next <stdint.h>
+        typedef int Count;
+        """.strip(),
+        header_name="bad_directive.h",
+    )
+
+    assert plan.has_errors()
+    assert any(
+        "Unsupported preprocessor directive: #include_next" in message
+        for message in plan.error_messages()
+    )
+
+
+def test_build_header_import_plan_from_files_uses_first_file_as_root():
+    plan = build_header_import_plan_from_files(
+        [
+            {
+                "name": "api/root.h",
+                "content": '#include "shared.h"\ntypedef Count LocalCount;',
+            },
+            {
+                "name": "api/shared.h",
+                "content": "typedef int Count;",
+            },
+        ]
+    )
+
+    assert not plan.has_errors(), plan.error_messages()
+    assert plan.header_path == Path("api/root.h")
+    assert plan.resolved_local_includes == (Path("api/shared.h"), Path("api/root.h"))
+    assert [definition.name for definition in plan.typedefs] == ["Count", "LocalCount"]
+
+
+def test_build_header_import_plan_from_source_reports_missing_include():
+    plan = build_header_import_plan_from_source(
+        """
+        #pragma once
+        #include "missing.h"
+        typedef int Count;
+        """.strip(),
+        header_name="broken.h",
+    )
+
+    assert plan.has_errors()
+    assert any("Missing local include 'missing.h'" in message for message in plan.error_messages())
+
+
+def test_translate_header_path_uses_longest_configured_prefix(monkeypatch, tmp_path):
+    broad_root = tmp_path / "broad"
+    narrow_root = tmp_path / "narrow"
+    monkeypatch.setenv(
+        "PYGHIDRA_MCP_HEADER_PATH_MAP",
+        f"/container={broad_root},/container/work={narrow_root}",
+    )
+
+    translated = translate_header_path("/container/work/project/types.h")
+
+    assert translated == str((narrow_root / "project/types.h").resolve())
+
+
+def test_translate_header_path_rejects_mapped_escapes(monkeypatch, tmp_path):
+    server_root = tmp_path / "host"
+    monkeypatch.setenv("PYGHIDRA_MCP_HEADER_PATH_MAP", f"/container/work={server_root}")
+
+    with pytest.raises(PlanningError, match="escapes configured server root"):
+        translate_header_path("/container/work/../secret.h")
+
+
+def test_build_header_import_plan_rejects_by_value_composite_cycles(tmp_path):
+    header_path = _write_header(
+        tmp_path / "cycle.h",
+        """
+        #pragma once
+
+        /* size=0x8 */
+        typedef struct A {
+            /* 0x000 */ struct B value;
+        } A;
+
+        /* size=0x8 */
+        typedef struct B {
+            /* 0x000 */ A value;
+        } B;
+        """,
+    )
+
+    plan = build_header_import_plan(header_path)
+
+    assert plan.has_errors()
+    assert any("dependency cycle" in message for message in plan.error_messages())

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -6,15 +6,21 @@ import pytest
 from pyghidra_mcp.gui_context import GuiPyGhidraContext
 from pyghidra_mcp.mcp_tools import (
     decompile_function,
+    describe_data_type,
     goto,
+    import_header_types,
+    list_data_types,
     list_project_binaries,
     rename_variable,
     search_symbols_by_name,
     set_comment,
+    set_data_type_at_address,
     set_function_prototype,
+    set_function_return_type,
     set_variable_type,
 )
 from pyghidra_mcp.models import ProgramInfo, SymbolInfo
+from pyghidra_mcp.tools import GhidraTools
 
 
 def test_list_project_binaries_uses_project_wide_context_listing():
@@ -130,10 +136,13 @@ def test_set_variable_type_uses_tool_path(monkeypatch):
         function_name_or_address="helper",
         variable_name="total",
         type_name="long",
+        variable_kind="local",
         ctx=ctx,
     )
 
-    fake_tools.set_variable_type.assert_called_once_with("helper", "total", "long")
+    fake_tools.set_variable_type.assert_called_once_with(
+        "helper", "total", "long", variable_kind="local"
+    )
     assert response.binary_name == "sample"
     assert response.function_name == "helper"
     assert response.function_address == "100001000"
@@ -175,6 +184,297 @@ def test_set_function_prototype_uses_tool_path(monkeypatch):
     assert response.function_address == "100001000"
     assert response.old_prototype == "int function_one(int count)"
     assert response.new_prototype == "long function_one(long count)"
+
+
+def test_set_function_return_type_uses_tool_path(monkeypatch):
+    pyghidra_context = Mock()
+    pyghidra_context.get_program_info.return_value = Mock()
+
+    fake_tools = Mock()
+    fake_tools.set_function_return_type.return_value = {
+        "function_name": "function_one",
+        "function_address": "100001000",
+        "old_return_type": "int",
+        "old_return_type_path": "/builtin/int",
+        "new_return_type": "Node",
+        "new_return_type_path": "/pyghidra_mcp/imported_headers/Node",
+    }
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = pyghidra_context
+
+    monkeypatch.setattr("pyghidra_mcp.mcp_tools.GhidraTools", lambda _program_info: fake_tools)
+
+    response = set_function_return_type(
+        binary_name="sample",
+        function_name_or_address="function_one",
+        type_name_or_path="/pyghidra_mcp/imported_headers/Node",
+        ctx=ctx,
+    )
+
+    fake_tools.set_function_return_type.assert_called_once_with(
+        "function_one", "/pyghidra_mcp/imported_headers/Node"
+    )
+    assert response.binary_name == "sample"
+    assert response.function_name == "function_one"
+    assert response.new_return_type_path == "/pyghidra_mcp/imported_headers/Node"
+
+
+def test_set_data_type_at_address_uses_tool_path(monkeypatch):
+    pyghidra_context = Mock()
+    pyghidra_context.get_program_info.return_value = Mock()
+
+    fake_tools = Mock()
+    fake_tools.set_data_type_at_address.return_value = {
+        "address": "100001000",
+        "old_type": None,
+        "old_type_path": None,
+        "new_type": "Node",
+        "new_type_path": "/pyghidra_mcp/imported_headers/Node",
+        "length": 16,
+    }
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = pyghidra_context
+
+    monkeypatch.setattr("pyghidra_mcp.mcp_tools.GhidraTools", lambda _program_info: fake_tools)
+
+    response = set_data_type_at_address(
+        binary_name="sample",
+        address="100001000",
+        type_name_or_path="/pyghidra_mcp/imported_headers/Node",
+        clear_existing=False,
+        ctx=ctx,
+    )
+
+    fake_tools.set_data_type_at_address.assert_called_once_with(
+        "100001000", "/pyghidra_mcp/imported_headers/Node", clear_existing=False
+    )
+    assert response.binary_name == "sample"
+    assert response.address == "100001000"
+    assert response.length == 16
+
+
+def test_import_header_types_uses_tool_path(monkeypatch):
+    pyghidra_context = Mock()
+    pyghidra_context.get_program_info.return_value = Mock()
+
+    fake_tools = Mock()
+    fake_tools.import_header_types.return_value = {
+        "header_path": "/tmp/sample.h",
+        "category_root": "/pyghidra_mcp/imported_headers",
+        "validate_only": False,
+        "resolved_local_includes": ["/tmp/sample.h"],
+        "resolved_system_includes": ["stdint.h"],
+        "created_types": ["Node"],
+        "updated_types": [],
+        "diagnostics": [],
+    }
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = pyghidra_context
+
+    monkeypatch.setattr("pyghidra_mcp.mcp_tools.GhidraTools", lambda _program_info: fake_tools)
+
+    response = import_header_types(
+        binary_name="sample",
+        header_path="/tmp/sample.h",
+        validate_only=False,
+        ctx=ctx,
+    )
+
+    fake_tools.import_header_types.assert_called_once_with(
+        header_path="/tmp/sample.h",
+        validate_only=False,
+        header_content=None,
+        header_name=None,
+        include_files=None,
+        header_files=None,
+    )
+    assert response.binary_name == "sample"
+    assert response.header_path == "/tmp/sample.h"
+    assert response.created_types == ["Node"]
+
+
+def test_import_header_types_forwards_content_mode(monkeypatch):
+    pyghidra_context = Mock()
+    pyghidra_context.get_program_info.return_value = Mock()
+
+    fake_tools = Mock()
+    fake_tools.import_header_types.return_value = {
+        "header_path": "api_types.h",
+        "category_root": "/pyghidra_mcp/imported_headers",
+        "validate_only": True,
+        "resolved_local_includes": ["api_types.h"],
+        "resolved_system_includes": ["stdint.h"],
+        "created_types": [],
+        "updated_types": [],
+        "diagnostics": [],
+    }
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = pyghidra_context
+
+    monkeypatch.setattr("pyghidra_mcp.mcp_tools.GhidraTools", lambda _program_info: fake_tools)
+
+    response = import_header_types(
+        binary_name="sample",
+        validate_only=True,
+        ctx=ctx,
+        header_content="#include <stdint.h>\ntypedef uint32_t ApiWord;",
+        header_name="api_types.h",
+        include_files={"shared.h": "typedef int Count;"},
+    )
+
+    fake_tools.import_header_types.assert_called_once_with(
+        header_path=None,
+        validate_only=True,
+        header_content="#include <stdint.h>\ntypedef uint32_t ApiWord;",
+        header_name="api_types.h",
+        include_files={"shared.h": "typedef int Count;"},
+        header_files=None,
+    )
+    assert response.binary_name == "sample"
+    assert response.header_path == "api_types.h"
+    assert response.validate_only is True
+
+
+def test_import_header_types_forwards_file_list_mode(monkeypatch):
+    pyghidra_context = Mock()
+    pyghidra_context.get_program_info.return_value = Mock()
+
+    fake_tools = Mock()
+    fake_tools.import_header_types.return_value = {
+        "header_path": "api_types.h",
+        "category_root": "/pyghidra_mcp/imported_headers",
+        "validate_only": True,
+        "resolved_local_includes": ["api_types.h"],
+        "resolved_system_includes": [],
+        "created_types": [],
+        "updated_types": [],
+        "diagnostics": [],
+    }
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = pyghidra_context
+
+    monkeypatch.setattr("pyghidra_mcp.mcp_tools.GhidraTools", lambda _program_info: fake_tools)
+
+    header_files = [
+        {"name": "api_types.h", "content": "typedef int Count;"},
+        {"name": "shared.h", "content": "typedef int Shared;"},
+    ]
+    response = import_header_types(
+        binary_name="sample",
+        validate_only=True,
+        ctx=ctx,
+        header_files=header_files,
+    )
+
+    fake_tools.import_header_types.assert_called_once_with(
+        header_path=None,
+        validate_only=True,
+        header_content=None,
+        header_name=None,
+        include_files=None,
+        header_files=header_files,
+    )
+    assert response.binary_name == "sample"
+    assert response.header_path == "api_types.h"
+    assert response.validate_only is True
+
+
+def test_list_data_types_uses_tool_path(monkeypatch):
+    pyghidra_context = Mock()
+    pyghidra_context.get_program_info.return_value = Mock()
+
+    fake_tools = Mock()
+    fake_tools.list_data_types.return_value = {
+        "data_types": [
+            {
+                "name": "Node",
+                "display_name": "Node",
+                "path": "/pyghidra_mcp/imported_headers/Node",
+                "category_path": "/pyghidra_mcp/imported_headers",
+                "kind": "structure",
+                "size": 16,
+            }
+        ],
+        "total_matches": 1,
+    }
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = pyghidra_context
+
+    monkeypatch.setattr("pyghidra_mcp.mcp_tools.GhidraTools", lambda _program_info: fake_tools)
+
+    response = list_data_types(
+        binary_name="sample",
+        query="Node",
+        category_path="/pyghidra_mcp/imported_headers",
+        include_builtins=True,
+        offset=2,
+        limit=3,
+        ctx=ctx,
+    )
+
+    fake_tools.list_data_types.assert_called_once_with(
+        query="Node",
+        category_path="/pyghidra_mcp/imported_headers",
+        include_builtins=True,
+        offset=2,
+        limit=3,
+    )
+    assert response.total_matches == 1
+    assert response.data_types[0].path == "/pyghidra_mcp/imported_headers/Node"
+
+
+def test_describe_data_type_uses_tool_path(monkeypatch):
+    pyghidra_context = Mock()
+    pyghidra_context.get_program_info.return_value = Mock()
+
+    fake_tools = Mock()
+    fake_tools.describe_data_type.return_value = {
+        "requested_name_or_path": "Node",
+        "name": "Node",
+        "display_name": "Node",
+        "path": "/pyghidra_mcp/imported_headers/Node",
+        "category_path": "/pyghidra_mcp/imported_headers",
+        "kind": "structure",
+        "size": 16,
+        "aligned_size": 16,
+        "description": "structure Node",
+        "base_type_name": None,
+        "base_type_path": None,
+        "base_type_kind": None,
+        "fields": [
+            {
+                "ordinal": 0,
+                "offset": 0,
+                "length": 8,
+                "field_name": "next",
+                "type_name": "Node *",
+                "type_path": "/builtin/NodePtr",
+                "comment": None,
+            }
+        ],
+    }
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = pyghidra_context
+
+    monkeypatch.setattr("pyghidra_mcp.mcp_tools.GhidraTools", lambda _program_info: fake_tools)
+
+    response = describe_data_type(
+        binary_name="sample",
+        data_type_name_or_path="Node",
+        ctx=ctx,
+    )
+
+    fake_tools.describe_data_type.assert_called_once_with("Node")
+    assert response.binary_name == "sample"
+    assert response.name == "Node"
+    assert response.fields[0].field_name == "next"
 
 
 @pytest.mark.asyncio
@@ -298,3 +598,185 @@ def test_goto_uses_gui_context():
     assert response.binary_name == "sample"
     assert response.address == "1000042e3"
     assert response.success is True
+
+
+class FakeAddress:
+    def __init__(self, offset, *, max_offset=0xFFFF):
+        self.offset = offset
+        self.max_offset = max_offset
+
+    def addNoWrap(self, delta):  # noqa: N802
+        new_offset = self.offset + delta
+        if new_offset > self.max_offset:
+            raise OverflowError("address overflow")
+        return FakeAddress(new_offset, max_offset=self.max_offset)
+
+    def __str__(self):
+        return f"{self.offset:x}"
+
+    def __eq__(self, other):
+        return isinstance(other, FakeAddress) and self.offset == other.offset
+
+
+class FakeAddressFactory:
+    def __init__(self, addresses):
+        self.addresses = addresses
+
+    def getAddress(self, address):  # noqa: N802
+        return self.addresses[address]
+
+
+class FakeDataTypeForAddress:
+    def __init__(self, length):
+        self.length = length
+
+    def getLength(self):  # noqa: N802
+        return self.length
+
+    def getDisplayName(self):  # noqa: N802
+        return "FakeType"
+
+    def getPathName(self):  # noqa: N802
+        return "/types/FakeType"
+
+
+class FakeDataAtAddress:
+    def __init__(self, data_type):
+        self.data_type = data_type
+
+    def getDataType(self):  # noqa: N802
+        return self.data_type
+
+    def getLength(self):  # noqa: N802
+        return self.data_type.getLength()
+
+
+class FakeListing:
+    def __init__(self):
+        self.cleared = []
+        self.created = []
+
+    def getDefinedDataAt(self, _addr):  # noqa: N802
+        return None
+
+    def clearCodeUnits(self, start, end, clear_context):  # noqa: N802
+        self.cleared.append((start, end, clear_context))
+
+    def createData(self, addr, data_type):  # noqa: N802
+        self.created.append((addr, data_type))
+        return FakeDataAtAddress(data_type)
+
+
+class FakeMemory:
+    def __init__(self, mapped_offsets, blocks):
+        self.mapped_offsets = set(mapped_offsets)
+        self.blocks = blocks
+
+    def contains(self, addr):
+        return addr.offset in self.mapped_offsets
+
+    def getBlock(self, addr):  # noqa: N802
+        return self.blocks.get(addr.offset)
+
+
+class FakeProgramForDataAtAddress:
+    def __init__(self, memory, listing, addresses, pointer_size=8):
+        self.memory = memory
+        self.listing = listing
+        self.address_factory = FakeAddressFactory(addresses)
+        self.pointer_size = pointer_size
+        self.transactions = []
+
+    def getAddressFactory(self):  # noqa: N802
+        return self.address_factory
+
+    def getMemory(self):  # noqa: N802
+        return self.memory
+
+    def getListing(self):  # noqa: N802
+        return self.listing
+
+    def getDefaultPointerSize(self):  # noqa: N802
+        return self.pointer_size
+
+    def startTransaction(self, description):  # noqa: N802
+        self.transactions.append(("start", description))
+        return 1
+
+    def endTransaction(self, tx_id, committed):  # noqa: N802
+        self.transactions.append(("end", tx_id, committed))
+
+
+def _tools_for_data_range(memory, listing, addresses, data_type):
+    program_info = Mock()
+    program_info.program = FakeProgramForDataAtAddress(memory, listing, addresses)
+    program_info.decompiler_pool = Mock()
+    tools = GhidraTools(program_info)
+    tools._resolve_or_parse_data_type = Mock(return_value=data_type)
+    tools.invalidate_decompiler_cache = Mock()
+    return tools, program_info.program
+
+
+def test_set_data_type_at_address_rejects_unmapped_end_before_transaction():
+    start = FakeAddress(0x1000)
+    memory = FakeMemory({0x1000}, {0x1000: "block"})
+    listing = FakeListing()
+    tools, program = _tools_for_data_range(
+        memory, listing, {"1000": start}, FakeDataTypeForAddress(2)
+    )
+
+    with pytest.raises(ValueError, match="not fully mapped"):
+        tools.set_data_type_at_address("1000", "FakeType")
+
+    assert program.transactions == []
+    assert listing.cleared == []
+    assert listing.created == []
+
+
+def test_set_data_type_at_address_rejects_ranges_that_cross_blocks_before_transaction():
+    start = FakeAddress(0x1000)
+    memory = FakeMemory({0x1000, 0x1001}, {0x1000: "block-a", 0x1001: "block-b"})
+    listing = FakeListing()
+    tools, program = _tools_for_data_range(
+        memory, listing, {"1000": start}, FakeDataTypeForAddress(2)
+    )
+
+    with pytest.raises(ValueError, match="crosses memory blocks"):
+        tools.set_data_type_at_address("1000", "FakeType")
+
+    assert program.transactions == []
+    assert listing.cleared == []
+    assert listing.created == []
+
+
+def test_set_data_type_at_address_rejects_address_overflow_before_transaction():
+    start = FakeAddress(0xFFFF, max_offset=0xFFFF)
+    memory = FakeMemory({0xFFFF}, {0xFFFF: "block"})
+    listing = FakeListing()
+    tools, program = _tools_for_data_range(
+        memory, listing, {"ffff": start}, FakeDataTypeForAddress(2)
+    )
+
+    with pytest.raises(ValueError, match="does not fit"):
+        tools.set_data_type_at_address("ffff", "FakeType")
+
+    assert program.transactions == []
+    assert listing.cleared == []
+    assert listing.created == []
+
+
+def test_set_data_type_at_address_validates_range_and_creates_data():
+    start = FakeAddress(0x1000)
+    data_type = FakeDataTypeForAddress(2)
+    memory = FakeMemory({0x1000, 0x1001}, {0x1000: "block", 0x1001: "block"})
+    listing = FakeListing()
+    tools, program = _tools_for_data_range(memory, listing, {"1000": start}, data_type)
+
+    result = tools.set_data_type_at_address("1000", "FakeType")
+
+    assert result["address"] == "1000"
+    assert result["length"] == 2
+    assert listing.cleared == [(start, FakeAddress(0x1001), False)]
+    assert listing.created == [(start, data_type)]
+    assert program.transactions[0][0] == "start"
+    assert program.transactions[-1] == ("end", 1, True)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -4,9 +4,17 @@ from pyghidra_mcp.models import (
     CodeSearchResults,
     CrossReferenceInfo,
     CrossReferenceInfos,
+    DataTypeAtAddressResponse,
+    DataTypeDescriptionResponse,
+    DataTypeFieldInfo,
+    DataTypeReference,
+    DataTypeSearchResults,
     DecompiledFunction,
     ExportInfo,
     ExportInfos,
+    FunctionReturnTypeResponse,
+    HeaderImportDiagnostic,
+    HeaderImportResponse,
     ImportInfo,
     ImportInfos,
     ProgramBasicInfo,
@@ -19,6 +27,7 @@ from pyghidra_mcp.models import (
     StringSearchResults,
     SymbolInfo,
     SymbolSearchResults,
+    VariableTypeResponse,
 )
 
 
@@ -102,6 +111,111 @@ def test_program_infos_model():
     assert len(infos.programs) == 2
     assert infos.programs[0].name == "test_program1"
     assert infos.programs[1].analysis_complete is False
+
+
+def test_header_import_response_model():
+    """Test the header import response model."""
+    response = HeaderImportResponse(
+        binary_name="sample",
+        header_path="/tmp/sample.h",
+        category_root="/pyghidra_mcp/imported_headers",
+        resolved_local_includes=["/tmp/sample.h"],
+        resolved_system_includes=["stdint.h"],
+        created_types=["Node"],
+        updated_types=[],
+        diagnostics=[HeaderImportDiagnostic(severity="warning", message="test")],
+    )
+    assert response.binary_name == "sample"
+    assert response.header_path == "/tmp/sample.h"
+    assert response.created_types == ["Node"]
+    assert response.created_type_refs == []
+    assert response.updated_type_refs == []
+    assert response.diagnostics[0].severity == "warning"
+
+
+def test_data_type_reference_and_search_results_models():
+    """Test datatype reference/search models."""
+    ref = DataTypeReference(
+        name="Node",
+        display_name="Node",
+        path="/pyghidra_mcp/imported_headers/Node",
+        category_path="/pyghidra_mcp/imported_headers",
+        kind="structure",
+        size=16,
+    )
+    results = DataTypeSearchResults(data_types=[ref], total_matches=1)
+
+    assert results.total_matches == 1
+    assert results.data_types[0].path == "/pyghidra_mcp/imported_headers/Node"
+    assert results.model_dump()["data_types"][0]["kind"] == "structure"
+
+
+def test_mutation_response_models_include_optional_type_paths():
+    """Test mutation response models with path metadata."""
+    variable = VariableTypeResponse(
+        binary_name="sample",
+        function_name="helper",
+        function_address="1000",
+        variable_kind="parameter",
+        variable_name="node",
+        old_type="int",
+        new_type="Node",
+        new_type_path="/pyghidra_mcp/imported_headers/Node",
+    )
+    function_return = FunctionReturnTypeResponse(
+        binary_name="sample",
+        function_name="make_node",
+        function_address="1000",
+        old_return_type="int",
+        new_return_type="Node",
+        new_return_type_path="/pyghidra_mcp/imported_headers/Node",
+    )
+    data = DataTypeAtAddressResponse(
+        binary_name="sample",
+        address="1000",
+        old_type=None,
+        new_type="Node",
+        new_type_path="/pyghidra_mcp/imported_headers/Node",
+        length=16,
+    )
+
+    assert variable.old_type_path is None
+    assert variable.new_type_path == "/pyghidra_mcp/imported_headers/Node"
+    assert function_return.old_return_type_path is None
+    assert data.old_type_path is None
+    assert data.length == 16
+
+
+def test_data_type_description_response_model():
+    """Test the datatype description response model."""
+    response = DataTypeDescriptionResponse(
+        binary_name="sample",
+        requested_name_or_path="Node",
+        name="Node",
+        display_name="Node",
+        path="/pyghidra_mcp/imported_headers/Node",
+        category_path="/pyghidra_mcp/imported_headers",
+        kind="structure",
+        size=16,
+        aligned_size=16,
+        description="structure Node",
+        base_type_name=None,
+        base_type_path=None,
+        base_type_kind=None,
+        fields=[
+            DataTypeFieldInfo(
+                ordinal=0,
+                offset=0,
+                length=8,
+                field_name="next",
+                type_name="Node *",
+                type_path="/builtin/NodePtr",
+            )
+        ],
+    )
+    assert response.binary_name == "sample"
+    assert response.path == "/pyghidra_mcp/imported_headers/Node"
+    assert response.fields[0].field_name == "next"
 
 
 def test_export_info_model():

--- a/uv.lock
+++ b/uv.lock
@@ -2494,6 +2494,7 @@ dependencies = [
     { name = "click-option-group" },
     { name = "ghidrecomp" },
     { name = "mcp", extra = ["cli"] },
+    { name = "pycparser" },
     { name = "pyghidra" },
 ]
 
@@ -2540,6 +2541,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
     { name = "mcp", extras = ["cli"], marker = "extra == 'dev'", specifier = ">=1.26.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "pycparser", specifier = ">=2.22" },
     { name = "pyghidra", specifier = ">=2.2.1" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.1" },


### PR DESCRIPTION
- Add C header import planning and apply flow for reviewed Ghidra datatypes
- Support inline header content, multi-file inputs, includes, and validate-only mode
- Add MCP tools to list, describe, import, and apply datatypes by name or path
- Add return-type, address datatype, and parameter/local-specific type setters
- Expand unit and integration coverage for header imports and datatype APIs