### PR TITLE
Fix decompiler pool deadlock and restore analysis readiness

### DIFF
--- a/src/pyghidra_mcp/context.py
+++ b/src/pyghidra_mcp/context.py
@@ -524,10 +524,18 @@ class PyGhidraContext(IndexingMixin):
 
     def _init_program_info(self, program):
         from ghidra.program.flatapi import FlatProgramAPI
+        from ghidra.program.util import GhidraProgramUtilities
 
         assert program is not None
 
         metadata = self.get_metadata(program)
+        try:
+            analysis_complete = not bool(
+                GhidraProgramUtilities.shouldAskToAnalyze(program)
+            )
+        except Exception:
+            logger.debug("Could not restore persisted analysis state", exc_info=True)
+            analysis_complete = False
 
         program_info = ProgramInfo(
             name=program.name,
@@ -535,7 +543,7 @@ class PyGhidraContext(IndexingMixin):
             flat_api=FlatProgramAPI(program),
             decompiler_pool=self._create_decompiler_pool(program),
             metadata=metadata,
-            ghidra_analysis_complete=False,
+            ghidra_analysis_complete=analysis_complete,
             file_path=metadata["Executable Location"],
             load_time=time.time(),
             code_collection=None,

--- a/src/pyghidra_mcp/context.py
+++ b/src/pyghidra_mcp/context.py
@@ -530,9 +530,8 @@ class PyGhidraContext(IndexingMixin):
 
         metadata = self.get_metadata(program)
         try:
-            analysis_complete = not bool(
-                GhidraProgramUtilities.shouldAskToAnalyze(program)
-            )
+            # "Don't ask" is not equivalent to analyzed; trust the persisted flag.
+            analysis_complete = bool(GhidraProgramUtilities.isAnalyzed(program))
         except Exception:
             logger.debug("Could not restore persisted analysis state", exc_info=True)
             analysis_complete = False

--- a/src/pyghidra_mcp/decompiler_pool.py
+++ b/src/pyghidra_mcp/decompiler_pool.py
@@ -21,22 +21,16 @@ class DecompilerPool:
         self._created: list[DecompInterface] = []
         self._created_lock = threading.Lock()
 
-    def _create(self) -> "DecompInterface":
-        decompiler = self._factory()
-        with self._created_lock:
-            self._created.append(decompiler)
-        return decompiler
-
     def _ensure_available(self) -> "DecompInterface":
         try:
             return self._queue.get_nowait()
         except queue.Empty:
             with self._created_lock:
                 if len(self._created) < self._size:
-                    pass
-                else:
-                    return self._queue.get()
-            return self._create()
+                    decompiler = self._factory()
+                    self._created.append(decompiler)
+                    return decompiler
+            return self._queue.get()
 
     @contextmanager
     def acquire(self):

--- a/tests/unit/test_decompiler_pool.py
+++ b/tests/unit/test_decompiler_pool.py
@@ -1,0 +1,38 @@
+import threading
+import time
+
+from pyghidra_mcp.decompiler_pool import DecompilerPool
+
+
+def test_concurrent_acquire_never_overcreates_or_blocks_return():
+    worker_count = 8
+    pool_size = 2
+    start = threading.Barrier(worker_count)
+    created = []
+    created_lock = threading.Lock()
+    completed = []
+
+    def factory():
+        time.sleep(0.05)
+        instance = object()
+        with created_lock:
+            created.append(instance)
+        return instance
+
+    pool = DecompilerPool(factory, size=pool_size)
+
+    def worker():
+        start.wait()
+        with pool.acquire():
+            time.sleep(0.01)
+        completed.append(True)
+
+    threads = [threading.Thread(target=worker, daemon=True) for _ in range(worker_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert len(completed) == worker_count
+    assert len(created) == pool_size
+    assert all(not thread.is_alive() for thread in threads)

--- a/tests/unit/test_restart_readiness.py
+++ b/tests/unit/test_restart_readiness.py
@@ -1,0 +1,58 @@
+import sys
+import types
+from unittest.mock import Mock
+
+from pyghidra_mcp.context import PyGhidraContext
+
+
+def _install_fake_program_modules(monkeypatch, *, should_ask_to_analyze: bool):
+    ghidra_module = types.ModuleType("ghidra")
+    program_module = types.ModuleType("ghidra.program")
+    flatapi_module = types.ModuleType("ghidra.program.flatapi")
+    util_module = types.ModuleType("ghidra.program.util")
+
+    flat_api = Mock()
+    flatapi_module.FlatProgramAPI = Mock(return_value=flat_api)
+    analysis_util = Mock()
+    analysis_util.shouldAskToAnalyze.return_value = should_ask_to_analyze
+    util_module.GhidraProgramUtilities = analysis_util
+
+    monkeypatch.setitem(sys.modules, "ghidra", ghidra_module)
+    monkeypatch.setitem(sys.modules, "ghidra.program", program_module)
+    monkeypatch.setitem(sys.modules, "ghidra.program.flatapi", flatapi_module)
+    monkeypatch.setitem(sys.modules, "ghidra.program.util", util_module)
+    return flat_api, analysis_util
+
+
+def _new_context_and_program():
+    context = PyGhidraContext.__new__(PyGhidraContext)
+    context.get_metadata = Mock(return_value={"Executable Location": "/tmp/sample"})
+    context._create_decompiler_pool = Mock(return_value="pool")
+    program = Mock()
+    program.name = "sample"
+    return context, program
+
+
+def test_init_program_info_restores_persisted_analysis_state(monkeypatch):
+    flat_api, analysis_util = _install_fake_program_modules(
+        monkeypatch, should_ask_to_analyze=False
+    )
+    context, program = _new_context_and_program()
+
+    info = context._init_program_info(program)
+
+    assert info.ghidra_analysis_complete is True
+    assert info.flat_api is flat_api
+    analysis_util.shouldAskToAnalyze.assert_called_once_with(program)
+
+
+def test_init_program_info_keeps_unanalyzed_program_blocked(monkeypatch):
+    _, analysis_util = _install_fake_program_modules(
+        monkeypatch, should_ask_to_analyze=True
+    )
+    context, program = _new_context_and_program()
+
+    info = context._init_program_info(program)
+
+    assert info.ghidra_analysis_complete is False
+    analysis_util.shouldAskToAnalyze.assert_called_once_with(program)

--- a/tests/unit/test_restart_readiness.py
+++ b/tests/unit/test_restart_readiness.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 from pyghidra_mcp.context import PyGhidraContext
 
 
-def _install_fake_program_modules(monkeypatch, *, should_ask_to_analyze: bool):
+def _install_fake_program_modules(monkeypatch, *, is_analyzed: bool):
     ghidra_module = types.ModuleType("ghidra")
     program_module = types.ModuleType("ghidra.program")
     flatapi_module = types.ModuleType("ghidra.program.flatapi")
@@ -14,7 +14,8 @@ def _install_fake_program_modules(monkeypatch, *, should_ask_to_analyze: bool):
     flat_api = Mock()
     flatapi_module.FlatProgramAPI = Mock(return_value=flat_api)
     analysis_util = Mock()
-    analysis_util.shouldAskToAnalyze.return_value = should_ask_to_analyze
+    analysis_util.isAnalyzed.return_value = is_analyzed
+    analysis_util.shouldAskToAnalyze.return_value = False
     util_module.GhidraProgramUtilities = analysis_util
 
     monkeypatch.setitem(sys.modules, "ghidra", ghidra_module)
@@ -34,25 +35,23 @@ def _new_context_and_program():
 
 
 def test_init_program_info_restores_persisted_analysis_state(monkeypatch):
-    flat_api, analysis_util = _install_fake_program_modules(
-        monkeypatch, should_ask_to_analyze=False
-    )
+    flat_api, analysis_util = _install_fake_program_modules(monkeypatch, is_analyzed=True)
     context, program = _new_context_and_program()
 
     info = context._init_program_info(program)
 
     assert info.ghidra_analysis_complete is True
     assert info.flat_api is flat_api
-    analysis_util.shouldAskToAnalyze.assert_called_once_with(program)
+    analysis_util.isAnalyzed.assert_called_once_with(program)
+    analysis_util.shouldAskToAnalyze.assert_not_called()
 
 
 def test_init_program_info_keeps_unanalyzed_program_blocked(monkeypatch):
-    _, analysis_util = _install_fake_program_modules(
-        monkeypatch, should_ask_to_analyze=True
-    )
+    _, analysis_util = _install_fake_program_modules(monkeypatch, is_analyzed=False)
     context, program = _new_context_and_program()
 
     info = context._init_program_info(program)
 
     assert info.ghidra_analysis_complete is False
-    analysis_util.shouldAskToAnalyze.assert_called_once_with(program)
+    analysis_util.isAnalyzed.assert_called_once_with(program)
+    analysis_util.shouldAskToAnalyze.assert_not_called()


### PR DESCRIPTION
## Summary

- prevent `DecompilerPool` from over-creating instances under concurrent acquisition
- avoid blocked returns to the bounded queue and resulting decompile timeouts
- restore persisted Ghidra analysis readiness when reopening existing programs
- add deterministic regression coverage for both behaviors

## Root causes

`DecompilerPool._ensure_available()` checked capacity under a lock but created and recorded the instance after releasing it. Concurrent callers could all observe available capacity, over-create the pool, and later block forever while returning extra instances to the bounded queue.

Existing analyzed programs were also reopened with `ghidra_analysis_complete=False` unconditionally, preventing startup indexing from restoring ready state after a runtime restart.

## Verification

- clean-fork unit suite: `95 passed`
- focused regressions: `3 passed`
- Ruff: passed
- compileall: passed
- `git diff --check`: passed
- live stress profile: `536/536` MCP calls succeeded after the fix
- decompile p95 improved from a 60-second timeout to about 565 ms under the tested burst load
