### PR TITLE
Bound decompiler waits and prepare v0.2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyghidra-mcp"
-version = "0.2.4"
+version = "0.2.5"
 description = "Python Command-Line Ghidra MCP"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pyghidra_mcp/__init__.py
+++ b/src/pyghidra_mcp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 __author__ = "clearbluejar"
 
 

--- a/src/pyghidra_mcp/decompiler_pool.py
+++ b/src/pyghidra_mcp/decompiler_pool.py
@@ -18,27 +18,51 @@ class DecompilerPool:
         self._factory = factory
         self._size = max(1, size)
         self._queue: queue.LifoQueue[DecompInterface] = queue.LifoQueue(maxsize=self._size)
+        self._slots = threading.BoundedSemaphore(value=self._size)
         self._created: list[DecompInterface] = []
         self._created_lock = threading.Lock()
+        self._closed = False
+
+    def _create(self) -> "DecompInterface":
+        decompiler = self._factory()
+        with self._created_lock:
+            if not self._closed:
+                self._created.append(decompiler)
+                return decompiler
+
+        self._dispose_one(decompiler)
+        raise RuntimeError("Decompiler pool is closed")
 
     def _ensure_available(self) -> "DecompInterface":
         try:
             return self._queue.get_nowait()
         except queue.Empty:
-            with self._created_lock:
-                if len(self._created) < self._size:
-                    decompiler = self._factory()
-                    self._created.append(decompiler)
-                    return decompiler
-            return self._queue.get()
+            return self._create()
 
     @contextmanager
-    def acquire(self):
-        decompiler = self._ensure_available()
+    def acquire(self, timeout: float | None = None):
+        if timeout is not None and timeout < 0:
+            raise ValueError("Decompiler pool timeout must be non-negative")
+
+        with self._created_lock:
+            if self._closed:
+                raise RuntimeError("Decompiler pool is closed")
+
+        if not self._slots.acquire(timeout=timeout):
+            raise TimeoutError(f"Timed out waiting for a decompiler after {timeout:g} seconds")
+
+        decompiler = None
         try:
+            decompiler = self._ensure_available()
             yield decompiler
         finally:
-            self._queue.put(decompiler)
+            try:
+                if decompiler is not None:
+                    with self._created_lock:
+                        if not self._closed:
+                            self._queue.put_nowait(decompiler)
+            finally:
+                self._slots.release()
 
     def invalidate_all(self) -> None:
         with self._created_lock:
@@ -53,18 +77,23 @@ class DecompilerPool:
 
     def dispose(self) -> None:
         with self._created_lock:
+            self._closed = True
             decompilers = list(self._created)
             self._created.clear()
 
-        while True:
-            try:
-                self._queue.get_nowait()
-            except queue.Empty:
-                break
+            while True:
+                try:
+                    self._queue.get_nowait()
+                except queue.Empty:
+                    break
 
         for decompiler in decompilers:
-            for method_name in ("dispose", "closeProgram"):
-                method = getattr(decompiler, method_name, None)
-                if method is not None:
-                    method()
-                    break
+            self._dispose_one(decompiler)
+
+    @staticmethod
+    def _dispose_one(decompiler: "DecompInterface") -> None:
+        for method_name in ("dispose", "closeProgram"):
+            method = getattr(decompiler, method_name, None)
+            if method is not None:
+                method()
+                break

--- a/src/pyghidra_mcp/indexing_mixin.py
+++ b/src/pyghidra_mcp/indexing_mixin.py
@@ -7,7 +7,7 @@ from typing import Any
 import chromadb
 from chromadb.config import Settings
 
-from pyghidra_mcp.tools import GhidraTools
+from pyghidra_mcp.tools import DEFAULT_DECOMPILE_TIMEOUT_SECONDS, GhidraTools
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +151,9 @@ class IndexingMixin:
             try:
                 if i % 10 == 0:
                     logger.debug("Decompiling %s/%s", i, len(functions))
-                decompiled = tools.decompile_function(func)
+                decompiled = tools.decompile_function(
+                    func, timeout=DEFAULT_DECOMPILE_TIMEOUT_SECONDS
+                )
                 decompiles.append(decompiled.code)
                 ids.append(decompiled.name)
                 metadatas.append(

--- a/src/pyghidra_mcp/mcp_tools.py
+++ b/src/pyghidra_mcp/mcp_tools.py
@@ -153,7 +153,7 @@ async def decompile_function(
                 timeout=timeout_sec + DECOMPILE_TIMEOUT_GRACE_SECONDS,
             )
             results.append(result)
-        except TimeoutError:
+        except asyncio.TimeoutError:
             results.append(
                 DecompiledFunction(
                     name=target,

--- a/src/pyghidra_mcp/mcp_tools.py
+++ b/src/pyghidra_mcp/mcp_tools.py
@@ -44,6 +44,7 @@ from pyghidra_mcp.models import (
 from pyghidra_mcp.tools import GhidraTools
 
 logger = logging.getLogger(__name__)
+DECOMPILE_TIMEOUT_GRACE_SECONDS = 1.0
 
 
 def _require_gui_context(ctx: Context):
@@ -126,6 +127,9 @@ async def decompile_function(
     Rich response flags attach callees, strings, and/or xrefs to each result.
     `timeout_sec` applies per target.
     """
+    if timeout_sec <= 0:
+        raise ValueError("timeout_sec must be greater than zero")
+
     pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     program_info = pyghidra_context.get_program_info(binary_name)
     tools = GhidraTools(program_info)
@@ -144,8 +148,19 @@ async def decompile_function(
 
     for target in targets:
         try:
-            result = await asyncio.to_thread(_decompile_target, target)
+            result = await asyncio.wait_for(
+                asyncio.to_thread(_decompile_target, target),
+                timeout=timeout_sec + DECOMPILE_TIMEOUT_GRACE_SECONDS,
+            )
             results.append(result)
+        except TimeoutError:
+            results.append(
+                DecompiledFunction(
+                    name=target,
+                    code="",
+                    error=f"Decompilation timed out after {timeout_sec:g} seconds",
+                )
+            )
         except Exception as e:
             results.append(DecompiledFunction(name=target, code="", error=str(e)))
     return results
@@ -530,9 +545,10 @@ def import_binary(binary_path: str, ctx: Context) -> ImportRequestResult:
     pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     return pyghidra_context.import_binary_backgrounded(binary_path)
 
+
 @mcp_error_handler
 def save(ctx: Context) -> SaveRequestResult:
-    '''Save all programs.'''
+    """Save all programs."""
     pyghidra_context: MCPContext = ctx.request_context.lifespan_context
     pyghidra_context.save()
     return SaveRequestResult()

--- a/src/pyghidra_mcp/tools.py
+++ b/src/pyghidra_mcp/tools.py
@@ -4,7 +4,9 @@ Comprehensive tool implementations for pyghidra-mcp.
 
 import functools
 import logging
+import math
 import re
+import time
 import typing
 from contextlib import contextmanager
 
@@ -39,6 +41,7 @@ if typing.TYPE_CHECKING:
     from .context import ProgramInfo
 
 logger = logging.getLogger(__name__)
+DEFAULT_DECOMPILE_TIMEOUT_SECONDS = 30
 
 
 @contextmanager
@@ -278,20 +281,30 @@ class GhidraTools:
 
     @handle_exceptions
     def decompile_function_by_name_or_addr(
-        self, name_or_address: str, timeout: int = 0
+        self, name_or_address: str, timeout: int = DEFAULT_DECOMPILE_TIMEOUT_SECONDS
     ) -> DecompiledFunction:
         """Finds and decompiles a function in a specified binary and returns its pseudo-C code."""
 
         func = self.find_function(name_or_address)
         return self.decompile_function(func, timeout=timeout)
 
-    def decompile_function(self, func: "Function", timeout: int = 0) -> DecompiledFunction:
+    def decompile_function(
+        self, func: "Function", timeout: int = DEFAULT_DECOMPILE_TIMEOUT_SECONDS
+    ) -> DecompiledFunction:
         """Decompiles a function in a specified binary and returns its pseudo-C code."""
         from ghidra.util.task import ConsoleTaskMonitor
 
+        if timeout <= 0:
+            raise ValueError("Decompiler timeout must be greater than zero")
+
         monitor = ConsoleTaskMonitor()
-        with self.decompiler_pool.acquire() as decompiler:
-            result: DecompileResults = decompiler.decompileFunction(func, timeout, monitor)
+        deadline = time.monotonic() + timeout
+        with self.decompiler_pool.acquire(timeout=timeout) as decompiler:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"Timed out waiting for a decompiler after {timeout} seconds")
+            ghidra_timeout = max(1, math.ceil(remaining))
+            result: DecompileResults = decompiler.decompileFunction(func, ghidra_timeout, monitor)
         if "" == result.getErrorMessage():
             decompiled = result.getDecompiledFunction()
             if decompiled is None:

--- a/tests/unit/test_code_index_completion.py
+++ b/tests/unit/test_code_index_completion.py
@@ -9,7 +9,12 @@ These tests exercise the gate against a real PersistentClient (no Ghidra runtime
 needed), reopening the client between steps to prove the marker is durable.
 """
 
+import sys
+import types
+from unittest.mock import Mock
+
 from pyghidra_mcp.indexing_mixin import COLLECTION_COMPLETE_KEY, IndexingMixin
+from pyghidra_mcp.tools import DEFAULT_DECOMPILE_TIMEOUT_SECONDS
 
 
 class _Probe(IndexingMixin):
@@ -71,3 +76,43 @@ def test_collection_without_marker_is_treated_as_incomplete(tmp_path):
 
     probe2 = _reopen(tmp_path)
     assert probe2._open_complete_collection("bin_legacy") is None
+
+
+def test_code_indexing_uses_a_finite_decompile_timeout(monkeypatch):
+    ghidra_module = types.ModuleType("ghidra")
+    program_module = types.ModuleType("ghidra.program")
+    model_module = types.ModuleType("ghidra.program.model")
+    listing_module = types.ModuleType("ghidra.program.model.listing")
+    listing_module.Function = object
+    monkeypatch.setitem(sys.modules, "ghidra", ghidra_module)
+    monkeypatch.setitem(sys.modules, "ghidra.program", program_module)
+    monkeypatch.setitem(sys.modules, "ghidra.program.model", model_module)
+    monkeypatch.setitem(sys.modules, "ghidra.program.model.listing", listing_module)
+
+    function = Mock()
+    function.getEntryPoint.return_value = "1000"
+    decompiled = Mock(code="int entry(void) { return 0; }")
+    decompiled.name = "entry-1000"
+    tools = Mock()
+    tools.get_all_functions.return_value = [function]
+    tools.decompile_function.return_value = decompiled
+    monkeypatch.setattr("pyghidra_mcp.indexing_mixin.GhidraTools", Mock(return_value=tools))
+
+    probe = IndexingMixin.__new__(IndexingMixin)
+    probe._open_complete_collection = Mock(return_value=None)
+    probe._mark_collection_complete = Mock()
+    collection = Mock()
+    probe.chroma_client = Mock()
+    probe.chroma_client.create_collection.return_value = collection
+    program_info = Mock(name="sample", code_collection=None)
+
+    probe._init_chroma_code_collection_for_program(program_info)
+
+    tools.decompile_function.assert_called_once_with(
+        function, timeout=DEFAULT_DECOMPILE_TIMEOUT_SECONDS
+    )
+    collection.add.assert_called_once_with(
+        documents=["int entry(void) { return 0; }"],
+        metadatas=[{"function_name": "entry-1000", "entry_point": "1000"}],
+        ids=["entry-1000"],
+    )

--- a/tests/unit/test_decompile_timeout.py
+++ b/tests/unit/test_decompile_timeout.py
@@ -1,0 +1,87 @@
+import sys
+import types
+from contextlib import contextmanager
+from unittest.mock import Mock
+
+import pytest
+
+from pyghidra_mcp.tools import DEFAULT_DECOMPILE_TIMEOUT_SECONDS, GhidraTools
+
+
+def _install_task_monitor(monkeypatch):
+    ghidra_module = types.ModuleType("ghidra")
+    util_module = types.ModuleType("ghidra.util")
+    task_module = types.ModuleType("ghidra.util.task")
+    monitor = Mock()
+    task_module.ConsoleTaskMonitor = Mock(return_value=monitor)
+
+    monkeypatch.setitem(sys.modules, "ghidra", ghidra_module)
+    monkeypatch.setitem(sys.modules, "ghidra.util", util_module)
+    monkeypatch.setitem(sys.modules, "ghidra.util.task", task_module)
+    return monitor
+
+
+class _RecordingPool:
+    def __init__(self, decompiler):
+        self.decompiler = decompiler
+        self.timeout = None
+
+    @contextmanager
+    def acquire(self, timeout=None):
+        self.timeout = timeout
+        yield self.decompiler
+
+
+def _make_tools(pool):
+    tools = GhidraTools.__new__(GhidraTools)
+    tools.decompiler_pool = pool
+    return tools
+
+
+def test_decompile_uses_one_finite_budget_for_pool_and_ghidra(monkeypatch):
+    monitor = _install_task_monitor(monkeypatch)
+    decompiled = Mock()
+    decompiled.getC.return_value = "int entry(void) { return 0; }"
+    decompiled.getSignature.return_value = "int entry(void)"
+
+    result = Mock()
+    result.getErrorMessage.return_value = ""
+    result.getDecompiledFunction.return_value = decompiled
+
+    decompiler = Mock()
+    decompiler.decompileFunction.return_value = result
+    pool = _RecordingPool(decompiler)
+    tools = _make_tools(pool)
+    tools._get_filename = Mock(return_value="entry-1000")
+    function = Mock()
+
+    response = tools.decompile_function(function)
+
+    assert pool.timeout == DEFAULT_DECOMPILE_TIMEOUT_SECONDS
+    decompiler.decompileFunction.assert_called_once_with(
+        function, DEFAULT_DECOMPILE_TIMEOUT_SECONDS, monitor
+    )
+    assert response.code == "int entry(void) { return 0; }"
+
+
+def test_decompile_does_not_enter_ghidra_after_pool_budget_expires(monkeypatch):
+    _install_task_monitor(monkeypatch)
+    decompiler = Mock()
+    pool = _RecordingPool(decompiler)
+    tools = _make_tools(pool)
+    function = Mock()
+    monkeypatch.setattr("pyghidra_mcp.tools.time.monotonic", Mock(side_effect=[100, 131]))
+
+    with pytest.raises(TimeoutError, match="Timed out waiting for a decompiler"):
+        tools.decompile_function(function, timeout=30)
+
+    assert pool.timeout == 30
+    decompiler.decompileFunction.assert_not_called()
+
+
+def test_decompile_rejects_unbounded_timeout(monkeypatch):
+    _install_task_monitor(monkeypatch)
+    tools = _make_tools(_RecordingPool(Mock()))
+
+    with pytest.raises(ValueError, match="greater than zero"):
+        tools.decompile_function(Mock(), timeout=0)

--- a/tests/unit/test_decompiler_pool.py
+++ b/tests/unit/test_decompiler_pool.py
@@ -1,6 +1,8 @@
 import threading
 import time
 
+import pytest
+
 from pyghidra_mcp.decompiler_pool import DecompilerPool
 
 
@@ -36,3 +38,69 @@ def test_concurrent_acquire_never_overcreates_or_blocks_return():
     assert len(completed) == worker_count
     assert len(created) == pool_size
     assert all(not thread.is_alive() for thread in threads)
+
+
+def test_acquire_times_out_when_pool_is_exhausted():
+    pool = DecompilerPool(object, size=1)
+
+    with pool.acquire():
+        started = time.monotonic()
+        with pytest.raises(TimeoutError, match="Timed out waiting for a decompiler"):
+            with pool.acquire(timeout=0.05):
+                pytest.fail("exhausted pool unexpectedly yielded a decompiler")
+
+    assert time.monotonic() - started < 0.5
+
+
+def test_slow_factory_does_not_prevent_another_caller_timing_out():
+    factory_started = threading.Event()
+    release_factory = threading.Event()
+    creator_finished = threading.Event()
+
+    def factory():
+        factory_started.set()
+        assert release_factory.wait(timeout=1)
+        return object()
+
+    pool = DecompilerPool(factory, size=1)
+
+    def create_first_decompiler():
+        with pool.acquire(timeout=1):
+            pass
+        creator_finished.set()
+
+    creator = threading.Thread(target=create_first_decompiler, daemon=True)
+    creator.start()
+    assert factory_started.wait(timeout=1)
+
+    started = time.monotonic()
+    with pytest.raises(TimeoutError, match="Timed out waiting for a decompiler"):
+        with pool.acquire(timeout=0.05):
+            pytest.fail("reserved pool slot unexpectedly became available")
+    assert time.monotonic() - started < 0.5
+
+    release_factory.set()
+    creator.join(timeout=1)
+    assert creator_finished.is_set()
+
+
+def test_factory_failure_releases_pool_capacity():
+    attempts = 0
+
+    def factory():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("factory failed")
+        return object()
+
+    pool = DecompilerPool(factory, size=1)
+
+    with pytest.raises(RuntimeError, match="factory failed"):
+        with pool.acquire(timeout=0.05):
+            pass
+
+    with pool.acquire(timeout=0.05) as decompiler:
+        assert decompiler is not None
+
+    assert attempts == 2

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 from unittest.mock import Mock
 
 import pytest
@@ -208,6 +209,43 @@ async def test_decompile_function_offloads_with_timeout(monkeypatch):
 
     fake_tools.decompile_function_by_name_or_addr.assert_called_once_with("entry", timeout=17)
     assert response == [decompiled]
+
+
+@pytest.mark.asyncio
+async def test_decompile_function_returns_timeout_when_worker_stalls(monkeypatch):
+    pyghidra_context = Mock()
+    pyghidra_context.get_program_info.return_value = Mock()
+
+    ctx = Mock()
+    ctx.request_context.lifespan_context = pyghidra_context
+
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    fake_tools = Mock()
+
+    def stalled_decompile(*_args, **_kwargs):
+        worker_started.set()
+        assert release_worker.wait(timeout=1)
+
+    fake_tools.decompile_function_by_name_or_addr.side_effect = stalled_decompile
+    monkeypatch.setattr("pyghidra_mcp.mcp_tools.GhidraTools", lambda _program_info: fake_tools)
+    monkeypatch.setattr("pyghidra_mcp.mcp_tools.DECOMPILE_TIMEOUT_GRACE_SECONDS", -0.99)
+
+    started = asyncio.get_running_loop().time()
+    response = await decompile_function(
+        binary_name="sample",
+        name_or_address="entry",
+        timeout_sec=1,
+        ctx=ctx,
+    )
+
+    assert asyncio.get_running_loop().time() - started < 0.5
+    assert worker_started.is_set()
+    assert len(response) == 1
+    assert response[0].name == "entry"
+    assert response[0].code == ""
+    assert response[0].error == "Decompilation timed out after 1 seconds"
+    release_worker.set()
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "pyghidra-mcp"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
- replace the decompiler pool check/create race with bounded semaphore leases
- bound pool acquisition and apply one finite deadline across acquisition and Ghidra decompilation
- return a structured timeout result if a Ghidra worker stalls
- give background code indexing a finite per-function decompile timeout
- prepare server release 0.2.5

## Regression coverage
- exhausted pools time out instead of hanging
- slow factories do not hold the pool state lock
- factory failures release capacity
- pool wait time is deducted from the Ghidra timeout budget
- stalled worker calls return within the MCP deadline, including on Python 3.10
- background indexing uses a finite timeout

## Validation
- 127 server unit tests passed
- 15 CLI unit tests passed
- 173 passed, 2 skipped in the full Ghidra 11.3 / Python 3.10 unit and integration suite
- 20 focused tests passed in the current Ghidra CI image, including real decompilation and concurrent streamable-server coverage
- Ruff passed
- Pyright passed with zero errors
- pre-commit hooks passed, including unit and integration smoke tests
- uv lock check passed
- built wheel metadata and isolated local uvx smoke test passed

## CI status
GitHub Actions has a major service outage as of 2026-08-06. Fresh Linux/Ghidra, CLI, and macOS matrices were dispatched against `d97b0eb` but hosted jobs may remain queued or time out. The CI-equivalent local Ghidra 11.3 / Python 3.10 suite was used as the release fallback gate and passed in full.
